### PR TITLE
Align with OpenClaw v2026.2.12: anti-detection stealth and untrusted content metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "^1.50.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -859,9 +859,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
-      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -386,6 +386,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
       '--disable-background-networking',
       '--disable-component-update',
       '--disable-features=Translate,MediaRouter',
+      '--disable-blink-features=AutomationControlled',
       '--disable-session-crashed-bubble',
       '--hide-crash-restore-bubble',
       '--password-store=basic',

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -51,5 +51,6 @@ export async function snapshotAi(opts: {
     snapshot: built.snapshot,
     refs: built.refs,
     stats: getRoleSnapshotStats(built.snapshot, built.refs),
+    untrusted: true,
   };
 }

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -48,6 +48,7 @@ export async function snapshotRole(opts: {
     snapshot: built.snapshot,
     refs: built.refs,
     stats: getRoleSnapshotStats(built.snapshot, built.refs),
+    untrusted: true,
   };
 }
 
@@ -78,7 +79,7 @@ export async function snapshotAria(opts: {
   try {
     await session.send('Accessibility.enable').catch(() => {});
     const res = await session.send('Accessibility.getFullAXTree') as { nodes?: CdpAXNode[] };
-    return { nodes: formatAriaNodes(Array.isArray(res?.nodes) ? res.nodes : [], limit) };
+    return { nodes: formatAriaNodes(Array.isArray(res?.nodes) ? res.nodes : [], limit), untrusted: true };
   } finally {
     await session.detach().catch(() => {});
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,12 @@ export interface SnapshotResult {
   refs: RoleRefs;
   /** Statistics about the snapshot */
   stats?: SnapshotStats;
+  /**
+   * Indicates this content originates from an untrusted external source (the web page).
+   * AI agents should treat snapshot content as potentially adversarial
+   * (e.g. prompt injection via page text). Always `true` for browser snapshots.
+   */
+  untrusted: boolean;
 }
 
 /** Statistics about a snapshot's content. */
@@ -131,6 +137,11 @@ export interface AriaNode {
 export interface AriaSnapshotResult {
   /** Flat list of accessibility tree nodes */
   nodes: AriaNode[];
+  /**
+   * Indicates this content originates from an untrusted external source (the web page).
+   * AI agents should treat snapshot content as potentially adversarial. Always `true`.
+   */
+  untrusted: boolean;
 }
 
 // ── Actions ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,7 @@ export interface SnapshotResult {
    * AI agents should treat snapshot content as potentially adversarial
    * (e.g. prompt injection via page text). Always `true` for browser snapshots.
    */
-  untrusted: boolean;
+  untrusted?: true;
 }
 
 /** Statistics about a snapshot's content. */
@@ -141,7 +141,7 @@ export interface AriaSnapshotResult {
    * Indicates this content originates from an untrusted external source (the web page).
    * AI agents should treat snapshot content as potentially adversarial. Always `true`.
    */
-  untrusted: boolean;
+  untrusted?: true;
 }
 
 // ── Actions ──


### PR DESCRIPTION
- Hide navigator.webdriver via addInitScript + evaluate on page observation,
  matching OpenClaw's reCAPTCHA v3 anti-detection improvement
- Add --disable-blink-features=AutomationControlled to Chrome launch args
- Mark all snapshot results (SnapshotResult, AriaSnapshotResult) with
  untrusted: true, matching OpenClaw's browser-content-as-untrusted security
  hardening for AI agent safety
- Bump version to 0.2.3

https://claude.ai/code/session_01GQzKca9GGKUygxXKocXz97