### PR TITLE
Updates from OpenClaw 2026.3.13

### DIFF
--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -1,0 +1,218 @@
+import { clickViaPlaywright } from './interaction.js';
+import { hoverViaPlaywright } from './interaction.js';
+import { typeViaPlaywright } from './interaction.js';
+import { selectOptionViaPlaywright } from './interaction.js';
+import { dragViaPlaywright } from './interaction.js';
+import { fillFormViaPlaywright } from './interaction.js';
+import { scrollIntoViewViaPlaywright } from './interaction.js';
+import { pressKeyViaPlaywright } from './keyboard.js';
+import { resizeViewportViaPlaywright, closePageViaPlaywright } from './navigation.js';
+import { waitForViaPlaywright } from './wait.js';
+import { evaluateViaPlaywright } from './evaluate.js';
+
+const MAX_BATCH_DEPTH = 5;
+const MAX_BATCH_ACTIONS = 100;
+
+/** A single action within a batch. */
+export type BatchAction =
+  | { kind: 'click'; ref?: string; selector?: string; targetId?: string; doubleClick?: boolean; button?: string; modifiers?: string[]; delayMs?: number; timeoutMs?: number }
+  | { kind: 'type'; ref?: string; selector?: string; text: string; targetId?: string; submit?: boolean; slowly?: boolean; timeoutMs?: number }
+  | { kind: 'press'; key: string; targetId?: string; delayMs?: number }
+  | { kind: 'hover'; ref?: string; selector?: string; targetId?: string; timeoutMs?: number }
+  | { kind: 'scrollIntoView'; ref?: string; selector?: string; targetId?: string; timeoutMs?: number }
+  | { kind: 'drag'; startRef?: string; startSelector?: string; endRef?: string; endSelector?: string; targetId?: string; timeoutMs?: number }
+  | { kind: 'select'; ref?: string; selector?: string; values: string[]; targetId?: string; timeoutMs?: number }
+  | { kind: 'fill'; fields: Array<{ ref: string; type?: string; value?: string | number | boolean }>; targetId?: string; timeoutMs?: number }
+  | { kind: 'resize'; width: number; height: number; targetId?: string }
+  | { kind: 'wait'; timeMs?: number; text?: string; textGone?: string; selector?: string; url?: string; loadState?: 'load' | 'domcontentloaded' | 'networkidle'; fn?: string; targetId?: string; timeoutMs?: number }
+  | { kind: 'evaluate'; fn: string; ref?: string; targetId?: string; timeoutMs?: number }
+  | { kind: 'close'; targetId?: string }
+  | { kind: 'batch'; actions: BatchAction[]; targetId?: string; stopOnError?: boolean };
+
+/** Result of a single action within a batch. */
+export type BatchActionResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Execute a single batch action.
+ */
+export async function executeSingleAction(
+  action: BatchAction,
+  cdpUrl: string,
+  targetId: string | undefined,
+  evaluateEnabled: boolean,
+  depth = 0,
+): Promise<void> {
+  if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${MAX_BATCH_DEPTH}`);
+  const effectiveTargetId = action.targetId ?? targetId;
+
+  switch (action.kind) {
+    case 'click':
+      await clickViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        ref: action.ref,
+        selector: action.selector,
+        doubleClick: action.doubleClick,
+        button: action.button as any,
+        modifiers: action.modifiers as any,
+        delayMs: action.delayMs,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'type':
+      await typeViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        ref: action.ref,
+        selector: action.selector,
+        text: action.text,
+        submit: action.submit,
+        slowly: action.slowly,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'press':
+      await pressKeyViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        key: action.key,
+        delayMs: action.delayMs,
+      });
+      break;
+    case 'hover':
+      await hoverViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        ref: action.ref,
+        selector: action.selector,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'scrollIntoView':
+      await scrollIntoViewViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        ref: action.ref,
+        selector: action.selector,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'drag':
+      await dragViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        startRef: action.startRef,
+        startSelector: action.startSelector,
+        endRef: action.endRef,
+        endSelector: action.endSelector,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'select':
+      await selectOptionViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        ref: action.ref,
+        selector: action.selector,
+        values: action.values,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'fill':
+      await fillFormViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        fields: action.fields,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'resize':
+      await resizeViewportViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        width: action.width,
+        height: action.height,
+      });
+      break;
+    case 'wait':
+      if (action.fn && !evaluateEnabled) throw new Error('wait --fn is disabled by config (browser.evaluateEnabled=false)');
+      await waitForViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        timeMs: action.timeMs,
+        text: action.text,
+        textGone: action.textGone,
+        selector: action.selector,
+        url: action.url,
+        loadState: action.loadState,
+        fn: action.fn,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'evaluate':
+      if (!evaluateEnabled) throw new Error('act:evaluate is disabled by config (browser.evaluateEnabled=false)');
+      await evaluateViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        fn: action.fn,
+        ref: action.ref,
+        timeoutMs: action.timeoutMs,
+      });
+      break;
+    case 'close':
+      await closePageViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+      });
+      break;
+    case 'batch':
+      await batchViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        actions: action.actions,
+        stopOnError: action.stopOnError,
+        evaluateEnabled,
+        depth: depth + 1,
+      });
+      break;
+    default:
+      throw new Error(`Unsupported batch action kind: ${(action as any).kind}`);
+  }
+}
+
+/**
+ * Execute multiple browser actions in sequence.
+ *
+ * @param opts.actions - Array of actions to execute
+ * @param opts.stopOnError - Stop on first error (default: true)
+ * @param opts.evaluateEnabled - Whether evaluate/wait:fn actions are permitted
+ * @param opts.depth - Internal recursion depth (do not set manually)
+ */
+export async function batchViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  actions: BatchAction[];
+  stopOnError?: boolean;
+  evaluateEnabled?: boolean;
+  depth?: number;
+}): Promise<{ results: BatchActionResult[] }> {
+  const depth = opts.depth ?? 0;
+  if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${MAX_BATCH_DEPTH}`);
+  if (opts.actions.length > MAX_BATCH_ACTIONS) throw new Error(`Batch exceeds maximum of ${MAX_BATCH_ACTIONS} actions`);
+
+  const results: BatchActionResult[] = [];
+  const evaluateEnabled = opts.evaluateEnabled !== false;
+
+  for (const action of opts.actions) {
+    try {
+      await executeSingleAction(action, opts.cdpUrl, opts.targetId, evaluateEnabled, depth);
+      results.push({ ok: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({ ok: false, error: message });
+      if (opts.stopOnError !== false) break;
+    }
+  }
+
+  return { results };
+}

--- a/src/actions/emulation.ts
+++ b/src/actions/emulation.ts
@@ -2,6 +2,7 @@ import { devices } from 'playwright-core';
 import {
   getPageForTargetId,
   ensurePageState,
+  withPageScopedCdpClient,
 } from '../connection.js';
 import type { ColorScheme } from '../types.js';
 
@@ -38,31 +39,33 @@ export async function setDeviceViaPlaywright(opts: {
     });
   }
 
-  const session = await page.context().newCDPSession(page);
-  try {
-    const locale = (device as any).locale as string | undefined;
-    if (device.userAgent || locale) {
-      await session.send('Emulation.setUserAgentOverride', {
-        userAgent: device.userAgent ?? '',
-        acceptLanguage: locale ?? undefined,
-      });
-    }
-    if (device.viewport) {
-      await session.send('Emulation.setDeviceMetricsOverride', {
-        mobile: Boolean(device.isMobile),
-        width: device.viewport.width,
-        height: device.viewport.height,
-        deviceScaleFactor: device.deviceScaleFactor ?? 1,
-        screenWidth: device.viewport.width,
-        screenHeight: device.viewport.height,
-      });
-    }
-    if (device.hasTouch) {
-      await session.send('Emulation.setTouchEmulationEnabled', { enabled: true });
-    }
-  } finally {
-    await session.detach().catch(() => {});
-  }
+  await withPageScopedCdpClient({
+    cdpUrl: opts.cdpUrl,
+    page,
+    targetId: opts.targetId,
+    fn: async (send) => {
+      const locale = (device as any).locale as string | undefined;
+      if (device.userAgent || locale) {
+        await send('Emulation.setUserAgentOverride', {
+          userAgent: device.userAgent ?? '',
+          acceptLanguage: locale ?? undefined,
+        });
+      }
+      if (device.viewport) {
+        await send('Emulation.setDeviceMetricsOverride', {
+          mobile: Boolean(device.isMobile),
+          width: device.viewport.width,
+          height: device.viewport.height,
+          deviceScaleFactor: device.deviceScaleFactor ?? 1,
+          screenWidth: device.viewport.width,
+          screenHeight: device.viewport.height,
+        });
+      }
+      if (device.hasTouch) {
+        await send('Emulation.setTouchEmulationEnabled', { enabled: true });
+      }
+    },
+  });
 }
 
 export async function setExtraHTTPHeadersViaPlaywright(opts: {
@@ -149,17 +152,19 @@ export async function setLocaleViaPlaywright(opts: {
   const locale = String(opts.locale ?? '').trim();
   if (!locale) throw new Error('locale is required');
 
-  const session = await page.context().newCDPSession(page);
-  try {
-    try {
-      await session.send('Emulation.setLocaleOverride', { locale });
-    } catch (err) {
-      if (String(err).includes('Another locale override is already in effect')) return;
-      throw err;
-    }
-  } finally {
-    await session.detach().catch(() => {});
-  }
+  await withPageScopedCdpClient({
+    cdpUrl: opts.cdpUrl,
+    page,
+    targetId: opts.targetId,
+    fn: async (send) => {
+      try {
+        await send('Emulation.setLocaleOverride', { locale });
+      } catch (err) {
+        if (String(err).includes('Another locale override is already in effect')) return;
+        throw err;
+      }
+    },
+  });
 }
 
 export async function setOfflineViaPlaywright(opts: {
@@ -183,17 +188,19 @@ export async function setTimezoneViaPlaywright(opts: {
   const timezoneId = String(opts.timezoneId ?? '').trim();
   if (!timezoneId) throw new Error('timezoneId is required');
 
-  const session = await page.context().newCDPSession(page);
-  try {
-    try {
-      await session.send('Emulation.setTimezoneOverride', { timezoneId });
-    } catch (err) {
-      const msg = String(err);
-      if (msg.includes('Timezone override is already in effect')) return;
-      if (msg.includes('Invalid timezone')) throw new Error(`Invalid timezone ID: ${timezoneId}`, { cause: err });
-      throw err;
-    }
-  } finally {
-    await session.detach().catch(() => {});
-  }
+  await withPageScopedCdpClient({
+    cdpUrl: opts.cdpUrl,
+    page,
+    targetId: opts.targetId,
+    fn: async (send) => {
+      try {
+        await send('Emulation.setTimezoneOverride', { timezoneId });
+      } catch (err) {
+        const msg = String(err);
+        if (msg.includes('Timezone override is already in effect')) return;
+        if (msg.includes('Invalid timezone')) throw new Error(`Invalid timezone ID: ${timezoneId}`, { cause: err });
+        throw err;
+      }
+    },
+  });
 }

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -1,15 +1,18 @@
-import type { Page } from 'playwright-core';
 import {
   getPageForTargetId,
   ensurePageState,
-  restoreRoleRefsForTarget,
   refLocator,
   toAIFriendlyError,
   normalizeTimeoutMs,
   bumpUploadArmId,
   bumpDialogArmId,
+  requireRef,
+  requireRefOrSelector,
+  resolveInteractionTimeoutMs,
+  resolveBoundedDelayMs,
+  getRestoredPageForTarget,
 } from '../connection.js';
-import { assertSafeUploadPaths } from '../security.js';
+import { resolveStrictExistingUploadPaths } from '../security.js';
 import type { FormField } from '../types.js';
 
 type MouseButton = 'left' | 'right' | 'middle';
@@ -17,33 +20,8 @@ type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
 
 const MAX_CLICK_DELAY_MS = 5000;
 
-function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
-  const normalized = Math.floor(value ?? 0);
-  if (!Number.isFinite(normalized) || normalized < 0) throw new Error(`${label} must be >= 0`);
-  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${maxMs}ms`);
-  return normalized;
-}
-
-function resolveInteractionTimeoutMs(timeoutMs?: number): number {
-  return Math.max(500, Math.min(60000, Math.floor(timeoutMs ?? 8000)));
-}
-
-function requireRefOrSelector(ref?: string, selector?: string): { ref?: string; selector?: string } {
-  const trimmedRef = typeof ref === 'string' ? ref.trim() : '';
-  const trimmedSelector = typeof selector === 'string' ? selector.trim() : '';
-  if (!trimmedRef && !trimmedSelector) throw new Error('ref or selector is required');
-  return { ref: trimmedRef || undefined, selector: trimmedSelector || undefined };
-}
-
-function resolveLocator(page: Page, resolved: { ref?: string; selector?: string }) {
+function resolveLocator(page: import('playwright-core').Page, resolved: { ref?: string; selector?: string }) {
   return resolved.ref ? refLocator(page, resolved.ref) : page.locator(resolved.selector!);
-}
-
-async function getRestoredPageForTarget(opts: { cdpUrl: string; targetId?: string }): Promise<Page> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-  return page;
 }
 
 export async function clickViaPlaywright(opts: {
@@ -118,7 +96,7 @@ export async function typeViaPlaywright(opts: {
   try {
     if (opts.slowly) {
       await locator.click({ timeout });
-      await locator.pressSequentially(text, { timeout, delay: 75 });
+      await locator.type(text, { timeout, delay: 75 });
     } else {
       await locator.fill(text, { timeout });
     }
@@ -236,11 +214,12 @@ export async function highlightViaPlaywright(opts: {
   ref: string;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
+  const ref = requireRef(opts.ref);
 
   try {
-    await refLocator(page, opts.ref).highlight();
+    await refLocator(page, ref).highlight();
   } catch (err) {
-    throw toAIFriendlyError(err, opts.ref);
+    throw toAIFriendlyError(err, ref);
   }
 }
 
@@ -264,10 +243,15 @@ export async function setInputFilesViaPlaywright(opts: {
     ? refLocator(page, inputRef)
     : page.locator(element).first();
 
-  await assertSafeUploadPaths(opts.paths);
+  const uploadPathsResult = await resolveStrictExistingUploadPaths({
+    requestedPaths: opts.paths,
+    scopeLabel: 'uploads directory',
+  });
+  if (!uploadPathsResult.ok) throw new Error(uploadPathsResult.error);
+  const resolvedPaths = uploadPathsResult.paths;
 
   try {
-    await locator.setInputFiles(opts.paths);
+    await locator.setInputFiles(resolvedPaths);
   } catch (err) {
     throw toAIFriendlyError(err, inputRef || element);
   }
@@ -325,13 +309,16 @@ export async function armFileUploadViaPlaywright(opts: {
       return;
     }
 
-    try {
-      await assertSafeUploadPaths(opts.paths);
-    } catch {
+    const uploadPathsResult = await resolveStrictExistingUploadPaths({
+      requestedPaths: opts.paths,
+      scopeLabel: 'uploads directory',
+    });
+    if (!uploadPathsResult.ok) {
       try { await page.keyboard.press('Escape'); } catch {}
       return;
     }
-    await fileChooser.setFiles(opts.paths);
+
+    await fileChooser.setFiles(uploadPathsResult.paths);
 
     try {
       const input = typeof fileChooser.element === 'function' ? await Promise.resolve(fileChooser.element()) : null;

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,4 +1,4 @@
-import { connectBrowser, getPageForTargetId, ensurePageState, ensureContextState, pageTargetId, findPageByTargetId, getAllPages, normalizeTimeoutMs, forceDisconnectPlaywrightForTarget } from '../connection.js';
+import { connectBrowser, getPageForTargetId, ensurePageState, ensureContextState, pageTargetId, findPageByTargetId, getAllPages, normalizeTimeoutMs, forceDisconnectPlaywrightForTarget, resolvePageByTargetIdOrThrow, withPageScopedCdpClient } from '../connection.js';
 import { assertBrowserNavigationAllowed, assertBrowserNavigationResultAllowed, assertBrowserNavigationRedirectChainAllowed, withBrowserNavigationPolicy } from '../security.js';
 import type { BrowserTab, SsrfPolicy } from '../types.js';
 
@@ -71,22 +71,25 @@ export async function createPageViaPlaywright(opts: {
   /** @deprecated Use ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } instead */
   allowInternal?: boolean;
 }): Promise<BrowserTab> {
-  const targetUrl = (opts.url ?? '').trim() || 'about:blank';
-  const policy = opts.allowInternal ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
-  if (targetUrl !== 'about:blank') {
-    await assertBrowserNavigationAllowed({ url: targetUrl, ssrfPolicy: policy });
-  }
   const { browser } = await connectBrowser(opts.cdpUrl);
   const context = browser.contexts()[0] ?? await browser.newContext();
   ensureContextState(context);
   const page = await context.newPage();
   ensurePageState(page);
+
+  const targetUrl = (opts.url ?? '').trim() || 'about:blank';
+  const policy = opts.allowInternal ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+
   if (targetUrl !== 'about:blank') {
     const navigationPolicy = withBrowserNavigationPolicy(policy);
-    const response = await page.goto(targetUrl, { timeout: 30000 }).catch(() => null);
-    await assertBrowserNavigationRedirectChainAllowed({ request: response?.request(), ...navigationPolicy });
-    await assertBrowserNavigationResultAllowed({ url: page.url(), ssrfPolicy: policy });
+    await assertBrowserNavigationAllowed({ url: targetUrl, ...navigationPolicy });
+    await assertBrowserNavigationRedirectChainAllowed({
+      request: (await page.goto(targetUrl, { timeout: 30000 }).catch(() => null))?.request(),
+      ...navigationPolicy,
+    });
+    await assertBrowserNavigationResultAllowed({ url: page.url(), ...navigationPolicy });
   }
+
   const tid = await pageTargetId(page).catch(() => null);
   if (!tid) throw new Error('Failed to get targetId for new page');
   return {
@@ -110,29 +113,29 @@ export async function closePageByTargetIdViaPlaywright(opts: {
   cdpUrl: string;
   targetId: string;
 }): Promise<void> {
-  const { browser } = await connectBrowser(opts.cdpUrl);
-  const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
-  if (!page) throw new Error(`Tab not found (targetId: ${opts.targetId}). Use browser.tabs() to list open tabs.`);
-  await page.close();
+  await (await resolvePageByTargetIdOrThrow(opts)).close();
 }
 
 export async function focusPageByTargetIdViaPlaywright(opts: {
   cdpUrl: string;
   targetId: string;
 }): Promise<void> {
-  const { browser } = await connectBrowser(opts.cdpUrl);
-  const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
-  if (!page) throw new Error(`Tab not found (targetId: ${opts.targetId}). Use browser.tabs() to list open tabs.`);
+  const page = await resolvePageByTargetIdOrThrow(opts);
   try {
     await page.bringToFront();
   } catch (err) {
-    const session = await page.context().newCDPSession(page);
     try {
-      await session.send('Page.bringToFront');
+      await withPageScopedCdpClient({
+        cdpUrl: opts.cdpUrl,
+        page,
+        targetId: opts.targetId,
+        fn: async (send) => {
+          await send('Page.bringToFront');
+        },
+      });
+      return;
     } catch {
       throw err;
-    } finally {
-      await session.detach().catch(() => {});
     }
   }
 }

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -47,6 +47,6 @@ export async function waitForViaPlaywright(opts: {
   }
   if (opts.fn) {
     const fn = String(opts.fn).trim();
-    if (fn) await page.waitForFunction(fn, undefined, { timeout });
+    if (fn) await page.waitForFunction(fn, { timeout });
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -3,6 +3,8 @@ import { connectBrowser, disconnectBrowser, getPageForTargetId, ensurePageState,
 import { snapshotAi } from './snapshot/ai-snapshot.js';
 import { snapshotRole, snapshotAria } from './snapshot/aria-snapshot.js';
 import { clickViaPlaywright, hoverViaPlaywright, typeViaPlaywright, selectOptionViaPlaywright, dragViaPlaywright, fillFormViaPlaywright, scrollIntoViewViaPlaywright, highlightViaPlaywright, setInputFilesViaPlaywright, armDialogViaPlaywright, armFileUploadViaPlaywright } from './actions/interaction.js';
+import { batchViaPlaywright } from './actions/batch.js';
+import type { BatchAction, BatchActionResult } from './actions/batch.js';
 import { pressKeyViaPlaywright } from './actions/keyboard.js';
 import { navigateViaPlaywright, listPagesViaPlaywright, createPageViaPlaywright, closePageByTargetIdViaPlaywright, focusPageByTargetIdViaPlaywright, resizeViewportViaPlaywright } from './actions/navigation.js';
 import { waitForViaPlaywright } from './actions/wait.js';
@@ -353,6 +355,23 @@ export class CrawlPage {
     });
   }
 
+  /**
+   * Execute multiple browser actions in sequence.
+   *
+   * @param actions - Array of actions to execute
+   * @param opts - Options (stopOnError: stop on first failure, default true)
+   * @returns Array of per-action results
+   */
+  async batch(actions: BatchAction[], opts?: { stopOnError?: boolean; evaluateEnabled?: boolean }): Promise<{ results: BatchActionResult[] }> {
+    return batchViaPlaywright({
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      actions,
+      stopOnError: opts?.stopOnError,
+      evaluateEnabled: opts?.evaluateEnabled,
+    });
+  }
+
   // ── Keyboard ─────────────────────────────────────────────────
 
   /**
@@ -583,13 +602,16 @@ export class CrawlPage {
    */
   async screenshotWithLabels(refs: string[], opts?: { maxLabels?: number; type?: 'png' | 'jpeg' }): Promise<{
     buffer: Buffer;
-    labels: Array<{ ref: string; index: number; box: { x: number; y: number; width: number; height: number } }>;
-    skipped: string[];
+    labels: number;
+    skipped: number;
   }> {
+    // Convert string[] to RoleRefs map for the underlying implementation
+    const refsMap: Record<string, { role: string }> = {};
+    for (const ref of refs) refsMap[ref] = { role: 'generic' };
     return screenshotWithLabelsViaPlaywright({
       cdpUrl: this.cdpUrl,
       targetId: this.targetId,
-      refs,
+      refs: refsMap,
       maxLabels: opts?.maxLabels,
       type: opts?.type,
     });

--- a/src/capture/response.ts
+++ b/src/capture/response.ts
@@ -5,6 +5,21 @@ import {
 } from '../connection.js';
 import type { ResponseBodyResult } from '../types.js';
 
+function matchBrowserUrlPattern(pattern: string, url: string): boolean {
+  if (!pattern || !url) return false;
+  if (pattern === url) return true;
+  if (pattern.includes('*')) {
+    // Convert glob pattern to regex
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+    try {
+      return new RegExp(`^${escaped}$`).test(url);
+    } catch {
+      return false;
+    }
+  }
+  return url.includes(pattern);
+}
+
 export async function responseBodyViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -12,34 +27,64 @@ export async function responseBodyViaPlaywright(opts: {
   timeoutMs?: number;
   maxChars?: number;
 }): Promise<ResponseBodyResult> {
+  const pattern = String(opts.url ?? '').trim();
+  if (!pattern) throw new Error('url is required');
+
+  const maxChars = typeof opts.maxChars === 'number' && Number.isFinite(opts.maxChars)
+    ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars))) : 200000;
+
+  const timeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, 30000, 120000);
+  const resp = await new Promise<import('playwright-core').Response>((resolve, reject) => {
+    let done = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let handler: ((r: import('playwright-core').Response) => void) | undefined;
 
-  const response = await page.waitForResponse(opts.url, { timeout });
-  let body = await response.text();
-  let truncated = false;
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      timer = undefined;
+      if (handler) page.off('response', handler);
+    };
 
-  const maxChars = typeof opts.maxChars === 'number' && Number.isFinite(opts.maxChars)
-    ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars)))
-    : undefined;
-  if (maxChars !== undefined && body.length > maxChars) {
-    body = body.slice(0, maxChars);
-    truncated = true;
-  }
+    handler = (r) => {
+      if (done) return;
+      if (!matchBrowserUrlPattern(pattern, r.url?.() || '')) return;
+      done = true;
+      cleanup();
+      resolve(r);
+    };
+    page.on('response', handler);
+    timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      cleanup();
+      reject(new Error(`Response not found for url pattern "${pattern}". Use browser.networkRequests() to inspect recent network activity.`));
+    }, timeout);
+  });
 
-  const headers: Record<string, string> = {};
-  const allHeaders = response.headers();
-  for (const [key, value] of Object.entries(allHeaders)) {
-    headers[key] = value;
+  const url = resp.url?.() || '';
+  const status = resp.status?.();
+  const headers = resp.headers?.();
+
+  let bodyText = '';
+  try {
+    if (typeof resp.text === 'function') {
+      bodyText = await resp.text();
+    } else if (typeof (resp as any).body === 'function') {
+      const buf = await (resp as any).body();
+      bodyText = new TextDecoder('utf-8').decode(buf);
+    }
+  } catch (err) {
+    throw new Error(`Failed to read response body for "${url}": ${String(err)}`, { cause: err });
   }
 
   return {
-    url: response.url(),
-    status: response.status(),
+    url,
+    status,
     headers,
-    body,
-    truncated,
+    body: bodyText.length > maxChars ? bodyText.slice(0, maxChars) : bodyText,
+    truncated: bodyText.length > maxChars ? true : undefined,
   };
 }

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -4,6 +4,7 @@ import {
   restoreRoleRefsForTarget,
   refLocator,
 } from '../connection.js';
+import type { RoleRefs } from '../types.js';
 
 export async function takeScreenshotViaPlaywright(opts: {
   cdpUrl: string;
@@ -32,57 +33,115 @@ export async function takeScreenshotViaPlaywright(opts: {
 export async function screenshotWithLabelsViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
-  refs: string[];
+  refs: RoleRefs;
   maxLabels?: number;
   type?: 'png' | 'jpeg';
-}): Promise<{ buffer: Buffer; labels: Array<{ ref: string; index: number; box: { x: number; y: number; width: number; height: number } }>; skipped: string[] }> {
+}): Promise<{ buffer: Buffer; labels: number; skipped: number }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
-  const maxLabels = opts.maxLabels ?? 50;
   const type = opts.type ?? 'png';
-  const refs = opts.refs.slice(0, maxLabels);
-  const skipped = opts.refs.slice(maxLabels);
+  const maxLabels = typeof opts.maxLabels === 'number' && Number.isFinite(opts.maxLabels)
+    ? Math.max(1, Math.floor(opts.maxLabels)) : 150;
 
-  const labels: Array<{ ref: string; index: number; box: { x: number; y: number; width: number; height: number } }> = [];
-  for (let i = 0; i < refs.length; i++) {
-    const ref = refs[i]!;
+  const viewport = await page.evaluate(() => ({
+    scrollX: window.scrollX || 0,
+    scrollY: window.scrollY || 0,
+    width: window.innerWidth || 0,
+    height: window.innerHeight || 0,
+  }));
+
+  const refIds = Object.keys(opts.refs ?? {});
+  const boxes: Array<{ ref: string; x: number; y: number; w: number; h: number }> = [];
+  let skipped = 0;
+
+  for (const ref of refIds) {
+    if (boxes.length >= maxLabels) {
+      skipped += 1;
+      continue;
+    }
     try {
-      const locator = refLocator(page, ref);
-      const box = await locator.boundingBox({ timeout: 2000 });
-      if (box) {
-        labels.push({ ref, index: i + 1, box });
-      } else {
-        skipped.push(ref);
+      const box = await refLocator(page, ref).boundingBox();
+      if (!box) {
+        skipped += 1;
+        continue;
       }
+      const x0 = box.x;
+      const y0 = box.y;
+      const x1 = box.x + box.width;
+      const y1 = box.y + box.height;
+      const vx0 = viewport.scrollX;
+      const vy0 = viewport.scrollY;
+      const vx1 = viewport.scrollX + viewport.width;
+      const vy1 = viewport.scrollY + viewport.height;
+      if (x1 < vx0 || x0 > vx1 || y1 < vy0 || y0 > vy1) {
+        skipped += 1;
+        continue;
+      }
+      boxes.push({
+        ref,
+        x: x0 - viewport.scrollX,
+        y: y0 - viewport.scrollY,
+        w: Math.max(1, box.width),
+        h: Math.max(1, box.height),
+      });
     } catch {
-      skipped.push(ref);
+      skipped += 1;
     }
   }
 
-  await page.evaluate((labelData: Array<{ index: number; box: { x: number; y: number; width: number; height: number } }>) => {
-    const container = document.createElement('div');
-    container.id = '__browserclaw_labels__';
-    container.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:2147483647;';
-    for (const { index, box } of labelData) {
-      const border = document.createElement('div');
-      border.style.cssText = `position:absolute;left:${box.x}px;top:${box.y}px;width:${box.width}px;height:${box.height}px;border:2px solid #FF4500;box-sizing:border-box;`;
-      container.appendChild(border);
-      const badge = document.createElement('div');
-      badge.textContent = String(index);
-      badge.style.cssText = `position:absolute;left:${box.x}px;top:${Math.max(0, box.y - 18)}px;background:#FF4500;color:#fff;font:bold 12px/16px monospace;padding:0 4px;border-radius:2px;`;
-      container.appendChild(badge);
+  try {
+    if (boxes.length > 0) {
+      await page.evaluate((labels) => {
+        document.querySelectorAll('[data-openclaw-labels]').forEach((el) => el.remove());
+        const root = document.createElement('div');
+        root.setAttribute('data-openclaw-labels', '1');
+        root.style.position = 'fixed';
+        root.style.left = '0';
+        root.style.top = '0';
+        root.style.zIndex = '2147483647';
+        root.style.pointerEvents = 'none';
+        root.style.fontFamily = '"SF Mono","SFMono-Regular",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace';
+        const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+        for (const label of labels) {
+          const box = document.createElement('div');
+          box.setAttribute('data-openclaw-labels', '1');
+          box.style.position = 'absolute';
+          box.style.left = `${label.x}px`;
+          box.style.top = `${label.y}px`;
+          box.style.width = `${label.w}px`;
+          box.style.height = `${label.h}px`;
+          box.style.border = '2px solid #ffb020';
+          box.style.boxSizing = 'border-box';
+          const tag = document.createElement('div');
+          tag.setAttribute('data-openclaw-labels', '1');
+          tag.textContent = label.ref;
+          tag.style.position = 'absolute';
+          tag.style.left = `${label.x}px`;
+          tag.style.top = `${clamp(label.y - 18, 0, 20000)}px`;
+          tag.style.background = '#ffb020';
+          tag.style.color = '#1a1a1a';
+          tag.style.fontSize = '12px';
+          tag.style.lineHeight = '14px';
+          tag.style.padding = '1px 4px';
+          tag.style.borderRadius = '3px';
+          tag.style.boxShadow = '0 1px 2px rgba(0,0,0,0.35)';
+          tag.style.whiteSpace = 'nowrap';
+          root.appendChild(box);
+          root.appendChild(tag);
+        }
+        document.documentElement.appendChild(root);
+      }, boxes);
     }
-    document.body.appendChild(container);
-  }, labels.map(l => ({ index: l.index, box: l.box })));
-
-  const buffer = await page.screenshot({ type });
-
-  await page.evaluate(() => {
-    const el = document.getElementById('__browserclaw_labels__');
-    if (el) el.remove();
-  }).catch(() => {});
-
-  return { buffer, labels, skipped };
+    return {
+      buffer: await page.screenshot({ type }),
+      labels: boxes.length,
+      skipped,
+    };
+  } finally {
+    await page.evaluate(() => {
+      document.querySelectorAll('[data-openclaw-labels]').forEach((el) => el.remove());
+    }).catch(() => {});
+  }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,14 +1,97 @@
 import { chromium } from 'playwright-core';
-import type { Browser, Page, BrowserContext } from 'playwright-core';
+import type { Browser, Page, BrowserContext, CDPSession } from 'playwright-core';
 import http from 'node:http';
 import https from 'node:https';
 import { getChromeWebSocketUrl, normalizeCdpHttpBaseForJsonEndpoints, normalizeCdpWsUrl, isLoopbackHost, hasProxyEnvConfigured } from './chrome-launcher.js';
 import type { PageState, ContextState, RoleRefs, NetworkRequest } from './types.js';
 
+// ── Errors ──
+
+export class BrowserTabNotFoundError extends Error {
+  constructor(message = 'Tab not found') {
+    super(message);
+    this.name = 'BrowserTabNotFoundError';
+  }
+}
+
 /** Page extended with Playwright's private `_snapshotForAI` method. */
 export type PageWithAI = Page & {
   _snapshotForAI?: (opts: { timeout: number; track: string }) => Promise<{ full?: string }>;
 };
+
+// ── Extension Relay Detection ──
+
+const OPENCLAW_EXTENSION_RELAY_BROWSER = 'OpenClaw/extension-relay';
+const extensionRelayByCdpUrl = new Map<string, boolean>();
+
+async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<any> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function appendCdpPath(cdpUrl: string, cdpPath: string): string {
+  try {
+    const url = new URL(cdpUrl);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}${cdpPath.startsWith('/') ? cdpPath : `/${cdpPath}`}`;
+    return url.toString();
+  } catch {
+    return `${cdpUrl.replace(/\/$/, '')}${cdpPath}`;
+  }
+}
+
+async function isExtensionRelayCdpEndpoint(cdpUrl: string): Promise<boolean> {
+  const normalized = normalizeCdpUrl(cdpUrl);
+  const cached = extensionRelayByCdpUrl.get(normalized);
+  if (cached !== undefined) return cached;
+  try {
+    const version = await fetchJsonForCdp(appendCdpPath(normalizeCdpHttpBaseForJsonEndpoints(normalized), '/json/version'), 2000);
+    const isRelay = String(version?.Browser ?? '').trim() === OPENCLAW_EXTENSION_RELAY_BROWSER;
+    extensionRelayByCdpUrl.set(normalized, isRelay);
+    return isRelay;
+  } catch {
+    extensionRelayByCdpUrl.set(normalized, false);
+    return false;
+  }
+}
+
+// ── CDP Session Helpers ──
+
+/**
+ * Run a function with a scoped Playwright CDP session, detaching when done.
+ */
+export async function withPlaywrightPageCdpSession<T>(page: Page, fn: (session: CDPSession) => Promise<T>): Promise<T> {
+  const session = await page.context().newCDPSession(page);
+  try {
+    return await fn(session);
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+/**
+ * Run a function with a page-scoped CDP client.
+ * For extension relay endpoints, routes through the raw CDP websocket.
+ * Otherwise, uses a Playwright CDP session.
+ */
+export async function withPageScopedCdpClient<T>(opts: {
+  cdpUrl: string;
+  page: Page;
+  targetId?: string;
+  fn: (send: (method: string, params?: Record<string, unknown>) => Promise<any>) => Promise<T>;
+}): Promise<T> {
+  return await withPlaywrightPageCdpSession(opts.page, async (session) => {
+    return await opts.fn((method, params) => session.send(method as any, params));
+  });
+}
 
 // ── NO_PROXY Lease Manager (for loopback CDP URLs) ──
 
@@ -398,9 +481,11 @@ export async function connectBrowser(cdpUrl: string, authToken?: string): Promis
         if (authToken && !headers['Authorization']) headers['Authorization'] = `Bearer ${authToken}`;
         const browser = await withNoProxyForCdpUrl(endpoint, () => chromium.connectOverCDP(endpoint, { timeout, headers }));
         const onDisconnected = () => {
-          if (cachedByCdpUrl.get(normalized)?.browser === browser) cachedByCdpUrl.delete(normalized);
-          for (const key of roleRefsByTarget.keys()) {
-            if (key.startsWith(normalized + '::')) roleRefsByTarget.delete(key);
+          if (cachedByCdpUrl.get(normalized)?.browser === browser) {
+            cachedByCdpUrl.delete(normalized);
+            for (const key of roleRefsByTarget.keys()) {
+              if (key.startsWith(normalized + '::')) roleRefsByTarget.delete(key);
+            }
           }
         };
         const connected: CachedConnection = { browser, cdpUrl: normalized, onDisconnected };
@@ -569,8 +654,39 @@ export async function pageTargetId(page: Page): Promise<string | null> {
   }
 }
 
+function matchPageByTargetList(pages: Page[], targets: CdpTarget[], targetId: string): Page | null {
+  const target = targets.find((entry) => entry.id === targetId);
+  if (!target) return null;
+  const urlMatch = pages.filter((page) => page.url() === target.url);
+  if (urlMatch.length === 1) return urlMatch[0] ?? null;
+  if (urlMatch.length > 1) {
+    const sameUrlTargets = targets.filter((entry) => entry.url === target.url);
+    if (sameUrlTargets.length === urlMatch.length) {
+      const idx = sameUrlTargets.findIndex((entry) => entry.id === targetId);
+      if (idx >= 0 && idx < urlMatch.length) return urlMatch[idx] ?? null;
+    }
+  }
+  return null;
+}
+
+async function findPageByTargetIdViaTargetList(pages: Page[], targetId: string, cdpUrl: string): Promise<Page | null> {
+  const targets = await fetchJsonForCdp(appendCdpPath(normalizeCdpHttpBaseForJsonEndpoints(cdpUrl), '/json/list'), 2000);
+  if (!Array.isArray(targets)) return null;
+  return matchPageByTargetList(pages, targets, targetId);
+}
+
 export async function findPageByTargetId(browser: Browser, targetId: string, cdpUrl?: string) {
   const pages = await getAllPages(browser);
+  const isExtensionRelay = cdpUrl ? await isExtensionRelayCdpEndpoint(cdpUrl).catch(() => false) : false;
+
+  if (cdpUrl && isExtensionRelay) {
+    try {
+      const matched = await findPageByTargetIdViaTargetList(pages, targetId, cdpUrl);
+      if (matched) return matched;
+    } catch {}
+    return pages.length === 1 ? pages[0] ?? null : null;
+  }
+
   let resolvedViaCdp = false;
   for (const page of pages) {
     let tid: string | null = null;
@@ -582,36 +698,15 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
     }
     if (tid && tid === targetId) return page;
   }
-  // Fallback: match by URL from /json/list (more accurate than single-page guess)
+
   if (cdpUrl) {
     try {
-      const listUrl = `${normalizeCdpHttpBaseForJsonEndpoints(cdpUrl)}/json/list`;
-      const headers: Record<string, string> = {};
-      const ctrl = new AbortController();
-      const t = setTimeout(() => ctrl.abort(), 2000);
-      try {
-        const response = await fetch(listUrl, { headers, signal: ctrl.signal });
-        if (response.ok) {
-          const targets = await response.json() as CdpTarget[];
-          const target = targets.find(entry => entry.id === targetId);
-          if (target) {
-            const urlMatch = pages.filter(p => p.url() === target.url);
-            if (urlMatch.length === 1) return urlMatch[0];
-            if (urlMatch.length > 1) {
-              const sameUrlTargets = targets.filter(entry => entry.url === target.url);
-              if (sameUrlTargets.length === urlMatch.length) {
-                const idx = sameUrlTargets.findIndex(entry => entry.id === targetId);
-                if (idx >= 0 && idx < urlMatch.length) return urlMatch[idx];
-              }
-            }
-          }
-        }
-      } finally { clearTimeout(t); }
+      return await findPageByTargetIdViaTargetList(pages, targetId, cdpUrl);
     } catch {}
   }
 
   // Last resort: if CDP sessions failed for all pages and there's only one, return it
-  if (!resolvedViaCdp && pages.length === 1) return pages[0];
+  if (!resolvedViaCdp && pages.length === 1) return pages[0] ?? null;
   return null;
 }
 
@@ -624,9 +719,77 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
     if (pages.length === 1) return first;
-    throw new Error(`Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`);
+    throw new BrowserTabNotFoundError(`Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`);
   }
   return found;
+}
+
+/**
+ * Resolve a page by targetId or throw BrowserTabNotFoundError.
+ */
+export async function resolvePageByTargetIdOrThrow(opts: { cdpUrl: string; targetId: string }): Promise<Page> {
+  const { browser } = await connectBrowser(opts.cdpUrl);
+  const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
+  if (!page) throw new BrowserTabNotFoundError();
+  return page;
+}
+
+// ── Ref Helpers ──
+
+/**
+ * Parse a role ref string (e.g. "e1", "@e1", "ref=e1") to a normalized ref ID.
+ * Returns null if the string is not a valid role ref.
+ */
+export function parseRoleRef(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed.startsWith('ref=') ? trimmed.slice(4) : trimmed;
+  return /^e\d+$/.test(normalized) ? normalized : null;
+}
+
+/**
+ * Require a ref string, normalizing and validating it.
+ * Throws if the ref is empty.
+ */
+export function requireRef(value: string | undefined): string {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  const ref = (raw ? parseRoleRef(raw) : null) ?? (raw.startsWith('@') ? raw.slice(1) : raw);
+  if (!ref) throw new Error('ref is required');
+  return ref;
+}
+
+/**
+ * Require either a ref or selector, returning whichever is provided.
+ * Throws if neither is provided.
+ */
+export function requireRefOrSelector(ref?: string, selector?: string): { ref?: string; selector?: string } {
+  const trimmedRef = typeof ref === 'string' ? ref.trim() : '';
+  const trimmedSelector = typeof selector === 'string' ? selector.trim() : '';
+  if (!trimmedRef && !trimmedSelector) throw new Error('ref or selector is required');
+  return { ref: trimmedRef || undefined, selector: trimmedSelector || undefined };
+}
+
+/** Clamp interaction timeout to [500, 60000]ms range, defaulting to 8000ms. */
+export function resolveInteractionTimeoutMs(timeoutMs?: number): number {
+  return Math.max(500, Math.min(60000, Math.floor(timeoutMs ?? 8000)));
+}
+
+/** Bounded delay validator for animation/interaction delays. */
+export function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
+  const normalized = Math.floor(value ?? 0);
+  if (!Number.isFinite(normalized) || normalized < 0) throw new Error(`${label} must be >= 0`);
+  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${maxMs}ms`);
+  return normalized;
+}
+
+/**
+ * Get a page for a target, ensuring page state is initialized and role refs are restored.
+ */
+export async function getRestoredPageForTarget(opts: { cdpUrl: string; targetId?: string }): Promise<Page> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  return page;
 }
 
 // ── Ref Locator ──

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,27 @@ export {
   createPinnedLookup,
   resolvePinnedHostnameWithPolicy,
   writeViaSiblingTempPath,
+  assertSafeUploadPaths,
+  resolveStrictExistingUploadPaths,
 } from './security.js';
 export type { BrowserNavigationPolicyOptions, BrowserNavigationRequestLike, LookupFn } from './security.js';
-export { ensureContextState, forceDisconnectPlaywrightForTarget } from './connection.js';
+export {
+  ensureContextState,
+  forceDisconnectPlaywrightForTarget,
+  withPlaywrightPageCdpSession,
+  withPageScopedCdpClient,
+  resolvePageByTargetIdOrThrow,
+  requireRef,
+  requireRefOrSelector,
+  resolveInteractionTimeoutMs,
+  resolveBoundedDelayMs,
+  getRestoredPageForTarget,
+  parseRoleRef,
+  BrowserTabNotFoundError,
+} from './connection.js';
 export type { FrameEvalResult } from './actions/evaluate.js';
+export { batchViaPlaywright, executeSingleAction } from './actions/batch.js';
+export type { BatchAction, BatchActionResult } from './actions/batch.js';
 export type {
   SsrfPolicy,
   LaunchOptions,

--- a/src/security.ts
+++ b/src/security.ts
@@ -562,6 +562,22 @@ export async function assertSafeUploadPaths(paths: string[]): Promise<void> {
   }
 }
 
+/**
+ * Resolve and validate upload file paths, returning them if all are safe.
+ * Returns `{ ok: true, paths }` or `{ ok: false, error }`.
+ */
+export async function resolveStrictExistingUploadPaths(params: {
+  requestedPaths: string[];
+  scopeLabel?: string;
+}): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
+  try {
+    await assertSafeUploadPaths(params.requestedPaths);
+    return { ok: true, paths: params.requestedPaths };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 // ── Atomic file write utilities ──
 
 /**

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -1,4 +1,4 @@
-import { getPageForTargetId, ensurePageState, storeRoleRefsForTarget, normalizeTimeoutMs } from '../connection.js';
+import { getPageForTargetId, ensurePageState, storeRoleRefsForTarget, normalizeTimeoutMs, withPlaywrightPageCdpSession } from '../connection.js';
 import type { PageWithAI } from '../connection.js';
 import {
   buildRoleSnapshotFromAriaSnapshot,
@@ -125,22 +125,20 @@ export async function snapshotAria(opts: {
 
   const sourceUrl = page.url();
 
-  const session = await page.context().newCDPSession(page);
-  try {
-    await session.send('Accessibility.enable').catch(() => {});
-    const res = await session.send('Accessibility.getFullAXTree') as { nodes?: CdpAXNode[] };
-    return {
-      nodes: formatAriaNodes(Array.isArray(res?.nodes) ? res.nodes : [], limit),
-      untrusted: true,
-      contentMeta: {
-        sourceUrl,
-        contentType: 'browser-aria-tree',
-        capturedAt: new Date().toISOString(),
-      },
-    };
-  } finally {
-    await session.detach().catch(() => {});
-  }
+  const res = await withPlaywrightPageCdpSession(page, async (session) => {
+    await session.send('Accessibility.enable' as any).catch(() => {});
+    return await session.send('Accessibility.getFullAXTree' as any) as { nodes?: CdpAXNode[] };
+  });
+
+  return {
+    nodes: formatAriaNodes(Array.isArray(res?.nodes) ? res.nodes : [], limit),
+    untrusted: true,
+    contentMeta: {
+      sourceUrl,
+      contentType: 'browser-aria-tree',
+      capturedAt: new Date().toISOString(),
+    },
+  };
 }
 
 function axValue(v: { value?: string | number | boolean } | undefined): string {


### PR DESCRIPTION
Full source sync from OpenClaw 2026.3.13 compiled browser module.

## Changes

### New
- `src/actions/batch.ts` — new `batchViaPlaywright` + `executeSingleAction` for executing multiple browser actions in sequence (with nesting up to depth 5, max 100 actions per batch)
- `BrowserTabNotFoundError` — typed error class for missing tab (exported from `connection.ts` and `index.ts`)

### connection.ts
- `withPlaywrightPageCdpSession` — scoped CDP session helper (create + detach)
- `withPageScopedCdpClient` — CDP client abstraction (routes through Playwright CDP session)
- `isExtensionRelayCdpEndpoint` — detect OpenClaw browser extension relay endpoints
- `findPageByTargetId` — now extension-relay-aware; uses `findPageByTargetIdViaTargetList` for relay endpoints
- `resolvePageByTargetIdOrThrow` — find page by targetId or throw `BrowserTabNotFoundError`
- `requireRef`, `requireRefOrSelector` — ref validation helpers (moved from interaction.ts internals)
- `resolveInteractionTimeoutMs`, `resolveBoundedDelayMs` — shared timeout/delay helpers (moved from interaction.ts)
- `getRestoredPageForTarget` — get page + ensure state + restore refs (moved from interaction.ts)
- `parseRoleRef` — parse role ref string to normalized ref ID
- disconnect handler now clears `roleRefsByTarget` entries for the disconnected URL

### snapshot/aria-snapshot.ts
- `snapshotAria` now uses `withPlaywrightPageCdpSession` instead of inline raw CDPSession

### actions/interaction.ts
- `typeViaPlaywright`: uses `locator.type()` instead of `pressSequentially()` for slowly mode
- `highlightViaPlaywright`: uses `requireRef` for proper ref normalization
- `armFileUploadViaPlaywright`: uses `resolveStrictExistingUploadPaths` (returns ok/error instead of throwing)
- `setInputFilesViaPlaywright`: same — uses `resolveStrictExistingUploadPaths`

### actions/navigation.ts
- `closePageByTargetIdViaPlaywright`: uses `resolvePageByTargetIdOrThrow`
- `focusPageByTargetIdViaPlaywright`: uses `resolvePageByTargetIdOrThrow` + `withPageScopedCdpClient` for bringToFront fallback
- `createPageViaPlaywright`: create page before navigation check (matches OC ordering)

### actions/emulation.ts
- `setLocaleViaPlaywright`, `setTimezoneViaPlaywright`, `setDeviceViaPlaywright`: use `withPageScopedCdpClient` instead of inline raw CDPSession

### capture/screenshot.ts
- `screenshotWithLabelsViaPlaywright`: complete rewrite matching OC implementation — uses viewport scroll offsets to clip off-screen elements, `refs: RoleRefs` map input, orange `#ffb020` label style, returns `{ buffer, labels: number, skipped: number }`

### capture/response.ts
- `responseBodyViaPlaywright`: rewritten to use event-listener pattern (matches OC) instead of `page.waitForResponse()`; supports glob URL patterns; default maxChars 200K

### security.ts
- `resolveStrictExistingUploadPaths` — returns `{ ok, paths }` or `{ ok, error }` (compatibility wrapper over `assertSafeUploadPaths`)