### PR TITLE
Add strict ESLint and Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,81 @@
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import importPlugin from 'eslint-plugin-import-x';
+
+export default tseslint.config(
+  {
+    ignores: ['dist/', 'node_modules/'],
+  },
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+      sourceType: 'module',
+    },
+    plugins: {
+      'import-x': importPlugin,
+    },
+    rules: {
+      // No `any` allowed
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
+
+      // No unused variables
+      '@typescript-eslint/no-unused-vars': 'error',
+
+      // No floating promises
+      '@typescript-eslint/no-floating-promises': 'error',
+
+      // Consistent type imports
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+      ],
+
+      // No non-null assertions
+      '@typescript-eslint/no-non-null-assertion': 'error',
+
+      // Strict boolean expressions
+      '@typescript-eslint/strict-boolean-expressions': 'error',
+
+      // No unnecessary conditions
+      '@typescript-eslint/no-unnecessary-condition': 'error',
+
+      // Prefer nullish coalescing
+      '@typescript-eslint/prefer-nullish-coalescing': 'error',
+
+      // Prefer optional chaining
+      '@typescript-eslint/prefer-optional-chain': 'error',
+
+      // Require await in async functions
+      '@typescript-eslint/require-await': 'error',
+
+      // No misused promises
+      '@typescript-eslint/no-misused-promises': 'error',
+
+      // Switch exhaustiveness check
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
+
+      // Import ordering
+      'import-x/order': [
+        'error',
+        {
+          groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+          'newlines-between': 'always',
+          alphabetize: { order: 'asc', caseInsensitive: true },
+        },
+      ],
+      'import-x/newline-after-import': 'error',
+      'import-x/no-duplicates': 'error',
+    },
+  },
+  eslintConfigPrettier,
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",
@@ -14,11 +14,52 @@
       },
       "devDependencies": {
         "@types/node": "^25.2.1",
+        "@typescript-eslint/eslint-plugin": "^8.57.2",
+        "@typescript-eslint/parser": "^8.57.2",
+        "eslint": "^10.1.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-import-x": "^4.16.2",
+        "prettier": "^3.8.1",
         "tsup": "^8.0.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "typescript-eslint": "^8.57.2"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -463,6 +504,152 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -501,6 +688,26 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@package-json/types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -852,10 +1059,35 @@
         "win32"
       ]
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -869,10 +1101,512 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/type-utils": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -882,12 +1616,62 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -941,6 +1725,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -956,6 +1750,21 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -975,6 +1784,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1018,6 +1834,307 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@package-json/types": "^0.0.12",
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1036,6 +2153,36 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -1047,6 +2194,27 @@
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1063,6 +2231,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
@@ -1072,6 +2286,36 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -1080,6 +2324,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -1112,6 +2401,22 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1120,6 +2425,22 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mlly": {
@@ -1154,6 +2475,29 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1162,6 +2506,76 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1268,6 +2682,42 @@
         }
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1290,6 +2740,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -1337,6 +2797,42 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -1345,6 +2841,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/sucrase": {
@@ -1427,12 +2933,33 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -1487,6 +3014,19 @@
         }
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1499,6 +3039,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
+      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.2",
+        "@typescript-eslint/parser": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/ufo": {
@@ -1514,6 +3078,90 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -25,6 +25,10 @@
     "build": "tsup && node -e \"import('./dist/index.js')\"",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/",
     "prepublishOnly": "npm run build",
     "test": "echo \"No tests yet\" && exit 0"
   },
@@ -61,7 +65,14 @@
   },
   "devDependencies": {
     "@types/node": "^25.2.1",
+    "@typescript-eslint/eslint-plugin": "^8.57.2",
+    "@typescript-eslint/parser": "^8.57.2",
+    "eslint": "^10.1.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import-x": "^4.16.2",
+    "prettier": "^3.8.1",
     "tsup": "^8.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.57.2"
   }
 }

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -1,30 +1,75 @@
-import { clickViaPlaywright } from './interaction.js';
-import { hoverViaPlaywright } from './interaction.js';
-import { typeViaPlaywright } from './interaction.js';
-import { selectOptionViaPlaywright } from './interaction.js';
-import { dragViaPlaywright } from './interaction.js';
-import { fillFormViaPlaywright } from './interaction.js';
-import { scrollIntoViewViaPlaywright } from './interaction.js';
+import { evaluateViaPlaywright } from './evaluate.js';
+import {
+  clickViaPlaywright,
+  hoverViaPlaywright,
+  typeViaPlaywright,
+  selectOptionViaPlaywright,
+  dragViaPlaywright,
+  fillFormViaPlaywright,
+  scrollIntoViewViaPlaywright,
+} from './interaction.js';
 import { pressKeyViaPlaywright } from './keyboard.js';
 import { resizeViewportViaPlaywright, closePageViaPlaywright } from './navigation.js';
 import { waitForViaPlaywright } from './wait.js';
-import { evaluateViaPlaywright } from './evaluate.js';
 
 const MAX_BATCH_DEPTH = 5;
 const MAX_BATCH_ACTIONS = 100;
 
 /** A single action within a batch. */
 export type BatchAction =
-  | { kind: 'click'; ref?: string; selector?: string; targetId?: string; doubleClick?: boolean; button?: string; modifiers?: string[]; delayMs?: number; timeoutMs?: number }
-  | { kind: 'type'; ref?: string; selector?: string; text: string; targetId?: string; submit?: boolean; slowly?: boolean; timeoutMs?: number }
+  | {
+      kind: 'click';
+      ref?: string;
+      selector?: string;
+      targetId?: string;
+      doubleClick?: boolean;
+      button?: string;
+      modifiers?: string[];
+      delayMs?: number;
+      timeoutMs?: number;
+    }
+  | {
+      kind: 'type';
+      ref?: string;
+      selector?: string;
+      text: string;
+      targetId?: string;
+      submit?: boolean;
+      slowly?: boolean;
+      timeoutMs?: number;
+    }
   | { kind: 'press'; key: string; targetId?: string; delayMs?: number }
   | { kind: 'hover'; ref?: string; selector?: string; targetId?: string; timeoutMs?: number }
   | { kind: 'scrollIntoView'; ref?: string; selector?: string; targetId?: string; timeoutMs?: number }
-  | { kind: 'drag'; startRef?: string; startSelector?: string; endRef?: string; endSelector?: string; targetId?: string; timeoutMs?: number }
+  | {
+      kind: 'drag';
+      startRef?: string;
+      startSelector?: string;
+      endRef?: string;
+      endSelector?: string;
+      targetId?: string;
+      timeoutMs?: number;
+    }
   | { kind: 'select'; ref?: string; selector?: string; values: string[]; targetId?: string; timeoutMs?: number }
-  | { kind: 'fill'; fields: Array<{ ref: string; type?: string; value?: string | number | boolean }>; targetId?: string; timeoutMs?: number }
+  | {
+      kind: 'fill';
+      fields: { ref: string; type?: string; value?: string | number | boolean }[];
+      targetId?: string;
+      timeoutMs?: number;
+    }
   | { kind: 'resize'; width: number; height: number; targetId?: string }
-  | { kind: 'wait'; timeMs?: number; text?: string; textGone?: string; selector?: string; url?: string; loadState?: 'load' | 'domcontentloaded' | 'networkidle'; fn?: string; targetId?: string; timeoutMs?: number }
+  | {
+      kind: 'wait';
+      timeMs?: number;
+      text?: string;
+      textGone?: string;
+      selector?: string;
+      url?: string;
+      loadState?: 'load' | 'domcontentloaded' | 'networkidle';
+      fn?: string;
+      targetId?: string;
+      timeoutMs?: number;
+    }
   | { kind: 'evaluate'; fn: string; ref?: string; targetId?: string; timeoutMs?: number }
   | { kind: 'close'; targetId?: string }
   | { kind: 'batch'; actions: BatchAction[]; targetId?: string; stopOnError?: boolean };
@@ -42,7 +87,7 @@ export async function executeSingleAction(
   evaluateEnabled: boolean,
   depth = 0,
 ): Promise<void> {
-  if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${MAX_BATCH_DEPTH}`);
+  if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${String(MAX_BATCH_DEPTH)}`);
   const effectiveTargetId = action.targetId ?? targetId;
 
   switch (action.kind) {
@@ -53,8 +98,8 @@ export async function executeSingleAction(
         ref: action.ref,
         selector: action.selector,
         doubleClick: action.doubleClick,
-        button: action.button as any,
-        modifiers: action.modifiers as any,
+        button: action.button as 'left' | 'right' | 'middle' | undefined,
+        modifiers: action.modifiers as ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[] | undefined,
         delayMs: action.delayMs,
         timeoutMs: action.timeoutMs,
       });
@@ -135,7 +180,8 @@ export async function executeSingleAction(
       });
       break;
     case 'wait':
-      if (action.fn && !evaluateEnabled) throw new Error('wait --fn is disabled by config (browser.evaluateEnabled=false)');
+      if (action.fn !== undefined && action.fn !== '' && !evaluateEnabled)
+        throw new Error('wait --fn is disabled by config (browser.evaluateEnabled=false)');
       await waitForViaPlaywright({
         cdpUrl,
         targetId: effectiveTargetId,
@@ -176,7 +222,7 @@ export async function executeSingleAction(
       });
       break;
     default:
-      throw new Error(`Unsupported batch action kind: ${(action as any).kind}`);
+      throw new Error(`Unsupported batch action kind: ${String((action as Record<string, unknown>).kind)}`);
   }
 }
 
@@ -197,8 +243,9 @@ export async function batchViaPlaywright(opts: {
   depth?: number;
 }): Promise<{ results: BatchActionResult[] }> {
   const depth = opts.depth ?? 0;
-  if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${MAX_BATCH_DEPTH}`);
-  if (opts.actions.length > MAX_BATCH_ACTIONS) throw new Error(`Batch exceeds maximum of ${MAX_BATCH_ACTIONS} actions`);
+  if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${String(MAX_BATCH_DEPTH)}`);
+  if (opts.actions.length > MAX_BATCH_ACTIONS)
+    throw new Error(`Batch exceeds maximum of ${String(MAX_BATCH_ACTIONS)} actions`);
 
   const results: BatchActionResult[] = [];
   const evaluateEnabled = opts.evaluateEnabled !== false;

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -1,4 +1,7 @@
+import { dirname } from 'node:path';
+
 import type { Page, Download } from 'playwright-core';
+
 import {
   getPageForTargetId,
   ensurePageState,
@@ -8,7 +11,6 @@ import {
   normalizeTimeoutMs,
   bumpDownloadArmId,
 } from '../connection.js';
-import { dirname } from 'node:path';
 import { assertSafeOutputPath, writeViaSiblingTempPath } from '../security.js';
 import type { DownloadResult, PageState } from '../types.js';
 
@@ -97,7 +99,7 @@ export async function downloadViaPlaywright(opts: {
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
-  const outPath = String(opts.path ?? '').trim();
+  const outPath = opts.path.trim();
   if (!outPath) throw new Error('path is required');
 
   state.armIdDownload = bumpDownloadArmId();

--- a/src/actions/emulation.ts
+++ b/src/actions/emulation.ts
@@ -1,9 +1,6 @@
 import { devices } from 'playwright-core';
-import {
-  getPageForTargetId,
-  ensurePageState,
-  withPageScopedCdpClient,
-} from '../connection.js';
+
+import { getPageForTargetId, ensurePageState, withPageScopedCdpClient } from '../connection.js';
 import type { ColorScheme } from '../types.js';
 
 export async function emulateMediaViaPlaywright(opts: {
@@ -16,23 +13,29 @@ export async function emulateMediaViaPlaywright(opts: {
   await page.emulateMedia({ colorScheme: opts.colorScheme });
 }
 
-export async function setDeviceViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  name: string;
-}): Promise<void> {
-  const name = String(opts.name ?? '').trim();
+export async function setDeviceViaPlaywright(opts: { cdpUrl: string; targetId?: string; name: string }): Promise<void> {
+  const name = opts.name.trim();
   if (!name) throw new Error('device name is required');
 
-  const device = devices[name];
-  if (!device) {
+  const device:
+    | {
+        viewport: { width: number; height: number } | null;
+        userAgent: string;
+        deviceScaleFactor: number;
+        isMobile: boolean;
+        hasTouch: boolean;
+        defaultBrowserType: string;
+        locale?: string;
+      }
+    | undefined = devices[name] as ((typeof devices)[string] & { locale?: string }) | undefined;
+  if (device === undefined) {
     throw new Error(`Unknown device "${name}".`);
   }
 
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  if (device.viewport) {
+  if (device.viewport !== null) {
     await page.setViewportSize({
       width: device.viewport.width,
       height: device.viewport.height,
@@ -44,19 +47,19 @@ export async function setDeviceViaPlaywright(opts: {
     page,
     targetId: opts.targetId,
     fn: async (send) => {
-      const locale = (device as any).locale as string | undefined;
-      if (device.userAgent || locale) {
+      const locale = device.locale;
+      if (device.userAgent !== '' || (locale !== undefined && locale !== '')) {
         await send('Emulation.setUserAgentOverride', {
-          userAgent: device.userAgent ?? '',
-          acceptLanguage: locale ?? undefined,
+          userAgent: device.userAgent,
+          acceptLanguage: locale,
         });
       }
-      if (device.viewport) {
+      if (device.viewport !== null) {
         await send('Emulation.setDeviceMetricsOverride', {
-          mobile: Boolean(device.isMobile),
+          mobile: device.isMobile,
           width: device.viewport.width,
           height: device.viewport.height,
-          deviceScaleFactor: device.deviceScaleFactor ?? 1,
+          deviceScaleFactor: device.deviceScaleFactor,
           screenWidth: device.viewport.width,
           screenHeight: device.viewport.height,
         });
@@ -91,9 +94,11 @@ export async function setGeolocationViaPlaywright(opts: {
   ensurePageState(page);
   const context = page.context();
 
-  if (opts.clear) {
+  if (opts.clear === true) {
     await context.setGeolocation(null);
-    await context.clearPermissions().catch(() => {});
+    await context.clearPermissions().catch(() => {
+      /* intentional no-op */
+    });
     return;
   }
 
@@ -107,10 +112,19 @@ export async function setGeolocationViaPlaywright(opts: {
     accuracy: typeof opts.accuracy === 'number' ? opts.accuracy : undefined,
   });
 
-  const origin = opts.origin?.trim() || (() => {
-    try { return new URL(page.url()).origin; } catch { return ''; }
-  })();
-  if (origin) await context.grantPermissions(['geolocation'], { origin }).catch(() => {});
+  const origin =
+    (opts.origin !== undefined && opts.origin !== '' ? opts.origin.trim() : '') ||
+    (() => {
+      try {
+        return new URL(page.url()).origin;
+      } catch {
+        return '';
+      }
+    })();
+  if (origin !== '')
+    await context.grantPermissions(['geolocation'], { origin }).catch(() => {
+      /* intentional no-op */
+    });
 }
 
 /**
@@ -129,15 +143,17 @@ export async function setHttpCredentialsViaPlaywright(opts: {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  if (opts.clear) {
-    await page.context().setHTTPCredentials(null as any);
+  if (opts.clear === true) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    await page.context().setHTTPCredentials(null);
     return;
   }
 
-  const username = String(opts.username ?? '');
-  const password = String(opts.password ?? '');
+  const username = opts.username ?? '';
+  const password = opts.password ?? '';
   if (!username) throw new Error('username is required (or set clear=true)');
 
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   await page.context().setHTTPCredentials({ username, password });
 }
 
@@ -149,7 +165,7 @@ export async function setLocaleViaPlaywright(opts: {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  const locale = String(opts.locale ?? '').trim();
+  const locale = opts.locale.trim();
   if (!locale) throw new Error('locale is required');
 
   await withPageScopedCdpClient({
@@ -174,7 +190,7 @@ export async function setOfflineViaPlaywright(opts: {
 }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
-  await page.context().setOffline(Boolean(opts.offline));
+  await page.context().setOffline(opts.offline);
 }
 
 export async function setTimezoneViaPlaywright(opts: {
@@ -185,7 +201,7 @@ export async function setTimezoneViaPlaywright(opts: {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  const timezoneId = String(opts.timezoneId ?? '').trim();
+  const timezoneId = opts.timezoneId.trim();
   if (!timezoneId) throw new Error('timezoneId is required');
 
   await withPageScopedCdpClient({

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -23,7 +23,7 @@ export async function evaluateInAllFramesViaPlaywright(opts: {
   targetId?: string;
   fn: string;
 }): Promise<FrameEvalResult[]> {
-  const fnText = String(opts.fn ?? '').trim();
+  const fnText = opts.fn.trim();
   if (!fnText) throw new Error('function is required');
 
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
@@ -33,19 +33,15 @@ export async function evaluateInAllFramesViaPlaywright(opts: {
   for (const frame of frames) {
     try {
       // Runs in the frame's browser context (sandboxed), not in Node.js
-      const result = await frame.evaluate(
-        // eslint-disable-next-line no-eval
-        (fnBody: string) => {
-          'use strict';
-          try {
-            const candidate = (0, eval)('(' + fnBody + ')');
-            return typeof candidate === 'function' ? candidate() : candidate;
-          } catch (err: unknown) {
-            throw new Error('Invalid evaluate function: ' + (err instanceof Error ? err.message : String(err)));
-          }
-        },
-        fnText,
-      );
+      const result: unknown = await frame.evaluate((fnBody: string) => {
+        'use strict';
+        try {
+          const candidate: unknown = (0, eval)('(' + fnBody + ')');
+          return typeof candidate === 'function' ? (candidate as () => unknown)() : candidate;
+        } catch (err: unknown) {
+          throw new Error('Invalid evaluate function: ' + (err instanceof Error ? err.message : String(err)));
+        }
+      }, fnText);
       results.push({
         frameUrl: frame.url(),
         frameName: frame.name(),
@@ -68,7 +64,9 @@ async function awaitEvalWithAbort(evalPromise: Promise<unknown>, abortPromise?: 
     return await Promise.race([evalPromise, abortPromise]);
   } catch (err) {
     // Suppress unhandled rejection from the eval promise if abort won the race
-    evalPromise.catch(() => {});
+    evalPromise.catch(() => {
+      /* suppress unhandled rejection */
+    });
     throw err;
   }
 }
@@ -76,8 +74,11 @@ async function awaitEvalWithAbort(evalPromise: Promise<unknown>, abortPromise?: 
 // Browser-side evaluator that wraps async results with a timeout via Promise.race.
 // This runs inside the browser sandbox (not Node.js) — `new Function` is the standard
 // pattern for browser-context evaluation with timeout, matching OpenClaw's implementation.
-// eslint-disable-next-line no-new-func
-const BROWSER_EVALUATOR = new Function('args', `
+
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const BROWSER_EVALUATOR = new Function(
+  'args',
+  `
   "use strict";
   var fnBody = args.fnBody, timeoutMs = args.timeoutMs;
   try {
@@ -95,10 +96,14 @@ const BROWSER_EVALUATOR = new Function('args', `
   } catch (err) {
     throw new Error("Invalid evaluate function: " + (err && err.message ? err.message : String(err)));
   }
-`);
+`,
+);
 
-// eslint-disable-next-line no-new-func
-const ELEMENT_EVALUATOR = new Function('el', 'args', `
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const ELEMENT_EVALUATOR = new Function(
+  'el',
+  'args',
+  `
   "use strict";
   var fnBody = args.fnBody, timeoutMs = args.timeoutMs;
   try {
@@ -116,7 +121,8 @@ const ELEMENT_EVALUATOR = new Function('el', 'args', `
   } catch (err) {
     throw new Error("Invalid evaluate function: " + (err && err.message ? err.message : String(err)));
   }
-`);
+`,
+);
 
 /**
  * Evaluate JavaScript in the browser page context.
@@ -132,7 +138,7 @@ export async function evaluateViaPlaywright(opts: {
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const fnText = String(opts.fn ?? '').trim();
+  const fnText = opts.fn.trim();
   if (!fnText) throw new Error('function is required');
 
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
@@ -148,20 +154,24 @@ export async function evaluateViaPlaywright(opts: {
   let abortReject: ((reason: unknown) => void) | undefined;
   let abortPromise: Promise<never> | undefined;
 
-  if (signal) {
+  if (signal !== undefined) {
     abortPromise = new Promise<never>((_, reject) => {
       abortReject = reject;
     });
-    abortPromise.catch(() => {});
+    abortPromise.catch(() => {
+      /* suppress unhandled rejection */
+    });
   }
 
-  if (signal) {
+  if (signal !== undefined) {
     const disconnect = () => {
       forceDisconnectPlaywrightForTarget({
         cdpUrl: opts.cdpUrl,
         targetId: opts.targetId,
         reason: 'evaluate aborted',
-      }).catch(() => {});
+      }).catch(() => {
+        /* intentional no-op */
+      });
     };
     if (signal.aborted) {
       disconnect();
@@ -172,6 +182,8 @@ export async function evaluateViaPlaywright(opts: {
       abortReject?.(signal.reason ?? new Error('aborted'));
     };
     signal.addEventListener('abort', abortListener, { once: true });
+    // Re-check after adding listener to handle race where signal was aborted between checks
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (signal.aborted) {
       abortListener();
       throw signal.reason ?? new Error('aborted');
@@ -179,16 +191,22 @@ export async function evaluateViaPlaywright(opts: {
   }
 
   try {
-    if (opts.ref) {
+    if (opts.ref !== undefined && opts.ref !== '') {
       const locator = refLocator(page, opts.ref);
       return await awaitEvalWithAbort(
-        locator.evaluate(ELEMENT_EVALUATOR as any, { fnBody: fnText, timeoutMs: evaluateTimeout }),
+        locator.evaluate(ELEMENT_EVALUATOR as (...args: unknown[]) => unknown, {
+          fnBody: fnText,
+          timeoutMs: evaluateTimeout,
+        }),
         abortPromise,
       );
     }
 
     return await awaitEvalWithAbort(
-      page.evaluate(BROWSER_EVALUATOR as any, { fnBody: fnText, timeoutMs: evaluateTimeout }),
+      page.evaluate(BROWSER_EVALUATOR as (...args: unknown[]) => unknown, {
+        fnBody: fnText,
+        timeoutMs: evaluateTimeout,
+      }),
       abortPromise,
     );
   } finally {

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -1,3 +1,5 @@
+import type { Page } from 'playwright-core';
+
 import {
   getPageForTargetId,
   ensurePageState,
@@ -22,8 +24,10 @@ type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
 const MAX_CLICK_DELAY_MS = 5000;
 const CHECKABLE_ROLES = new Set(['menuitemcheckbox', 'menuitemradio', 'checkbox', 'switch']);
 
-function resolveLocator(page: import('playwright-core').Page, resolved: { ref?: string; selector?: string }) {
-  return resolved.ref ? refLocator(page, resolved.ref) : page.locator(resolved.selector!);
+function resolveLocator(page: Page, resolved: { ref?: string; selector?: string }) {
+  if (resolved.ref !== undefined && resolved.ref !== '') return refLocator(page, resolved.ref);
+  const sel = resolved.selector ?? '';
+  return page.locator(sel);
 }
 
 export async function clickViaPlaywright(opts: {
@@ -39,15 +43,15 @@ export async function clickViaPlaywright(opts: {
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
+  const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
 
   // Determine if this is a checkable role element so we can verify the click worked.
   let checkableRole = false;
-  if (resolved.ref) {
+  if (resolved.ref !== undefined && resolved.ref !== '') {
     const refId = parseRoleRef(resolved.ref);
-    if (refId) {
+    if (refId !== null) {
       const state = ensurePageState(page);
       const info = state.roleRefs?.[refId];
       if (info && CHECKABLE_ROLES.has(info.role)) checkableRole = true;
@@ -63,11 +67,11 @@ export async function clickViaPlaywright(opts: {
 
     // For checkable roles, capture aria-checked before the click.
     let ariaCheckedBefore: string | null | undefined;
-    if (checkableRole && !opts.doubleClick) {
+    if (checkableRole && opts.doubleClick !== true) {
       ariaCheckedBefore = await locator.getAttribute('aria-checked', { timeout }).catch(() => undefined);
     }
 
-    if (opts.doubleClick) {
+    if (opts.doubleClick === true) {
       await locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers });
     } else {
       await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
@@ -76,7 +80,7 @@ export async function clickViaPlaywright(opts: {
     // If this is a checkable role and aria-checked didn't change, fall back to JS click.
     // Poll briefly to give async frameworks time to update the DOM before concluding
     // the click didn't work — otherwise we'd fire a second click that un-toggles it.
-    if (checkableRole && !opts.doubleClick && ariaCheckedBefore !== undefined) {
+    if (checkableRole && opts.doubleClick !== true && ariaCheckedBefore !== undefined) {
       const POLL_INTERVAL_MS = 50;
       const POLL_TIMEOUT_MS = 500;
       let changed = false;
@@ -89,7 +93,13 @@ export async function clickViaPlaywright(opts: {
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
       }
       if (!changed) {
-        await locator.evaluate((el: Element) => (el as HTMLElement).click()).catch(() => {});
+        await locator
+          .evaluate((el: Element) => {
+            (el as HTMLElement).click();
+          })
+          .catch(() => {
+            /* intentional no-op */
+          });
       }
     }
   } catch (err) {
@@ -106,7 +116,7 @@ export async function hoverViaPlaywright(opts: {
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
+  const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
 
   try {
@@ -127,20 +137,20 @@ export async function typeViaPlaywright(opts: {
   timeoutMs?: number;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  const text = String(opts.text ?? '');
+  const text = opts.text;
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
+  const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
 
   try {
-    if (opts.slowly) {
+    if (opts.slowly === true) {
       await locator.click({ timeout });
       await locator.pressSequentially(text, { timeout, delay: 75 });
     } else {
       await locator.fill(text, { timeout });
     }
-    if (opts.submit) await locator.press('Enter', { timeout });
+    if (opts.submit === true) await locator.press('Enter', { timeout });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -155,9 +165,9 @@ export async function selectOptionViaPlaywright(opts: {
   timeoutMs?: number;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  if (!opts.values?.length) throw new Error('values are required');
+  if (opts.values.length === 0) throw new Error('values are required');
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
+  const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
 
   try {
@@ -181,8 +191,8 @@ export async function dragViaPlaywright(opts: {
   const page = await getRestoredPageForTarget(opts);
   const startLocator = resolveLocator(page, resolvedStart);
   const endLocator = resolveLocator(page, resolvedEnd);
-  const startLabel = resolvedStart.ref ?? resolvedStart.selector!;
-  const endLabel = resolvedEnd.ref ?? resolvedEnd.selector!;
+  const startLabel = resolvedStart.ref ?? resolvedStart.selector ?? '';
+  const endLabel = resolvedEnd.ref ?? resolvedEnd.selector ?? '';
 
   try {
     await startLocator.dragTo(endLocator, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
@@ -204,9 +214,12 @@ export async function fillFormViaPlaywright(opts: {
     const ref = field.ref.trim();
     const type = (typeof field.type === 'string' ? field.type.trim() : '') || 'text';
     const rawValue = field.value;
-    const value = typeof rawValue === 'string' ? rawValue
-      : typeof rawValue === 'number' || typeof rawValue === 'boolean' ? String(rawValue)
-      : '';
+    const value =
+      typeof rawValue === 'string'
+        ? rawValue
+        : typeof rawValue === 'number' || typeof rawValue === 'boolean'
+          ? String(rawValue)
+          : '';
 
     if (!ref) continue;
     const locator = refLocator(page, ref);
@@ -238,7 +251,7 @@ export async function scrollIntoViewViaPlaywright(opts: {
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
+  const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
 
   try {
@@ -248,11 +261,7 @@ export async function scrollIntoViewViaPlaywright(opts: {
   }
 }
 
-export async function highlightViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-}): Promise<void> {
+export async function highlightViaPlaywright(opts: { cdpUrl: string; targetId?: string; ref: string }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const ref = requireRef(opts.ref);
 
@@ -279,9 +288,7 @@ export async function setInputFilesViaPlaywright(opts: {
   if (inputRef && element) throw new Error('ref and element are mutually exclusive');
   if (!inputRef && !element) throw new Error('Either ref or element is required for setInputFiles');
 
-  const locator = inputRef
-    ? refLocator(page, inputRef)
-    : page.locator(element).first();
+  const locator = inputRef ? refLocator(page, inputRef) : page.locator(element).first();
 
   const uploadPathsResult = await resolveStrictExistingUploadPaths({
     requestedPaths: opts.paths,
@@ -304,7 +311,9 @@ export async function setInputFilesViaPlaywright(opts: {
         el.dispatchEvent(new Event('change', { bubbles: true }));
       });
     }
-  } catch {}
+  } catch {
+    /* intentional no-op */
+  }
 }
 
 export async function armDialogViaPlaywright(opts: {
@@ -321,11 +330,16 @@ export async function armDialogViaPlaywright(opts: {
   state.armIdDialog = bumpDialogArmId();
   const armId = state.armIdDialog;
 
-  page.waitForEvent('dialog', { timeout }).then(async (dialog) => {
-    if (state.armIdDialog !== armId) return;
-    if (opts.accept) await dialog.accept(opts.promptText);
-    else await dialog.dismiss();
-  }).catch(() => {});
+  page
+    .waitForEvent('dialog', { timeout })
+    .then(async (dialog) => {
+      if (state.armIdDialog !== armId) return;
+      if (opts.accept) await dialog.accept(opts.promptText);
+      else await dialog.dismiss();
+    })
+    .catch(() => {
+      /* intentional no-op */
+    });
 }
 
 export async function armFileUploadViaPlaywright(opts: {
@@ -341,33 +355,48 @@ export async function armFileUploadViaPlaywright(opts: {
   state.armIdUpload = bumpUploadArmId();
   const armId = state.armIdUpload;
 
-  page.waitForEvent('filechooser', { timeout }).then(async (fileChooser) => {
-    if (state.armIdUpload !== armId) return;
+  page
+    .waitForEvent('filechooser', { timeout })
+    .then(async (fileChooser) => {
+      if (state.armIdUpload !== armId) return;
 
-    if (!opts.paths?.length) {
-      try { await page.keyboard.press('Escape'); } catch {}
-      return;
-    }
-
-    const uploadPathsResult = await resolveStrictExistingUploadPaths({
-      requestedPaths: opts.paths,
-      scopeLabel: 'uploads directory',
-    });
-    if (!uploadPathsResult.ok) {
-      try { await page.keyboard.press('Escape'); } catch {}
-      return;
-    }
-
-    await fileChooser.setFiles(uploadPathsResult.paths);
-
-    try {
-      const input = typeof fileChooser.element === 'function' ? await Promise.resolve(fileChooser.element()) : null;
-      if (input) {
-        await (input as any).evaluate((el: Element) => {
-          el.dispatchEvent(new Event('input', { bubbles: true }));
-          el.dispatchEvent(new Event('change', { bubbles: true }));
-        });
+      if (opts.paths === undefined || opts.paths.length === 0) {
+        try {
+          await page.keyboard.press('Escape');
+        } catch {
+          /* intentional no-op */
+        }
+        return;
       }
-    } catch {}
-  }).catch(() => {});
+
+      const uploadPathsResult = await resolveStrictExistingUploadPaths({
+        requestedPaths: opts.paths,
+        scopeLabel: 'uploads directory',
+      });
+      if (!uploadPathsResult.ok) {
+        try {
+          await page.keyboard.press('Escape');
+        } catch {
+          /* intentional no-op */
+        }
+        return;
+      }
+
+      await fileChooser.setFiles(uploadPathsResult.paths);
+
+      try {
+        const input = typeof fileChooser.element === 'function' ? await Promise.resolve(fileChooser.element()) : null;
+        if (input !== null) {
+          await input.evaluate((el: Element) => {
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+          });
+        }
+      } catch {
+        /* intentional no-op */
+      }
+    })
+    .catch(() => {
+      /* intentional no-op */
+    });
 }

--- a/src/actions/keyboard.ts
+++ b/src/actions/keyboard.ts
@@ -6,7 +6,7 @@ export async function pressKeyViaPlaywright(opts: {
   key: string;
   delayMs?: number;
 }): Promise<void> {
-  const key = String(opts.key ?? '').trim();
+  const key = opts.key.trim();
   if (!key) throw new Error('key is required');
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,5 +1,20 @@
-import { connectBrowser, getPageForTargetId, ensurePageState, ensureContextState, pageTargetId, findPageByTargetId, getAllPages, normalizeTimeoutMs, forceDisconnectPlaywrightForTarget, resolvePageByTargetIdOrThrow, withPageScopedCdpClient } from '../connection.js';
-import { assertBrowserNavigationAllowed, assertBrowserNavigationResultAllowed, assertBrowserNavigationRedirectChainAllowed, withBrowserNavigationPolicy } from '../security.js';
+import {
+  connectBrowser,
+  getPageForTargetId,
+  ensurePageState,
+  ensureContextState,
+  pageTargetId,
+  getAllPages,
+  forceDisconnectPlaywrightForTarget,
+  resolvePageByTargetIdOrThrow,
+  withPageScopedCdpClient,
+} from '../connection.js';
+import {
+  assertBrowserNavigationAllowed,
+  assertBrowserNavigationResultAllowed,
+  assertBrowserNavigationRedirectChainAllowed,
+  withBrowserNavigationPolicy,
+} from '../security.js';
 import type { BrowserTab, SsrfPolicy } from '../types.js';
 
 function isRetryableNavigateError(err: unknown): boolean {
@@ -16,9 +31,12 @@ export async function navigateViaPlaywright(opts: {
   /** @deprecated Use ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } instead */
   allowInternal?: boolean;
 }): Promise<{ url: string }> {
-  const url = String(opts.url ?? '').trim();
+  const url = opts.url.trim();
   if (!url) throw new Error('url is required');
-  const policy = opts.allowInternal ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+  /* eslint-disable @typescript-eslint/no-deprecated */
+  const policy =
+    opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+  /* eslint-enable @typescript-eslint/no-deprecated */
   await assertBrowserNavigationAllowed({ url, ...withBrowserNavigationPolicy(policy) });
 
   const timeout = Math.max(1000, Math.min(120000, opts.timeoutMs ?? 20000));
@@ -36,13 +54,18 @@ export async function navigateViaPlaywright(opts: {
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       reason: 'retry navigate after detached frame',
-    }).catch(() => {});
+    }).catch(() => {
+      /* intentional no-op */
+    });
     page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
     ensurePageState(page);
     response = await navigate();
   }
 
-  await assertBrowserNavigationRedirectChainAllowed({ request: response?.request(), ...withBrowserNavigationPolicy(policy) });
+  await assertBrowserNavigationRedirectChainAllowed({
+    request: response?.request(),
+    ...withBrowserNavigationPolicy(policy),
+  });
   const finalUrl = page.url();
   await assertBrowserNavigationResultAllowed({ url: finalUrl, ...withBrowserNavigationPolicy(policy) });
   return { url: finalUrl };
@@ -50,16 +73,17 @@ export async function navigateViaPlaywright(opts: {
 
 export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<BrowserTab[]> {
   const { browser } = await connectBrowser(opts.cdpUrl);
-  const pages = await getAllPages(browser);
+  const pages = getAllPages(browser);
   const results: BrowserTab[] = [];
   for (const page of pages) {
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid) results.push({
-      targetId: tid,
-      title: await page.title().catch(() => ''),
-      url: page.url(),
-      type: 'page',
-    });
+    if (tid !== null && tid !== '')
+      results.push({
+        targetId: tid,
+        title: await page.title().catch(() => ''),
+        url: page.url(),
+        type: 'page',
+      });
   }
   return results;
 }
@@ -72,13 +96,16 @@ export async function createPageViaPlaywright(opts: {
   allowInternal?: boolean;
 }): Promise<BrowserTab> {
   const { browser } = await connectBrowser(opts.cdpUrl);
-  const context = browser.contexts()[0] ?? await browser.newContext();
+  const context = browser.contexts()[0] ?? (await browser.newContext());
   ensureContextState(context);
   const page = await context.newPage();
   ensurePageState(page);
 
   const targetUrl = (opts.url ?? '').trim() || 'about:blank';
-  const policy = opts.allowInternal ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+  /* eslint-disable @typescript-eslint/no-deprecated */
+  const policy =
+    opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+  /* eslint-enable @typescript-eslint/no-deprecated */
 
   if (targetUrl !== 'about:blank') {
     const navigationPolicy = withBrowserNavigationPolicy(policy);
@@ -91,7 +118,7 @@ export async function createPageViaPlaywright(opts: {
   }
 
   const tid = await pageTargetId(page).catch(() => null);
-  if (!tid) throw new Error('Failed to get targetId for new page');
+  if (tid === null || tid === '') throw new Error('Failed to get targetId for new page');
   return {
     targetId: tid,
     title: await page.title().catch(() => ''),
@@ -100,26 +127,17 @@ export async function createPageViaPlaywright(opts: {
   };
 }
 
-export async function closePageViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-}): Promise<void> {
+export async function closePageViaPlaywright(opts: { cdpUrl: string; targetId?: string }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   await page.close();
 }
 
-export async function closePageByTargetIdViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId: string;
-}): Promise<void> {
+export async function closePageByTargetIdViaPlaywright(opts: { cdpUrl: string; targetId: string }): Promise<void> {
   await (await resolvePageByTargetIdOrThrow(opts)).close();
 }
 
-export async function focusPageByTargetIdViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId: string;
-}): Promise<void> {
+export async function focusPageByTargetIdViaPlaywright(opts: { cdpUrl: string; targetId: string }): Promise<void> {
   const page = await resolvePageByTargetIdOrThrow(opts);
   try {
     await page.bringToFront();

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -5,7 +5,7 @@ const MAX_WAIT_TIME_MS = 30000;
 function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
   const normalized = Math.floor(value ?? 0);
   if (!Number.isFinite(normalized) || normalized < 0) throw new Error(`${label} must be >= 0`);
-  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${maxMs}ms`);
+  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${String(maxMs)}ms`);
   return normalized;
 }
 
@@ -28,25 +28,25 @@ export async function waitForViaPlaywright(opts: {
   if (typeof opts.timeMs === 'number' && Number.isFinite(opts.timeMs)) {
     await page.waitForTimeout(resolveBoundedDelayMs(opts.timeMs, 'wait timeMs', MAX_WAIT_TIME_MS));
   }
-  if (opts.text) {
+  if (opts.text !== undefined && opts.text !== '') {
     await page.getByText(opts.text).first().waitFor({ state: 'visible', timeout });
   }
-  if (opts.textGone) {
+  if (opts.textGone !== undefined && opts.textGone !== '') {
     await page.getByText(opts.textGone).first().waitFor({ state: 'hidden', timeout });
   }
-  if (opts.selector) {
-    const selector = String(opts.selector).trim();
-    if (selector) await page.locator(selector).first().waitFor({ state: 'visible', timeout });
+  if (opts.selector !== undefined && opts.selector !== '') {
+    const selector = opts.selector.trim();
+    if (selector !== '') await page.locator(selector).first().waitFor({ state: 'visible', timeout });
   }
-  if (opts.url) {
-    const url = String(opts.url).trim();
-    if (url) await page.waitForURL(url, { timeout });
+  if (opts.url !== undefined && opts.url !== '') {
+    const url = opts.url.trim();
+    if (url !== '') await page.waitForURL(url, { timeout });
   }
-  if (opts.loadState) {
+  if (opts.loadState !== undefined) {
     await page.waitForLoadState(opts.loadState, { timeout });
   }
-  if (opts.fn) {
-    const fn = String(opts.fn).trim();
-    if (fn) await page.waitForFunction(fn, undefined, { timeout });
+  if (opts.fn !== undefined && opts.fn !== '') {
+    const fn = opts.fn.trim();
+    if (fn !== '') await page.waitForFunction(fn, undefined, { timeout });
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,29 +1,97 @@
-import { launchChrome, stopChrome, isChromeReachable } from './chrome-launcher.js';
-import { connectBrowser, disconnectBrowser, getPageForTargetId, ensurePageState, restoreRoleRefsForTarget, refLocator, pageTargetId, getAllPages, normalizeTimeoutMs } from './connection.js';
-import { snapshotAi } from './snapshot/ai-snapshot.js';
-import { snapshotRole, snapshotAria } from './snapshot/aria-snapshot.js';
-import { clickViaPlaywright, hoverViaPlaywright, typeViaPlaywright, selectOptionViaPlaywright, dragViaPlaywright, fillFormViaPlaywright, scrollIntoViewViaPlaywright, highlightViaPlaywright, setInputFilesViaPlaywright, armDialogViaPlaywright, armFileUploadViaPlaywright } from './actions/interaction.js';
+import type { BrowserContext } from 'playwright-core';
+
 import { batchViaPlaywright } from './actions/batch.js';
 import type { BatchAction, BatchActionResult } from './actions/batch.js';
-import { pressKeyViaPlaywright } from './actions/keyboard.js';
-import { navigateViaPlaywright, listPagesViaPlaywright, createPageViaPlaywright, closePageByTargetIdViaPlaywright, focusPageByTargetIdViaPlaywright, resizeViewportViaPlaywright } from './actions/navigation.js';
-import { waitForViaPlaywright } from './actions/wait.js';
-import { evaluateViaPlaywright, evaluateInAllFramesViaPlaywright, type FrameEvalResult } from './actions/evaluate.js';
 import { downloadViaPlaywright, waitForDownloadViaPlaywright } from './actions/download.js';
-import { emulateMediaViaPlaywright, setDeviceViaPlaywright, setExtraHTTPHeadersViaPlaywright, setGeolocationViaPlaywright, setHttpCredentialsViaPlaywright, setLocaleViaPlaywright, setOfflineViaPlaywright, setTimezoneViaPlaywright } from './actions/emulation.js';
-import { takeScreenshotViaPlaywright, screenshotWithLabelsViaPlaywright } from './capture/screenshot.js';
+import {
+  emulateMediaViaPlaywright,
+  setDeviceViaPlaywright,
+  setExtraHTTPHeadersViaPlaywright,
+  setGeolocationViaPlaywright,
+  setHttpCredentialsViaPlaywright,
+  setLocaleViaPlaywright,
+  setOfflineViaPlaywright,
+  setTimezoneViaPlaywright,
+} from './actions/emulation.js';
+import { evaluateViaPlaywright, evaluateInAllFramesViaPlaywright, type FrameEvalResult } from './actions/evaluate.js';
+import {
+  clickViaPlaywright,
+  hoverViaPlaywright,
+  typeViaPlaywright,
+  selectOptionViaPlaywright,
+  dragViaPlaywright,
+  fillFormViaPlaywright,
+  scrollIntoViewViaPlaywright,
+  highlightViaPlaywright,
+  setInputFilesViaPlaywright,
+  armDialogViaPlaywright,
+  armFileUploadViaPlaywright,
+} from './actions/interaction.js';
+import { pressKeyViaPlaywright } from './actions/keyboard.js';
+import {
+  navigateViaPlaywright,
+  listPagesViaPlaywright,
+  createPageViaPlaywright,
+  closePageByTargetIdViaPlaywright,
+  focusPageByTargetIdViaPlaywright,
+  resizeViewportViaPlaywright,
+} from './actions/navigation.js';
+import { waitForViaPlaywright } from './actions/wait.js';
+import {
+  getConsoleMessagesViaPlaywright,
+  getPageErrorsViaPlaywright,
+  getNetworkRequestsViaPlaywright,
+} from './capture/activity.js';
 import { pdfViaPlaywright } from './capture/pdf.js';
-import { traceStartViaPlaywright, traceStopViaPlaywright } from './capture/trace.js';
 import { responseBodyViaPlaywright } from './capture/response.js';
-import { getConsoleMessagesViaPlaywright, getPageErrorsViaPlaywright, getNetworkRequestsViaPlaywright } from './capture/activity.js';
-import { cookiesGetViaPlaywright, cookiesSetViaPlaywright, cookiesClearViaPlaywright, storageGetViaPlaywright, storageSetViaPlaywright, storageClearViaPlaywright } from './storage/index.js';
+import { takeScreenshotViaPlaywright, screenshotWithLabelsViaPlaywright } from './capture/screenshot.js';
+import { traceStartViaPlaywright, traceStopViaPlaywright } from './capture/trace.js';
+import { launchChrome, stopChrome, isChromeReachable } from './chrome-launcher.js';
+import {
+  connectBrowser,
+  disconnectBrowser,
+  getPageForTargetId,
+  ensurePageState,
+  pageTargetId,
+  getAllPages,
+  normalizeTimeoutMs,
+} from './connection.js';
+import { snapshotAi } from './snapshot/ai-snapshot.js';
+import { snapshotRole, snapshotAria } from './snapshot/aria-snapshot.js';
+import {
+  cookiesGetViaPlaywright,
+  cookiesSetViaPlaywright,
+  cookiesClearViaPlaywright,
+  storageGetViaPlaywright,
+  storageSetViaPlaywright,
+  storageClearViaPlaywright,
+} from './storage/index.js';
 import type {
-  LaunchOptions, ConnectOptions, SnapshotResult, SnapshotOptions, AriaSnapshotResult,
-  BrowserTab, FormField, ClickOptions, TypeOptions, WaitOptions,
-  ScreenshotOptions, ConsoleMessage, PageError, NetworkRequest,
-  CookieData, StorageKind, RunningChrome, SsrfPolicy,
-  DownloadResult, DialogOptions, ResponseBodyResult, TraceStartOptions,
-  ColorScheme, GeolocationOptions, HttpCredentials,
+  LaunchOptions,
+  ConnectOptions,
+  SnapshotResult,
+  SnapshotOptions,
+  AriaSnapshotResult,
+  BrowserTab,
+  FormField,
+  ClickOptions,
+  TypeOptions,
+  WaitOptions,
+  ScreenshotOptions,
+  ConsoleMessage,
+  PageError,
+  NetworkRequest,
+  CookieData,
+  StorageKind,
+  RunningChrome,
+  SsrfPolicy,
+  DownloadResult,
+  DialogOptions,
+  ResponseBodyResult,
+  TraceStartOptions,
+  ColorScheme,
+  GeolocationOptions,
+  HttpCredentials,
 } from './types.js';
 
 /**
@@ -101,8 +169,13 @@ export class CrawlPage {
         },
       });
     }
-    if (opts?.selector || opts?.frameSelector) {
-      throw new Error('selector and frameSelector are only supported in role mode. Use { mode: "role" } or omit these options.');
+    if (
+      (opts?.selector !== undefined && opts.selector !== '') ||
+      (opts?.frameSelector !== undefined && opts.frameSelector !== '')
+    ) {
+      throw new Error(
+        'selector and frameSelector are only supported in role mode. Use { mode: "role" } or omit these options.',
+      );
     }
     return snapshotAi({
       cdpUrl: this.cdpUrl,
@@ -362,7 +435,10 @@ export class CrawlPage {
    * @param opts - Options (stopOnError: stop on first failure, default true)
    * @returns Array of per-action results
    */
-  async batch(actions: BatchAction[], opts?: { stopOnError?: boolean; evaluateEnabled?: boolean }): Promise<{ results: BatchActionResult[] }> {
+  async batch(
+    actions: BatchAction[],
+    opts?: { stopOnError?: boolean; evaluateEnabled?: boolean },
+  ): Promise<{ results: BatchActionResult[] }> {
     return batchViaPlaywright({
       cdpUrl: this.cdpUrl,
       targetId: this.targetId,
@@ -600,9 +676,12 @@ export class CrawlPage {
    * fs.writeFileSync('labeled.png', buffer);
    * ```
    */
-  async screenshotWithLabels(refs: string[], opts?: { maxLabels?: number; type?: 'png' | 'jpeg' }): Promise<{
+  async screenshotWithLabels(
+    refs: string[],
+    opts?: { maxLabels?: number; type?: 'png' | 'jpeg' },
+  ): Promise<{
     buffer: Buffer;
-    labels: Array<{ ref: string; index: number; box: { x: number; y: number; width: number; height: number } }>;
+    labels: { ref: string; index: number; box: { x: number; y: number; width: number; height: number } }[];
     skipped: string[];
   }> {
     return screenshotWithLabelsViaPlaywright({
@@ -749,7 +828,7 @@ export class CrawlPage {
    *
    * @returns Array of cookie objects
    */
-  async cookies(): Promise<Awaited<ReturnType<import('playwright-core').BrowserContext['cookies']>>> {
+  async cookies(): Promise<Awaited<ReturnType<BrowserContext['cookies']>>> {
     const result = await cookiesGetViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this.targetId });
     return result.cookies;
   }
@@ -786,7 +865,10 @@ export class CrawlPage {
    */
   async storageGet(kind: StorageKind, key?: string): Promise<Record<string, string>> {
     const result = await storageGetViaPlaywright({
-      cdpUrl: this.cdpUrl, targetId: this.targetId, kind, key,
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      kind,
+      key,
     });
     return result.values;
   }
@@ -800,7 +882,11 @@ export class CrawlPage {
    */
   async storageSet(kind: StorageKind, key: string, value: string): Promise<void> {
     return storageSetViaPlaywright({
-      cdpUrl: this.cdpUrl, targetId: this.targetId, kind, key, value,
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      kind,
+      key,
+      value,
     });
   }
 
@@ -811,7 +897,9 @@ export class CrawlPage {
    */
   async storageClear(kind: StorageKind): Promise<void> {
     return storageClearViaPlaywright({
-      cdpUrl: this.cdpUrl, targetId: this.targetId, kind,
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      kind,
     });
   }
 
@@ -831,7 +919,11 @@ export class CrawlPage {
    * console.log(result.suggestedFilename); // 'report.pdf'
    * ```
    */
-  async download(ref: string, path: string, opts?: { timeoutMs?: number; allowedOutputRoots?: string[] }): Promise<DownloadResult> {
+  async download(
+    ref: string,
+    path: string,
+    opts?: { timeoutMs?: number; allowedOutputRoots?: string[] },
+  ): Promise<DownloadResult> {
     return downloadViaPlaywright({
       cdpUrl: this.cdpUrl,
       targetId: this.targetId,
@@ -850,7 +942,11 @@ export class CrawlPage {
    * @param opts - Options (path: save location, timeoutMs)
    * @returns Download result with URL, suggested filename, and saved path
    */
-  async waitForDownload(opts?: { path?: string; timeoutMs?: number; allowedOutputRoots?: string[] }): Promise<DownloadResult> {
+  async waitForDownload(opts?: {
+    path?: string;
+    timeoutMs?: number;
+    allowedOutputRoots?: string[];
+  }): Promise<DownloadResult> {
     return waitForDownloadViaPlaywright({
       cdpUrl: this.cdpUrl,
       targetId: this.targetId,
@@ -1051,8 +1147,11 @@ export class BrowserClaw {
    */
   static async launch(opts: LaunchOptions = {}): Promise<BrowserClaw> {
     const chrome = await launchChrome(opts);
-    const cdpUrl = `http://127.0.0.1:${chrome.cdpPort}`;
-    const ssrfPolicy = opts.allowInternal ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+    const cdpUrl = `http://127.0.0.1:${String(chrome.cdpPort)}`;
+    /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
+    const ssrfPolicy =
+      opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+    /* eslint-enable @typescript-eslint/no-deprecated */
     return new BrowserClaw(cdpUrl, chrome, ssrfPolicy);
   }
 
@@ -1071,11 +1170,14 @@ export class BrowserClaw {
    * ```
    */
   static async connect(cdpUrl: string, opts?: ConnectOptions): Promise<BrowserClaw> {
-    if (!await isChromeReachable(cdpUrl, 3000, opts?.authToken)) {
+    if (!(await isChromeReachable(cdpUrl, 3000, opts?.authToken))) {
       throw new Error(`Cannot connect to Chrome at ${cdpUrl}. Is Chrome running with --remote-debugging-port?`);
     }
     await connectBrowser(cdpUrl, opts?.authToken);
-    const ssrfPolicy = opts?.allowInternal ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts?.ssrfPolicy;
+    /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
+    const ssrfPolicy =
+      opts?.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts?.ssrfPolicy;
+    /* eslint-enable @typescript-eslint/no-deprecated */
     return new BrowserClaw(cdpUrl, null, ssrfPolicy);
   }
 
@@ -1103,10 +1205,10 @@ export class BrowserClaw {
    */
   async currentPage(): Promise<CrawlPage> {
     const { browser } = await connectBrowser(this.cdpUrl);
-    const pages = await getAllPages(browser);
+    const pages = getAllPages(browser);
     if (!pages.length) throw new Error('No pages available. Use browser.open(url) to create a tab.');
-    const tid = await pageTargetId(pages[0]!).catch(() => null);
-    if (!tid) throw new Error('Failed to get targetId for the current page.');
+    const tid = await pageTargetId(pages[0]).catch(() => null);
+    if (tid === null || tid === '') throw new Error('Failed to get targetId for the current page.');
     return new CrawlPage(this.cdpUrl, tid, this.ssrfPolicy);
   }
 

--- a/src/capture/activity.ts
+++ b/src/capture/activity.ts
@@ -3,13 +3,18 @@ import type { ConsoleMessage, PageError, NetworkRequest } from '../types.js';
 
 function consolePriority(level: string): number {
   switch (level) {
-    case 'error': return 3;
+    case 'error':
+      return 3;
     case 'warning':
-    case 'warn': return 2;
+    case 'warn':
+      return 2;
     case 'info':
-    case 'log': return 1;
-    case 'debug': return 0;
-    default: return 1;
+    case 'log':
+      return 1;
+    case 'debug':
+      return 0;
+    default:
+      return 1;
   }
 }
 
@@ -20,10 +25,11 @@ export async function getConsoleMessagesViaPlaywright(opts: {
   clear?: boolean;
 }): Promise<ConsoleMessage[]> {
   const state = ensurePageState(await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }));
-  const messages = opts.level
-    ? state.console.filter(msg => consolePriority(msg.type) >= consolePriority(opts.level!))
-    : [...state.console];
-  if (opts.clear) state.console = [];
+  const messages =
+    opts.level !== undefined && opts.level !== ''
+      ? state.console.filter((msg) => consolePriority(msg.type) >= consolePriority(opts.level ?? ''))
+      : [...state.console];
+  if (opts.clear === true) state.console = [];
   return messages;
 }
 
@@ -34,7 +40,7 @@ export async function getPageErrorsViaPlaywright(opts: {
 }): Promise<{ errors: PageError[] }> {
   const state = ensurePageState(await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }));
   const errors = [...state.errors];
-  if (opts.clear) state.errors = [];
+  if (opts.clear === true) state.errors = [];
   return { errors };
 }
 
@@ -47,8 +53,8 @@ export async function getNetworkRequestsViaPlaywright(opts: {
   const state = ensurePageState(await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }));
   const raw = [...state.requests];
   const filter = typeof opts.filter === 'string' ? opts.filter.trim() : '';
-  const requests = filter ? raw.filter(r => r.url.includes(filter)) : raw;
-  if (opts.clear) {
+  const requests = filter ? raw.filter((r) => r.url.includes(filter)) : raw;
+  if (opts.clear === true) {
     state.requests = [];
     state.requestIds = new WeakMap();
   }

--- a/src/capture/pdf.ts
+++ b/src/capture/pdf.ts
@@ -1,9 +1,6 @@
 import { getPageForTargetId, ensurePageState } from '../connection.js';
 
-export async function pdfViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-}): Promise<{ buffer: Buffer }> {
+export async function pdfViaPlaywright(opts: { cdpUrl: string; targetId?: string }): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   return { buffer: await page.pdf({ printBackground: true }) };

--- a/src/capture/response.ts
+++ b/src/capture/response.ts
@@ -1,8 +1,4 @@
-import {
-  getPageForTargetId,
-  ensurePageState,
-  normalizeTimeoutMs,
-} from '../connection.js';
+import { getPageForTargetId, ensurePageState, normalizeTimeoutMs } from '../connection.js';
 import type { ResponseBodyResult } from '../types.js';
 
 function matchUrlPattern(pattern: string, url: string): boolean {
@@ -19,7 +15,6 @@ function matchUrlPattern(pattern: string, url: string): boolean {
   return url.includes(pattern);
 }
 
-
 export async function responseBodyViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -31,18 +26,17 @@ export async function responseBodyViaPlaywright(opts: {
   ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 30000, 120000);
-  const pattern = String(opts.url ?? '').trim();
+  const pattern = opts.url.trim();
   if (!pattern) throw new Error('url is required');
 
-  const response = await page.waitForResponse(
-    (resp) => matchUrlPattern(pattern, resp.url()),
-    { timeout },
-  );
+  const response = await page.waitForResponse((resp) => matchUrlPattern(pattern, resp.url()), { timeout });
   let body = await response.text();
   let truncated = false;
 
-  const maxChars = typeof opts.maxChars === 'number' && Number.isFinite(opts.maxChars)
-    ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars))) : 200000;
+  const maxChars =
+    typeof opts.maxChars === 'number' && Number.isFinite(opts.maxChars)
+      ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars)))
+      : 200000;
   if (body.length > maxChars) {
     body = body.slice(0, maxChars);
     truncated = true;

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -1,9 +1,4 @@
-import {
-  getPageForTargetId,
-  ensurePageState,
-  restoreRoleRefsForTarget,
-  refLocator,
-} from '../connection.js';
+import { getPageForTargetId, ensurePageState, restoreRoleRefsForTarget, refLocator } from '../connection.js';
 
 export async function takeScreenshotViaPlaywright(opts: {
   cdpUrl: string;
@@ -18,12 +13,12 @@ export async function takeScreenshotViaPlaywright(opts: {
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   const type = opts.type ?? 'png';
 
-  if (opts.ref) {
-    if (opts.fullPage) throw new Error('fullPage is not supported for element screenshots');
+  if (opts.ref !== undefined && opts.ref !== '') {
+    if (opts.fullPage === true) throw new Error('fullPage is not supported for element screenshots');
     return { buffer: await refLocator(page, opts.ref).screenshot({ type }) };
   }
-  if (opts.element) {
-    if (opts.fullPage) throw new Error('fullPage is not supported for element screenshots');
+  if (opts.element !== undefined && opts.element !== '') {
+    if (opts.fullPage === true) throw new Error('fullPage is not supported for element screenshots');
     return { buffer: await page.locator(opts.element).first().screenshot({ type }) };
   }
   return { buffer: await page.screenshot({ type, fullPage: Boolean(opts.fullPage) }) };
@@ -35,13 +30,19 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   refs: string[];
   maxLabels?: number;
   type?: 'png' | 'jpeg';
-}): Promise<{ buffer: Buffer; labels: Array<{ ref: string; index: number; box: { x: number; y: number; width: number; height: number } }>; skipped: string[] }> {
+}): Promise<{
+  buffer: Buffer;
+  labels: { ref: string; index: number; box: { x: number; y: number; width: number; height: number } }[];
+  skipped: string[];
+}> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
-  const maxLabels = typeof opts.maxLabels === 'number' && Number.isFinite(opts.maxLabels)
-    ? Math.max(1, Math.floor(opts.maxLabels)) : 150;
+  const maxLabels =
+    typeof opts.maxLabels === 'number' && Number.isFinite(opts.maxLabels)
+      ? Math.max(1, Math.floor(opts.maxLabels))
+      : 150;
   const type = opts.type ?? 'png';
   const refs = opts.refs.slice(0, maxLabels);
   const skipped = opts.refs.slice(maxLabels);
@@ -51,9 +52,9 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
     height: window.innerHeight || 0,
   }));
 
-  const labels: Array<{ ref: string; index: number; box: { x: number; y: number; width: number; height: number } }> = [];
+  const labels: { ref: string; index: number; box: { x: number; y: number; width: number; height: number } }[] = [];
   for (let i = 0; i < refs.length; i++) {
-    const ref = refs[i]!;
+    const ref = refs[i];
     try {
       const locator = refLocator(page, ref);
       const box = await locator.boundingBox({ timeout: 2000 });
@@ -76,22 +77,28 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
 
   try {
     if (labels.length > 0) {
-      await page.evaluate((labelData: Array<{ index: number; box: { x: number; y: number; width: number; height: number } }>) => {
-        document.querySelectorAll('[data-browserclaw-labels]').forEach((el) => el.remove());
-        const container = document.createElement('div');
-        container.setAttribute('data-browserclaw-labels', '1');
-        container.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:2147483647;';
-        for (const { index, box } of labelData) {
-          const border = document.createElement('div');
-          border.style.cssText = `position:absolute;left:${box.x}px;top:${box.y}px;width:${box.width}px;height:${box.height}px;border:2px solid #FF4500;box-sizing:border-box;`;
-          container.appendChild(border);
-          const badge = document.createElement('div');
-          badge.textContent = String(index);
-          badge.style.cssText = `position:absolute;left:${box.x}px;top:${Math.max(0, box.y - 18)}px;background:#FF4500;color:#fff;font:bold 12px/16px monospace;padding:0 4px;border-radius:2px;`;
-          container.appendChild(badge);
-        }
-        document.documentElement.appendChild(container);
-      }, labels.map(l => ({ index: l.index, box: l.box })));
+      await page.evaluate(
+        (labelData: { index: number; box: { x: number; y: number; width: number; height: number } }[]) => {
+          document.querySelectorAll('[data-browserclaw-labels]').forEach((el) => {
+            el.remove();
+          });
+          const container = document.createElement('div');
+          container.setAttribute('data-browserclaw-labels', '1');
+          container.style.cssText =
+            'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:2147483647;';
+          for (const { index, box } of labelData) {
+            const border = document.createElement('div');
+            border.style.cssText = `position:absolute;left:${String(box.x)}px;top:${String(box.y)}px;width:${String(box.width)}px;height:${String(box.height)}px;border:2px solid #FF4500;box-sizing:border-box;`;
+            container.appendChild(border);
+            const badge = document.createElement('div');
+            badge.textContent = String(index);
+            badge.style.cssText = `position:absolute;left:${String(box.x)}px;top:${String(Math.max(0, box.y - 18))}px;background:#FF4500;color:#fff;font:bold 12px/16px monospace;padding:0 4px;border-radius:2px;`;
+            container.appendChild(badge);
+          }
+          document.documentElement.appendChild(container);
+        },
+        labels.map((l) => ({ index: l.index, box: l.box })),
+      );
     }
     return {
       buffer: await page.screenshot({ type }),
@@ -99,8 +106,14 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
       skipped,
     };
   } finally {
-    await page.evaluate(() => {
-      document.querySelectorAll('[data-browserclaw-labels]').forEach((el) => el.remove());
-    }).catch(() => {});
+    await page
+      .evaluate(() => {
+        document.querySelectorAll('[data-browserclaw-labels]').forEach((el) => {
+          el.remove();
+        });
+      })
+      .catch(() => {
+        /* intentional no-op */
+      });
   }
 }

--- a/src/capture/trace.ts
+++ b/src/capture/trace.ts
@@ -1,9 +1,6 @@
 import { dirname } from 'node:path';
-import {
-  getPageForTargetId,
-  ensurePageState,
-  ensureContextState,
-} from '../connection.js';
+
+import { getPageForTargetId, ensurePageState, ensureContextState } from '../connection.js';
 import { assertSafeOutputPath, writeViaSiblingTempPath } from '../security.js';
 
 export async function traceStartViaPlaywright(opts: {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -1,8 +1,9 @@
-import os from 'node:os';
-import path from 'node:path';
+import { execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import net from 'node:net';
-import { execFileSync, spawn } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+
 import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome } from './types.js';
 
 // ── Executable Detection ──
@@ -47,18 +48,48 @@ const CHROMIUM_DESKTOP_IDS = new Set([
 ]);
 
 const CHROMIUM_EXE_NAMES = new Set([
-  'chrome.exe', 'msedge.exe', 'brave.exe', 'brave-browser.exe', 'chromium.exe',
-  'vivaldi.exe', 'opera.exe', 'launcher.exe', 'yandex.exe', 'yandexbrowser.exe',
-  'google chrome', 'google chrome canary', 'brave browser', 'microsoft edge',
-  'chromium', 'chrome', 'brave', 'msedge', 'brave-browser',
-  'google-chrome', 'google-chrome-stable', 'google-chrome-beta', 'google-chrome-unstable',
-  'microsoft-edge', 'microsoft-edge-beta', 'microsoft-edge-dev', 'microsoft-edge-canary',
-  'chromium-browser', 'vivaldi', 'vivaldi-stable', 'opera', 'opera-stable', 'opera-gx',
+  'chrome.exe',
+  'msedge.exe',
+  'brave.exe',
+  'brave-browser.exe',
+  'chromium.exe',
+  'vivaldi.exe',
+  'opera.exe',
+  'launcher.exe',
+  'yandex.exe',
+  'yandexbrowser.exe',
+  'google chrome',
+  'google chrome canary',
+  'brave browser',
+  'microsoft edge',
+  'chromium',
+  'chrome',
+  'brave',
+  'msedge',
+  'brave-browser',
+  'google-chrome',
+  'google-chrome-stable',
+  'google-chrome-beta',
+  'google-chrome-unstable',
+  'microsoft-edge',
+  'microsoft-edge-beta',
+  'microsoft-edge-dev',
+  'microsoft-edge-canary',
+  'chromium-browser',
+  'vivaldi',
+  'vivaldi-stable',
+  'opera',
+  'opera-stable',
+  'opera-gx',
   'yandex-browser',
 ]);
 
 function fileExists(filePath: string): boolean {
-  try { return fs.existsSync(filePath); } catch { return false; }
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
 }
 
 function execText(command: string, args: string[], timeoutMs = 1200): string | null {
@@ -68,8 +99,10 @@ function execText(command: string, args: string[], timeoutMs = 1200): string | n
       encoding: 'utf8',
       maxBuffer: 1024 * 1024,
     });
-    return String(output ?? '').trim() || null;
-  } catch { return null; }
+    return output.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 function inferKindFromIdentifier(identifier: string): ChromeKind {
@@ -78,7 +111,8 @@ function inferKindFromIdentifier(identifier: string): ChromeKind {
   if (id.includes('edge')) return 'edge';
   if (id.includes('chromium')) return 'chromium';
   if (id.includes('canary')) return 'canary';
-  if (id.includes('opera') || id.includes('vivaldi') || id.includes('yandex') || id.includes('thebrowser')) return 'chromium';
+  if (id.includes('opera') || id.includes('vivaldi') || id.includes('yandex') || id.includes('thebrowser'))
+    return 'chromium';
   return 'chrome';
 }
 
@@ -100,22 +134,33 @@ function findFirstExe(candidates: ChromeExecutable[]): ChromeExecutable | null {
 // ── Mac Detection ──
 
 function detectDefaultBrowserBundleIdMac(): string | null {
-  const plistPath = path.join(os.homedir(), 'Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist');
+  const plistPath = path.join(
+    os.homedir(),
+    'Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist',
+  );
   if (!fileExists(plistPath)) return null;
   const handlersRaw = execText('/usr/bin/plutil', ['-extract', 'LSHandlers', 'json', '-o', '-', '--', plistPath], 2000);
-  if (!handlersRaw) return null;
-  let handlers: any[];
-  try { handlers = JSON.parse(handlersRaw); } catch { return null; }
-  if (!Array.isArray(handlers)) return null;
+  if (handlersRaw === null) return null;
+  let handlers: unknown[];
+  try {
+    const parsed: unknown = JSON.parse(handlersRaw);
+    if (!Array.isArray(parsed)) return null;
+    handlers = parsed;
+  } catch {
+    return null;
+  }
 
   const resolveScheme = (scheme: string): string | null => {
     let candidate: string | null = null;
     for (const entry of handlers) {
-      if (!entry || typeof entry !== 'object') continue;
-      if (entry.LSHandlerURLScheme !== scheme) continue;
-      const role = (typeof entry.LSHandlerRoleAll === 'string' && entry.LSHandlerRoleAll) ||
-                   (typeof entry.LSHandlerRoleViewer === 'string' && entry.LSHandlerRoleViewer) || null;
-      if (role) candidate = role;
+      if (entry === null || entry === undefined || typeof entry !== 'object') continue;
+      const rec = entry as Record<string, unknown>;
+      if (rec.LSHandlerURLScheme !== scheme) continue;
+      const role =
+        (typeof rec.LSHandlerRoleAll === 'string' ? rec.LSHandlerRoleAll : null) ??
+        (typeof rec.LSHandlerRoleViewer === 'string' ? rec.LSHandlerRoleViewer : null) ??
+        null;
+      if (role !== null) candidate = role;
     }
     return candidate;
   };
@@ -124,12 +169,12 @@ function detectDefaultBrowserBundleIdMac(): string | null {
 
 function detectDefaultChromiumMac(): ChromeExecutable | null {
   const bundleId = detectDefaultBrowserBundleIdMac();
-  if (!bundleId || !CHROMIUM_BUNDLE_IDS.has(bundleId)) return null;
+  if (bundleId === null || !CHROMIUM_BUNDLE_IDS.has(bundleId)) return null;
   const appPathRaw = execText('/usr/bin/osascript', ['-e', `POSIX path of (path to application id "${bundleId}")`]);
-  if (!appPathRaw) return null;
+  if (appPathRaw === null) return null;
   const appPath = appPathRaw.trim().replace(/\/$/, '');
   const exeName = execText('/usr/bin/defaults', ['read', path.join(appPath, 'Contents', 'Info'), 'CFBundleExecutable']);
-  if (!exeName) return null;
+  if (exeName === null) return null;
   const exePath = path.join(appPath, 'Contents', 'MacOS', exeName.trim());
   if (!fileExists(exePath)) return null;
   return { kind: inferKindFromIdentifier(bundleId), path: exePath };
@@ -146,16 +191,20 @@ function findChromeMac(): ChromeExecutable | null {
     { kind: 'chromium', path: '/Applications/Chromium.app/Contents/MacOS/Chromium' },
     { kind: 'chromium', path: path.join(os.homedir(), 'Applications/Chromium.app/Contents/MacOS/Chromium') },
     { kind: 'canary', path: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary' },
-    { kind: 'canary', path: path.join(os.homedir(), 'Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary') },
+    {
+      kind: 'canary',
+      path: path.join(os.homedir(), 'Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'),
+    },
   ]);
 }
 
 // ── Linux Detection ──
 
 function detectDefaultChromiumLinux(): ChromeExecutable | null {
-  const desktopId = execText('xdg-settings', ['get', 'default-web-browser']) ||
+  const desktopId =
+    execText('xdg-settings', ['get', 'default-web-browser']) ??
     execText('xdg-mime', ['query', 'default', 'x-scheme-handler/http']);
-  if (!desktopId) return null;
+  if (desktopId === null) return null;
   const trimmed = desktopId.trim();
   if (!CHROMIUM_DESKTOP_IDS.has(trimmed)) return null;
 
@@ -168,16 +217,25 @@ function detectDefaultChromiumLinux(): ChromeExecutable | null {
   let desktopPath: string | null = null;
   for (const dir of searchDirs) {
     const candidate = path.join(dir, trimmed);
-    if (fileExists(candidate)) { desktopPath = candidate; break; }
+    if (fileExists(candidate)) {
+      desktopPath = candidate;
+      break;
+    }
   }
-  if (!desktopPath) return null;
+  if (desktopPath === null) return null;
 
   let execLine: string | null = null;
   try {
     const lines = fs.readFileSync(desktopPath, 'utf8').split(/\r?\n/);
-    for (const line of lines) if (line.startsWith('Exec=')) { execLine = line.slice(5).trim(); break; }
-  } catch {}
-  if (!execLine) return null;
+    for (const line of lines)
+      if (line.startsWith('Exec=')) {
+        execLine = line.slice(5).trim();
+        break;
+      }
+  } catch {
+    /* no exec line found */
+  }
+  if (execLine === null) return null;
 
   const tokens = execLine.split(/\s+/);
   let command: string | null = null;
@@ -186,10 +244,10 @@ function detectDefaultChromiumLinux(): ChromeExecutable | null {
     command = token.replace(/^["']|["']$/g, '');
     break;
   }
-  if (!command) return null;
+  if (command === null) return null;
 
   const resolved = command.startsWith('/') ? command : (execText('which', [command], 800)?.trim() ?? null);
-  if (!resolved) return null;
+  if (resolved === null || resolved === '') return null;
   const exeName = path.posix.basename(resolved).toLowerCase();
   if (!CHROMIUM_EXE_NAMES.has(exeName)) return null;
   return { kind: inferKindFromExeName(exeName), path: resolved };
@@ -222,15 +280,24 @@ function findChromeWindows(): ChromeExecutable | null {
   const candidates: ChromeExecutable[] = [];
   if (localAppData) {
     candidates.push({ kind: 'chrome', path: j(localAppData, 'Google', 'Chrome', 'Application', 'chrome.exe') });
-    candidates.push({ kind: 'brave', path: j(localAppData, 'BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe') });
+    candidates.push({
+      kind: 'brave',
+      path: j(localAppData, 'BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe'),
+    });
     candidates.push({ kind: 'edge', path: j(localAppData, 'Microsoft', 'Edge', 'Application', 'msedge.exe') });
     candidates.push({ kind: 'chromium', path: j(localAppData, 'Chromium', 'Application', 'chrome.exe') });
     candidates.push({ kind: 'canary', path: j(localAppData, 'Google', 'Chrome SxS', 'Application', 'chrome.exe') });
   }
   candidates.push({ kind: 'chrome', path: j(programFiles, 'Google', 'Chrome', 'Application', 'chrome.exe') });
   candidates.push({ kind: 'chrome', path: j(programFilesX86, 'Google', 'Chrome', 'Application', 'chrome.exe') });
-  candidates.push({ kind: 'brave', path: j(programFiles, 'BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe') });
-  candidates.push({ kind: 'brave', path: j(programFilesX86, 'BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe') });
+  candidates.push({
+    kind: 'brave',
+    path: j(programFiles, 'BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe'),
+  });
+  candidates.push({
+    kind: 'brave',
+    path: j(programFilesX86, 'BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe'),
+  });
   candidates.push({ kind: 'edge', path: j(programFiles, 'Microsoft', 'Edge', 'Application', 'msedge.exe') });
   candidates.push({ kind: 'edge', path: j(programFilesX86, 'Microsoft', 'Edge', 'Application', 'msedge.exe') });
   return findFirstExe(candidates);
@@ -239,7 +306,7 @@ function findChromeWindows(): ChromeExecutable | null {
 // ── Resolve Executable ──
 
 export function resolveBrowserExecutable(opts?: { executablePath?: string }): ChromeExecutable | null {
-  if (opts?.executablePath) {
+  if (opts?.executablePath !== undefined && opts.executablePath !== '') {
     if (!fileExists(opts.executablePath)) throw new Error(`executablePath not found: ${opts.executablePath}`);
     return { kind: 'custom', path: opts.executablePath };
   }
@@ -254,40 +321,47 @@ export function resolveBrowserExecutable(opts?: { executablePath?: string }): Ch
 
 async function ensurePortAvailable(port: number): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const tester = net.createServer()
+    const tester = net
+      .createServer()
       .once('error', (err: NodeJS.ErrnoException) => {
-        if (err.code === 'EADDRINUSE') reject(new Error(`Port ${port} is already in use`));
+        if (err.code === 'EADDRINUSE') reject(new Error(`Port ${String(port)} is already in use`));
         else reject(err);
       })
-      .once('listening', () => { tester.close(() => resolve()); })
+      .once('listening', () => {
+        tester.close(() => {
+          resolve();
+        });
+      })
       .listen(port);
   });
 }
 
 // ── Profile Decoration ──
 
-function safeReadJson(filePath: string): Record<string, any> | null {
+function safeReadJson(filePath: string): Record<string, unknown> | null {
   try {
     if (!fs.existsSync(filePath)) return null;
-    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const parsed: unknown = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
-    return parsed;
-  } catch { return null; }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
 }
 
-function safeWriteJson(filePath: string, data: Record<string, any>): void {
+function safeWriteJson(filePath: string, data: Record<string, unknown>): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
 }
 
-function setDeep(obj: Record<string, any>, keys: string[], value: any): void {
-  let node = obj;
+function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown): void {
+  let node: Record<string, unknown> = obj;
   for (const key of keys.slice(0, -1)) {
     const next = node[key];
     if (typeof next !== 'object' || next === null || Array.isArray(next)) node[key] = {};
-    node = node[key];
+    node = node[key] as Record<string, unknown>;
   }
-  node[keys[keys.length - 1]!] = value;
+  node[keys[keys.length - 1]] = value;
 }
 
 function parseHexRgbToSignedArgbInt(hex: string): number | null {
@@ -348,7 +422,9 @@ function isWebSocketUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return parsed.protocol === 'ws:' || parsed.protocol === 'wss:';
-  } catch { return false; }
+  } catch {
+    return false;
+  }
 }
 
 export function isLoopbackHost(hostname: string): boolean {
@@ -356,7 +432,10 @@ export function isLoopbackHost(hostname: string): boolean {
 }
 
 export function hasProxyEnvConfigured(): boolean {
-  return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy);
+  return (
+    (process.env.HTTP_PROXY ?? process.env.HTTPS_PROXY ?? process.env.http_proxy ?? process.env.https_proxy ?? '') !==
+    ''
+  );
 }
 
 /**
@@ -421,14 +500,30 @@ async function canOpenWebSocket(url: string, timeoutMs: number): Promise<boolean
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      try { ws.close(); } catch {}
+      try {
+        ws.close();
+      } catch {}
       resolve(value);
     };
-    const timer = setTimeout(() => finish(false), Math.max(50, timeoutMs + 25));
+    const timer = setTimeout(
+      () => {
+        finish(false);
+      },
+      Math.max(50, timeoutMs + 25),
+    );
     let ws: WebSocket;
-    try { ws = new WebSocket(url); } catch { finish(false); return; }
-    ws.onopen = () => finish(true);
-    ws.onerror = () => finish(false);
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      finish(false);
+      return;
+    }
+    ws.onopen = () => {
+      finish(true);
+    };
+    ws.onerror = () => {
+      finish(false);
+    };
   });
 }
 
@@ -436,20 +531,25 @@ async function fetchChromeVersion(
   cdpUrl: string,
   timeoutMs = 500,
   authToken?: string,
-): Promise<Record<string, any> | null> {
+): Promise<Record<string, unknown> | null> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(() => {
+    ctrl.abort();
+  }, timeoutMs);
   try {
     const httpBase = isWebSocketUrl(cdpUrl) ? normalizeCdpHttpBaseForJsonEndpoints(cdpUrl) : cdpUrl;
     const headers: Record<string, string> = {};
-    if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+    if (authToken !== undefined && authToken !== '') headers.Authorization = `Bearer ${authToken}`;
     const res = await fetch(appendCdpPath(httpBase, '/json/version'), { signal: ctrl.signal, headers });
     if (!res.ok) return null;
-    const data = await res.json();
-    if (!data || typeof data !== 'object') return null;
-    return data as Record<string, any>;
-  } catch { return null; }
-  finally { clearTimeout(t); }
+    const data: unknown = await res.json();
+    if (data === null || data === undefined || typeof data !== 'object') return null;
+    return data as Record<string, unknown>;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
 }
 
 export async function isChromeReachable(cdpUrl: string, timeoutMs = 500, authToken?: string): Promise<boolean> {
@@ -458,17 +558,22 @@ export async function isChromeReachable(cdpUrl: string, timeoutMs = 500, authTok
   return Boolean(version);
 }
 
-export async function getChromeWebSocketUrl(cdpUrl: string, timeoutMs = 500, authToken?: string): Promise<string | null> {
+export async function getChromeWebSocketUrl(
+  cdpUrl: string,
+  timeoutMs = 500,
+  authToken?: string,
+): Promise<string | null> {
   if (isWebSocketUrl(cdpUrl)) return cdpUrl;
   const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken);
-  const wsUrl = String(version?.webSocketDebuggerUrl ?? '').trim();
-  if (!wsUrl) return null;
+  const rawWsUrl = version?.webSocketDebuggerUrl;
+  const wsUrl = typeof rawWsUrl === 'string' ? rawWsUrl.trim() : '';
+  if (wsUrl === '') return null;
   return normalizeCdpWsUrl(wsUrl, cdpUrl);
 }
 
 export async function isChromeCdpReady(cdpUrl: string, timeoutMs = 500, handshakeTimeoutMs = 800): Promise<boolean> {
   const wsUrl = await getChromeWebSocketUrl(cdpUrl, timeoutMs);
-  if (!wsUrl) return false;
+  if (wsUrl === null) return false;
   return await canRunCdpHealthCommand(wsUrl, handshakeTimeoutMs);
 }
 
@@ -479,11 +584,18 @@ async function canRunCdpHealthCommand(wsUrl: string, timeoutMs = 800): Promise<b
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      try { ws.close(); } catch {}
+      try {
+        ws.close();
+      } catch {}
       resolve(value);
     };
 
-    const timer = setTimeout(() => finish(false), Math.max(50, timeoutMs + 25));
+    const timer = setTimeout(
+      () => {
+        finish(false);
+      },
+      Math.max(50, timeoutMs + 25),
+    );
 
     let ws: WebSocket;
     try {
@@ -496,17 +608,27 @@ async function canRunCdpHealthCommand(wsUrl: string, timeoutMs = 800): Promise<b
     ws.onopen = () => {
       try {
         ws.send(JSON.stringify({ id: 1, method: 'Browser.getVersion' }));
-      } catch { finish(false); }
+      } catch {
+        finish(false);
+      }
     };
     ws.onmessage = (event) => {
       try {
-        const parsed = JSON.parse(String(event.data));
-        if (parsed?.id !== 1) return;
-        finish(Boolean(parsed.result && typeof parsed.result === 'object'));
-      } catch { /* ignore non-JSON frames */ }
+        const parsed: unknown = JSON.parse(String(event.data));
+        if (typeof parsed !== 'object' || parsed === null) return;
+        const msg = parsed as Record<string, unknown>;
+        if (msg.id !== 1) return;
+        finish(typeof msg.result === 'object' && msg.result !== null);
+      } catch {
+        /* ignore non-JSON frames */
+      }
     };
-    ws.onerror = () => finish(false);
-    ws.onclose = () => finish(false);
+    ws.onerror = () => {
+      finish(false);
+    };
+    ws.onclose = () => {
+      finish(false);
+    };
   });
 }
 
@@ -515,7 +637,8 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   await ensurePortAvailable(cdpPort);
 
   const exe = resolveBrowserExecutable({ executablePath: opts.executablePath });
-  if (!exe) throw new Error('No supported browser found (Chrome/Brave/Edge/Chromium). Install one or provide executablePath.');
+  if (!exe)
+    throw new Error('No supported browser found (Chrome/Brave/Edge/Chromium). Install one or provide executablePath.');
 
   const profileName = opts.profileName ?? DEFAULT_PROFILE_NAME;
   const userDataDir = opts.userDataDir ?? resolveUserDataDir(profileName);
@@ -523,7 +646,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 
   const spawnChrome = () => {
     const args = [
-      `--remote-debugging-port=${cdpPort}`,
+      `--remote-debugging-port=${String(cdpPort)}`,
       `--user-data-dir=${userDataDir}`,
       '--no-first-run',
       '--no-default-browser-check',
@@ -536,10 +659,10 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
       '--hide-crash-restore-bubble',
       '--password-store=basic',
     ];
-    if (opts.headless) {
+    if (opts.headless === true) {
       args.push('--headless=new', '--disable-gpu');
     }
-    if (opts.noSandbox) {
+    if (opts.noSandbox === true) {
       args.push('--no-sandbox', '--disable-setuid-sandbox');
     }
     if (process.platform === 'linux') args.push('--disable-dev-shm-usage');
@@ -564,16 +687,20 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     const deadline = Date.now() + 10000;
     while (Date.now() < deadline) {
       if (fileExists(localStatePath) && fileExists(preferencesPath)) break;
-      await new Promise(r => setTimeout(r, 100));
+      await new Promise((r) => setTimeout(r, 100));
     }
-    try { bootstrap.kill('SIGTERM'); } catch {}
+    try {
+      bootstrap.kill('SIGTERM');
+    } catch {}
     const exitDeadline = Date.now() + 5000;
     while (Date.now() < exitDeadline) {
       if (bootstrap.exitCode != null) break;
-      await new Promise(r => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 50));
     }
     if (bootstrap.exitCode == null) {
-      try { bootstrap.kill('SIGKILL'); } catch {}
+      try {
+        bootstrap.kill('SIGKILL');
+      } catch {}
     }
   }
 
@@ -581,32 +708,40 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     decorateProfile(userDataDir, profileName, opts.profileColor ?? DEFAULT_PROFILE_COLOR);
   } catch {}
 
-  try { ensureCleanExit(userDataDir); } catch {}
+  try {
+    ensureCleanExit(userDataDir);
+  } catch {}
 
   const proc = spawnChrome();
-  const cdpUrl = `http://127.0.0.1:${cdpPort}`;
+  const cdpUrl = `http://127.0.0.1:${String(cdpPort)}`;
 
   // Capture stderr for diagnostics on failure
   const stderrChunks: Buffer[] = [];
-  const onStderr = (chunk: Buffer) => { stderrChunks.push(chunk); };
-  proc.stderr?.on('data', onStderr);
+  const onStderr = (chunk: Buffer) => {
+    stderrChunks.push(chunk);
+  };
+  proc.stderr.on('data', onStderr);
 
   const readyDeadline = Date.now() + 15000;
   while (Date.now() < readyDeadline) {
     if (await isChromeReachable(cdpUrl, 500)) break;
-    await new Promise(r => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, 200));
   }
 
-  if (!await isChromeReachable(cdpUrl, 500)) {
+  if (!(await isChromeReachable(cdpUrl, 500))) {
     const stderrOutput = Buffer.concat(stderrChunks).toString('utf8').trim();
     const stderrHint = stderrOutput ? `\nChrome stderr:\n${stderrOutput.slice(0, 2000)}` : '';
-    const sandboxHint = process.platform === 'linux' && !opts.noSandbox
-      ? '\nHint: If running in a container or as root, try setting noSandbox: true.' : '';
-    try { proc.kill('SIGKILL'); } catch {}
-    throw new Error(`Failed to start Chrome CDP on port ${cdpPort}.${sandboxHint}${stderrHint}`);
+    const sandboxHint =
+      process.platform === 'linux' && opts.noSandbox !== true
+        ? '\nHint: If running in a container or as root, try setting noSandbox: true.'
+        : '';
+    try {
+      proc.kill('SIGKILL');
+    } catch {}
+    throw new Error(`Failed to start Chrome CDP on port ${String(cdpPort)}.${sandboxHint}${stderrHint}`);
   }
 
-  proc.stderr?.off('data', onStderr);
+  proc.stderr.off('data', onStderr);
   stderrChunks.length = 0;
 
   return {
@@ -621,12 +756,21 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 
 export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Promise<void> {
   const proc = running.proc;
-  if (proc.exitCode != null) return;
-  try { proc.kill('SIGTERM'); } catch {}
+  if (proc.exitCode !== null) return;
+  try {
+    proc.kill('SIGTERM');
+  } catch {
+    /* process may already be dead */
+  }
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (proc.exitCode != null) return;
-    await new Promise(r => setTimeout(r, 100));
+    // exitCode changes asynchronously after SIGTERM; re-read from proc
+    if ((proc as { exitCode: number | null }).exitCode !== null) return;
+    await new Promise((r) => setTimeout(r, 100));
   }
-  try { proc.kill('SIGKILL'); } catch {}
+  try {
+    proc.kill('SIGKILL');
+  } catch {
+    /* process may already be dead */
+  }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,8 +1,16 @@
-import { chromium } from 'playwright-core';
-import type { Browser, Page, BrowserContext, CDPSession } from 'playwright-core';
 import http from 'node:http';
 import https from 'node:https';
-import { getChromeWebSocketUrl, normalizeCdpHttpBaseForJsonEndpoints, normalizeCdpWsUrl, isLoopbackHost, hasProxyEnvConfigured } from './chrome-launcher.js';
+
+import { chromium } from 'playwright-core';
+import type { Browser, Page, BrowserContext, CDPSession } from 'playwright-core';
+
+import {
+  getChromeWebSocketUrl,
+  normalizeCdpHttpBaseForJsonEndpoints,
+  normalizeCdpWsUrl,
+  isLoopbackHost,
+  hasProxyEnvConfigured,
+} from './chrome-launcher.js';
 import type { PageState, ContextState, RoleRefs, NetworkRequest } from './types.js';
 
 // ── Errors ──
@@ -19,9 +27,11 @@ export type PageWithAI = Page & {
   _snapshotForAI?: (opts: { timeout: number; track: string }) => Promise<{ full?: string }>;
 };
 
-async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<any> {
+async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<unknown> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(() => {
+    ctrl.abort();
+  }, timeoutMs);
   try {
     const res = await fetch(url, { signal: ctrl.signal });
     if (!res.ok) return null;
@@ -53,7 +63,9 @@ export async function withPlaywrightPageCdpSession<T>(page: Page, fn: (session: 
   try {
     return await fn(session);
   } finally {
-    await session.detach().catch(() => {});
+    await session.detach().catch(() => {
+      /* noop */
+    });
   }
 }
 
@@ -64,10 +76,10 @@ export async function withPageScopedCdpClient<T>(opts: {
   cdpUrl: string;
   page: Page;
   targetId?: string;
-  fn: (send: (method: string, params?: Record<string, unknown>) => Promise<any>) => Promise<T>;
+  fn: (send: (method: string, params?: Record<string, unknown>) => Promise<unknown>) => Promise<T>;
 }): Promise<T> {
   return await withPlaywrightPageCdpSession(opts.page, async (session) => {
-    return await opts.fn((method, params) => session.send(method as any, params));
+    return await opts.fn((method, params) => session.send(method as Parameters<CDPSession['send']>[0], params));
   });
 }
 
@@ -76,7 +88,7 @@ export async function withPageScopedCdpClient<T>(opts: {
 const LOOPBACK_ENTRIES = 'localhost,127.0.0.1,[::1]';
 
 function noProxyAlreadyCoversLocalhost(): boolean {
-  const current = process.env.NO_PROXY || process.env.no_proxy || '';
+  const current = process.env.NO_PROXY ?? process.env.no_proxy ?? '';
   return current.includes('localhost') && current.includes('127.0.0.1') && current.includes('[::1]');
 }
 
@@ -97,7 +109,7 @@ class NoProxyLeaseManager {
     if (this.leaseCount === 0 && !noProxyAlreadyCoversLocalhost()) {
       const noProxy = process.env.NO_PROXY;
       const noProxyLower = process.env.no_proxy;
-      const current = noProxy || noProxyLower || '';
+      const current = noProxy ?? noProxyLower ?? '';
       const applied = current ? `${current},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
       process.env.NO_PROXY = applied;
       process.env.no_proxy = applied;
@@ -156,8 +168,7 @@ export function getDirectAgentForCdp(url: string): http.Agent | https.Agent | un
   try {
     const parsed = new URL(url);
     if (isLoopbackHost(parsed.hostname)) {
-      return parsed.protocol === 'https:' || parsed.protocol === 'wss:'
-        ? directHttpsAgent : directHttpAgent;
+      return parsed.protocol === 'https:' || parsed.protocol === 'wss:' ? directHttpsAgent : directHttpAgent;
     }
   } catch {}
   return undefined;
@@ -173,10 +184,12 @@ export function getHeadersWithAuth(endpoint: string, baseHeaders: Record<string,
   const headers = { ...baseHeaders };
   try {
     const parsed = new URL(endpoint);
-    if (Object.keys(headers).some(k => k.toLowerCase() === 'authorization')) return headers;
+    if (Object.keys(headers).some((k) => k.toLowerCase() === 'authorization')) return headers;
     if (parsed.username || parsed.password) {
-      const credentials = Buffer.from(`${decodeURIComponent(parsed.username)}:${decodeURIComponent(parsed.password)}`).toString('base64');
-      headers['Authorization'] = `Basic ${credentials}`;
+      const credentials = Buffer.from(
+        `${decodeURIComponent(parsed.username)}:${decodeURIComponent(parsed.password)}`,
+      ).toString('base64');
+      headers.Authorization = `Basic ${credentials}`;
     }
   } catch {}
   return headers;
@@ -228,11 +241,14 @@ export function ensureContextState(context: BrowserContext): ContextState {
 }
 
 // Ref cache: keyed by "cdpUrl::targetId"
-const roleRefsByTarget = new Map<string, {
-  refs: RoleRefs;
-  frameSelector?: string;
-  mode?: 'role' | 'aria';
-}>();
+const roleRefsByTarget = new Map<
+  string,
+  {
+    refs: RoleRefs;
+    frameSelector?: string;
+    mode?: 'role' | 'aria';
+  }
+>();
 const MAX_ROLE_REFS_CACHE = 50;
 
 const MAX_CONSOLE_MESSAGES = 500;
@@ -253,7 +269,7 @@ function roleRefsKey(cdpUrl: string, targetId: string): string {
 export function findNetworkRequestById(state: PageState, id: string): NetworkRequest | undefined {
   for (let i = state.requests.length - 1; i >= 0; i--) {
     const candidate = state.requests[i];
-    if (candidate && candidate.id === id) return candidate;
+    if (candidate.id === id) return candidate;
   }
   return undefined;
 }
@@ -289,9 +305,9 @@ export function ensurePageState(page: Page): PageState {
 
     page.on('pageerror', (err) => {
       state.errors.push({
-        message: err?.message ? String(err.message) : String(err),
-        name: err?.name ? String(err.name) : undefined,
-        stack: err?.stack ? String(err.stack) : undefined,
+        message: err.message !== '' ? err.message : String(err),
+        name: err.name !== '' ? err.name : undefined,
+        stack: err.stack !== undefined && err.stack !== '' ? err.stack : undefined,
         timestamp: new Date().toISOString(),
       });
       if (state.errors.length > MAX_PAGE_ERRORS) state.errors.shift();
@@ -299,7 +315,7 @@ export function ensurePageState(page: Page): PageState {
 
     page.on('request', (req) => {
       state.nextRequestId += 1;
-      const id = `r${state.nextRequestId}`;
+      const id = `r${String(state.nextRequestId)}`;
       state.requestIds.set(req, id);
       state.requests.push({
         id,
@@ -314,7 +330,7 @@ export function ensurePageState(page: Page): PageState {
     page.on('response', (resp) => {
       const req = resp.request();
       const id = state.requestIds.get(req);
-      if (!id) return;
+      if (id === undefined) return;
       const rec = findNetworkRequestById(state, id);
       if (rec) {
         rec.status = resp.status();
@@ -324,7 +340,7 @@ export function ensurePageState(page: Page): PageState {
 
     page.on('requestfailed', (req) => {
       const id = state.requestIds.get(req);
-      if (!id) return;
+      if (id === undefined) return;
       const rec = findNetworkRequestById(state, id);
       if (rec) {
         rec.failureText = req.failure()?.errorText;
@@ -346,8 +362,9 @@ export function ensurePageState(page: Page): PageState {
 const STEALTH_SCRIPT = `Object.defineProperty(navigator, 'webdriver', { get: () => undefined })`;
 
 function applyStealthToPage(page: Page): void {
-  page.evaluate(STEALTH_SCRIPT).catch((e) => {
-    if (process.env.DEBUG) console.warn('[browserclaw] stealth evaluate failed:', e.message);
+  page.evaluate(STEALTH_SCRIPT).catch((e: unknown) => {
+    if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
+      console.warn('[browserclaw] stealth evaluate failed:', e instanceof Error ? e.message : String(e));
   });
 }
 
@@ -356,8 +373,9 @@ function observeContext(context: BrowserContext): void {
   observedContexts.add(context);
   ensureContextState(context);
 
-  context.addInitScript(STEALTH_SCRIPT).catch((e) => {
-    if (process.env.DEBUG) console.warn('[browserclaw] stealth initScript failed:', e.message);
+  context.addInitScript(STEALTH_SCRIPT).catch((e: unknown) => {
+    if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
+      console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
   });
 
   for (const page of context.pages()) {
@@ -388,15 +406,15 @@ export function rememberRoleRefsForTarget(opts: {
   mode?: 'role' | 'aria';
 }): void {
   const targetId = opts.targetId.trim();
-  if (!targetId) return;
+  if (targetId === '') return;
   roleRefsByTarget.set(roleRefsKey(opts.cdpUrl, targetId), {
     refs: opts.refs,
-    ...(opts.frameSelector ? { frameSelector: opts.frameSelector } : {}),
-    ...(opts.mode ? { mode: opts.mode } : {}),
+    ...(opts.frameSelector !== undefined && opts.frameSelector !== '' ? { frameSelector: opts.frameSelector } : {}),
+    ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
   });
   while (roleRefsByTarget.size > MAX_ROLE_REFS_CACHE) {
     const first = roleRefsByTarget.keys().next();
-    if (first.done) break;
+    if (first.done === true) break;
     roleRefsByTarget.delete(first.value);
   }
 }
@@ -414,7 +432,7 @@ export function storeRoleRefsForTarget(opts: {
   state.roleRefsFrameSelector = opts.frameSelector;
   state.roleRefsMode = opts.mode;
 
-  if (!opts.targetId?.trim()) return;
+  if (opts.targetId === undefined || opts.targetId.trim() === '') return;
   rememberRoleRefsForTarget({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
@@ -424,13 +442,9 @@ export function storeRoleRefsForTarget(opts: {
   });
 }
 
-export function restoreRoleRefsForTarget(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  page: Page;
-}): void {
-  const targetId = opts.targetId?.trim() || '';
-  if (!targetId) return;
+export function restoreRoleRefsForTarget(opts: { cdpUrl: string; targetId?: string; page: Page }): void {
+  const targetId = opts.targetId?.trim() ?? '';
+  if (targetId === '') return;
   const entry = roleRefsByTarget.get(roleRefsKey(opts.cdpUrl, targetId));
   if (!entry) return;
   const state = ensurePageState(opts.page);
@@ -455,10 +469,13 @@ export async function connectBrowser(cdpUrl: string, authToken?: string): Promis
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         const timeout = 5000 + attempt * 2000;
-        const endpoint = await getChromeWebSocketUrl(normalized, timeout, authToken).catch(() => null) ?? normalized;
+        const endpoint = (await getChromeWebSocketUrl(normalized, timeout, authToken).catch(() => null)) ?? normalized;
         const headers: Record<string, string> = getHeadersWithAuth(endpoint);
-        if (authToken && !headers['Authorization']) headers['Authorization'] = `Bearer ${authToken}`;
-        const browser = await withNoProxyForCdpUrl(endpoint, () => chromium.connectOverCDP(endpoint, { timeout, headers }));
+        if (authToken !== undefined && authToken !== '' && !headers.Authorization)
+          headers.Authorization = `Bearer ${authToken}`;
+        const browser = await withNoProxyForCdpUrl(endpoint, () =>
+          chromium.connectOverCDP(endpoint, { timeout, headers }),
+        );
         const onDisconnected = () => {
           if (cachedByCdpUrl.get(normalized)?.browser === browser) {
             cachedByCdpUrl.delete(normalized);
@@ -475,13 +492,15 @@ export async function connectBrowser(cdpUrl: string, authToken?: string): Promis
       } catch (err) {
         lastErr = err;
         if ((err instanceof Error ? err.message : String(err)).includes('rate limit')) break;
-        await new Promise(r => setTimeout(r, 250 + attempt * 250));
+        await new Promise((r) => setTimeout(r, 250 + attempt * 250));
       }
     }
     throw lastErr instanceof Error ? lastErr : new Error('CDP connect failed');
   };
 
-  const promise = connectWithRetry().finally(() => { connectingByCdpUrl.delete(normalized); });
+  const promise = connectWithRetry().finally(() => {
+    connectingByCdpUrl.delete(normalized);
+  });
   connectingByCdpUrl.set(normalized, promise);
   return await promise;
 }
@@ -489,11 +508,15 @@ export async function connectBrowser(cdpUrl: string, authToken?: string): Promis
 export async function disconnectBrowser(): Promise<void> {
   if (connectingByCdpUrl.size) {
     for (const p of connectingByCdpUrl.values()) {
-      try { await p; } catch {}
+      try {
+        await p;
+      } catch {}
     }
   }
   for (const cur of cachedByCdpUrl.values()) {
-    await cur.browser.close().catch(() => {});
+    await cur.browser.close().catch(() => {
+      /* noop */
+    });
   }
   cachedByCdpUrl.clear();
 }
@@ -502,12 +525,15 @@ export async function disconnectBrowser(): Promise<void> {
  * Close the Playwright connection for a specific CDP URL without affecting other connections.
  */
 export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string }): Promise<void> {
-  if (opts?.cdpUrl) {
+  if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
     const normalized = normalizeCdpUrl(opts.cdpUrl);
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
-    if (cur) await cur.browser.close().catch(() => {});
+    if (cur)
+      await cur.browser.close().catch(() => {
+        /* noop */
+      });
   } else {
     await disconnectBrowser();
   }
@@ -516,7 +542,9 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
 function cdpSocketNeedsAttach(wsUrl: string): boolean {
   try {
     const pathname = new URL(wsUrl).pathname;
-    return pathname === '/cdp' || pathname.endsWith('/cdp') || pathname.includes('/devtools/browser/') || pathname === '/';
+    return (
+      pathname === '/cdp' || pathname.endsWith('/cdp') || pathname.includes('/devtools/browser/') || pathname === '/'
+    );
   } catch {
     return false;
   }
@@ -530,30 +558,51 @@ function cdpSocketNeedsAttach(wsUrl: string): boolean {
 async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string): Promise<void> {
   const httpBase = normalizeCdpHttpBaseForJsonEndpoints(cdpUrl);
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), 2000);
-  let targets: any[];
+  const t = setTimeout(() => {
+    ctrl.abort();
+  }, 2000);
+  let targets: unknown;
   try {
     const res = await fetch(`${httpBase}/json/list`, { signal: ctrl.signal });
     if (!res.ok) return;
     targets = await res.json();
-  } catch { return; }
-  finally { clearTimeout(t); }
+  } catch {
+    return;
+  } finally {
+    clearTimeout(t);
+  }
 
   if (!Array.isArray(targets)) return;
-  const target = targets.find((entry: any) => String(entry?.id ?? '').trim() === targetId);
-  const wsUrlRaw = String(target?.webSocketDebuggerUrl ?? '').trim();
-  if (!wsUrlRaw) return;
+  const target = targets.find((entry: unknown) => {
+    const e = entry as { id?: string; webSocketDebuggerUrl?: string };
+    return (e.id ?? '').trim() === targetId;
+  }) as { id?: string; webSocketDebuggerUrl?: string } | undefined;
+  const wsUrlRaw = (target?.webSocketDebuggerUrl ?? '').trim();
+  if (wsUrlRaw === '') return;
 
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, httpBase);
   const needsAttach = cdpSocketNeedsAttach(wsUrl);
 
   await new Promise<void>((resolve) => {
     let done = false;
-    const finish = () => { if (done) return; done = true; clearTimeout(timer); try { ws.close(); } catch {} resolve(); };
+    const finish = () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {}
+      resolve();
+    };
     const timer = setTimeout(finish, 3000);
     let ws: WebSocket;
     let nextId = 1;
-    try { ws = new WebSocket(wsUrl); } catch { finish(); return; }
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch {
+      finish();
+      return;
+    }
     ws.onopen = () => {
       if (needsAttach) {
         ws.send(JSON.stringify({ id: nextId++, method: 'Target.attachToTarget', params: { targetId, flatten: true } }));
@@ -565,16 +614,34 @@ async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string): Pr
     ws.onmessage = (event) => {
       if (!needsAttach) return;
       try {
-        const msg = JSON.parse(String(event.data));
-        if (msg.id && msg.result?.sessionId) {
-          ws.send(JSON.stringify({ id: nextId++, sessionId: msg.result.sessionId, method: 'Runtime.terminateExecution' }));
-          try { ws.send(JSON.stringify({ id: nextId++, method: 'Target.detachFromTarget', params: { sessionId: msg.result.sessionId } })); } catch {}
+        const msg = JSON.parse(String(event.data)) as Record<string, unknown>;
+        const result = msg.result as Record<string, unknown> | undefined;
+        if (msg.id !== undefined && result?.sessionId !== undefined) {
+          const sessionId = result.sessionId as string;
+          ws.send(JSON.stringify({ id: nextId++, sessionId, method: 'Runtime.terminateExecution' }));
+          try {
+            ws.send(
+              JSON.stringify({
+                id: nextId++,
+                method: 'Target.detachFromTarget',
+                params: { sessionId },
+              }),
+            );
+          } catch {
+            /* noop */
+          }
           setTimeout(finish, 300);
         }
-      } catch {}
+      } catch {
+        /* noop */
+      }
     };
-    ws.onerror = () => finish();
-    ws.onclose = () => finish();
+    ws.onerror = () => {
+      finish();
+    };
+    ws.onclose = () => {
+      finish();
+    };
   });
 }
 
@@ -599,12 +666,16 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
     cur.browser.off('disconnected', cur.onDisconnected);
   }
 
-  const targetId = opts.targetId?.trim() || '';
-  if (targetId) {
-    await tryTerminateExecutionViaCdp(normalized, targetId).catch(() => {});
+  const targetId = opts.targetId?.trim() ?? '';
+  if (targetId !== '') {
+    await tryTerminateExecutionViaCdp(normalized, targetId).catch(() => {
+      /* noop */
+    });
   }
 
-  cur.browser.close().catch(() => {});
+  cur.browser.close().catch(() => {
+    /* noop */
+  });
 }
 
 // ── Page Lookup ──
@@ -618,8 +689,8 @@ interface CdpTarget {
   webSocketDebuggerUrl?: string;
 }
 
-export async function getAllPages(browser: Browser) {
-  return browser.contexts().flatMap(c => c.pages());
+export function getAllPages(browser: Browser) {
+  return browser.contexts().flatMap((c) => c.pages());
 }
 
 export async function pageTargetId(page: Page): Promise<string | null> {
@@ -627,9 +698,11 @@ export async function pageTargetId(page: Page): Promise<string | null> {
   try {
     const info = await session.send('Target.getTargetInfo');
     const targetInfo = (info as { targetInfo?: { targetId?: string } }).targetInfo;
-    return String(targetInfo?.targetId ?? '').trim() || null;
+    return (targetInfo?.targetId ?? '').trim() || null;
   } finally {
-    await session.detach().catch(() => {});
+    await session.detach().catch(() => {
+      /* noop */
+    });
   }
 }
 
@@ -649,13 +722,16 @@ function matchPageByTargetList(pages: Page[], targets: CdpTarget[], targetId: st
 }
 
 async function findPageByTargetIdViaTargetList(pages: Page[], targetId: string, cdpUrl: string): Promise<Page | null> {
-  const targets = await fetchJsonForCdp(appendCdpPath(normalizeCdpHttpBaseForJsonEndpoints(cdpUrl), '/json/list'), 2000);
+  const targets = await fetchJsonForCdp(
+    appendCdpPath(normalizeCdpHttpBaseForJsonEndpoints(cdpUrl), '/json/list'),
+    2000,
+  );
   if (!Array.isArray(targets)) return null;
-  return matchPageByTargetList(pages, targets, targetId);
+  return matchPageByTargetList(pages, targets as CdpTarget[], targetId);
 }
 
 export async function findPageByTargetId(browser: Browser, targetId: string, cdpUrl?: string) {
-  const pages = await getAllPages(browser);
+  const pages = getAllPages(browser);
 
   let resolvedViaCdp = false;
   for (const page of pages) {
@@ -666,10 +742,10 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
     } catch {
       tid = null;
     }
-    if (tid && tid === targetId) return page;
+    if (tid !== null && tid !== '' && tid === targetId) return page;
   }
 
-  if (cdpUrl) {
+  if (cdpUrl !== undefined && cdpUrl !== '') {
     try {
       return await findPageByTargetIdViaTargetList(pages, targetId, cdpUrl);
     } catch {}
@@ -682,14 +758,16 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
 
 export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string }) {
   const { browser } = await connectBrowser(opts.cdpUrl);
-  const pages = await getAllPages(browser);
+  const pages = getAllPages(browser);
   if (!pages.length) throw new Error('No pages available in the connected browser.');
-  const first = pages[0]!;
-  if (!opts.targetId) return first;
+  const first = pages[0];
+  if (opts.targetId === undefined || opts.targetId === '') return first;
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
     if (pages.length === 1) return first;
-    throw new BrowserTabNotFoundError(`Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`);
+    throw new BrowserTabNotFoundError(
+      `Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`,
+    );
   }
   return found;
 }
@@ -713,7 +791,11 @@ export async function resolvePageByTargetIdOrThrow(opts: { cdpUrl: string; targe
 export function parseRoleRef(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) return null;
-  const normalized = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed.startsWith('ref=') ? trimmed.slice(4) : trimmed;
+  const normalized = trimmed.startsWith('@')
+    ? trimmed.slice(1)
+    : trimmed.startsWith('ref=')
+      ? trimmed.slice(4)
+      : trimmed;
   return /^e\d+$/.test(normalized) ? normalized : null;
 }
 
@@ -748,7 +830,7 @@ export function resolveInteractionTimeoutMs(timeoutMs?: number): number {
 export function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
   const normalized = Math.floor(value ?? 0);
   if (!Number.isFinite(normalized) || normalized < 0) throw new Error(`${label} must be >= 0`);
-  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${maxMs}ms`);
+  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${String(maxMs)}ms`);
   return normalized;
 }
 
@@ -766,28 +848,33 @@ export async function getRestoredPageForTarget(opts: { cdpUrl: string; targetId?
 
 export function refLocator(page: Page, ref: string) {
   const normalized = ref.startsWith('@') ? ref.slice(1) : ref.startsWith('ref=') ? ref.slice(4) : ref;
-  if (!normalized.trim()) throw new Error('ref is required');
+  if (normalized.trim() === '') throw new Error('ref is required');
 
   if (/^e\d+$/.test(normalized)) {
     const state = pageStates.get(page);
 
     // Aria mode: use aria-ref locator
     if (state?.roleRefsMode === 'aria') {
-      return (state.roleRefsFrameSelector ? page.frameLocator(state.roleRefsFrameSelector) : page)
-        .locator(`aria-ref=${normalized}`);
+      return (
+        state.roleRefsFrameSelector !== undefined && state.roleRefsFrameSelector !== ''
+          ? page.frameLocator(state.roleRefsFrameSelector)
+          : page
+      ).locator(`aria-ref=${normalized}`);
     }
 
     // Role mode: use getByRole
     const info = state?.roleRefs?.[normalized];
     if (!info) throw new Error(`Unknown ref "${normalized}". Run a new snapshot and use a ref from that snapshot.`);
 
-    const locAny = state?.roleRefsFrameSelector
-      ? page.frameLocator(state.roleRefsFrameSelector)
-      : page;
+    const locAny =
+      state.roleRefsFrameSelector !== undefined && state.roleRefsFrameSelector !== ''
+        ? page.frameLocator(state.roleRefsFrameSelector)
+        : page;
     const role = info.role as Parameters<Page['getByRole']>[0];
-    const locator = info.name
-      ? locAny.getByRole(role, { name: info.name, exact: true })
-      : locAny.getByRole(role);
+    const locator =
+      info.name !== undefined && info.name !== ''
+        ? locAny.getByRole(role, { name: info.name, exact: true })
+        : locAny.getByRole(role);
     return info.nth !== undefined ? locator.nth(info.nth) : locator;
   }
 
@@ -799,16 +886,28 @@ export function refLocator(page: Page, ref: string) {
 export function toAIFriendlyError(error: unknown, selector: string): Error {
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes('strict mode violation')) {
-    const countMatch = message.match(/resolved to (\d+) elements/);
+    const countMatch = /resolved to (\d+) elements/.exec(message);
     const count = countMatch ? countMatch[1] : 'multiple';
-    return new Error(`Selector "${selector}" matched ${count} elements. Run a new snapshot to get updated refs, or use a different ref.`);
+    return new Error(
+      `Selector "${selector}" matched ${count} elements. Run a new snapshot to get updated refs, or use a different ref.`,
+    );
   }
-  if ((message.includes('Timeout') || message.includes('waiting for')) &&
-      (message.includes('to be visible') || message.includes('not visible'))) {
-    return new Error(`Element "${selector}" not found or not visible. Run a new snapshot to see current page elements.`);
+  if (
+    (message.includes('Timeout') || message.includes('waiting for')) &&
+    (message.includes('to be visible') || message.includes('not visible'))
+  ) {
+    return new Error(
+      `Element "${selector}" not found or not visible. Run a new snapshot to see current page elements.`,
+    );
   }
-  if (message.includes('intercepts pointer events') || message.includes('not visible') || message.includes('not receive pointer events')) {
-    return new Error(`Element "${selector}" is not interactable (hidden or covered). Try scrolling it into view, closing overlays, or re-snapshotting.`);
+  if (
+    message.includes('intercepts pointer events') ||
+    message.includes('not visible') ||
+    message.includes('not receive pointer events')
+  ) {
+    return new Error(
+      `Element "${selector}" is not interactable (hidden or covered). Try scrolling it into view, closing overlays, or re-snapshotting.`,
+    );
   }
   return error instanceof Error ? error : new Error(message);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { BrowserClaw, CrawlPage } from './browser.js';
-export { isChromeCdpReady, isChromeReachable, getChromeWebSocketUrl, normalizeCdpHttpBaseForJsonEndpoints } from './chrome-launcher.js';
+export {
+  isChromeCdpReady,
+  isChromeReachable,
+  getChromeWebSocketUrl,
+  normalizeCdpHttpBaseForJsonEndpoints,
+} from './chrome-launcher.js';
 export {
   InvalidBrowserNavigationUrlError,
   withBrowserNavigationPolicy,

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,9 +1,11 @@
-import { resolve, normalize, dirname, basename, join, sep, relative, posix, win32 } from 'node:path';
-import { lookup as dnsLookup } from 'node:dns/promises';
-import { lookup as dnsLookupCb } from 'node:dns';
-import { lstat, realpath, rename, rm } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
+import { lookup as dnsLookupCb } from 'node:dns';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { lstat, realpath, rename, rm } from 'node:fs/promises';
+import { resolve, normalize, dirname, basename, join, sep, relative, posix, win32 } from 'node:path';
+
 import * as ipaddr from 'ipaddr.js';
+
 import type { SsrfPolicy, PinnedHostname } from './types.js';
 
 export type LookupFn = typeof dnsLookup;
@@ -21,15 +23,15 @@ export class InvalidBrowserNavigationUrlError extends Error {
 }
 
 /** Options for browser navigation SSRF policy. */
-export type BrowserNavigationPolicyOptions = {
+export interface BrowserNavigationPolicyOptions {
   ssrfPolicy?: SsrfPolicy;
-};
+}
 
 /** Playwright-compatible request interface for redirect chain inspection. */
-export type BrowserNavigationRequestLike = {
+export interface BrowserNavigationRequestLike {
   url(): string;
   redirectedFrom(): BrowserNavigationRequestLike | null;
-};
+}
 
 /** Build a BrowserNavigationPolicyOptions from an SsrfPolicy. */
 export function withBrowserNavigationPolicy(ssrfPolicy?: SsrfPolicy): BrowserNavigationPolicyOptions {
@@ -42,17 +44,14 @@ const SAFE_NON_NETWORK_URLS = new Set(['about:blank']);
 
 const PROXY_ENV_KEYS = ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy'];
 
-const BLOCKED_HOSTNAMES = new Set([
-  'localhost',
-  'localhost.localdomain',
-  'metadata.google.internal',
-]);
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'localhost.localdomain', 'metadata.google.internal']);
 
 function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
   return SAFE_NON_NETWORK_URLS.has(parsed.href);
 }
 
 function isPrivateNetworkAllowedByPolicy(policy?: SsrfPolicy): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return policy?.dangerouslyAllowPrivateNetwork === true || policy?.allowPrivateNetwork === true;
 }
 
@@ -67,7 +66,7 @@ function hasProxyEnvConfigured(env: Record<string, string | undefined> = process
 // ── Hostname normalization & blocking ──
 
 function normalizeHostname(hostname: string): string {
-  let h = String(hostname ?? '').trim().toLowerCase();
+  let h = hostname.trim().toLowerCase();
   if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1);
   // Strip trailing dot (FQDN)
   if (h.endsWith('.')) h = h.slice(0, -1);
@@ -82,17 +81,23 @@ function isBlockedHostnameNormalized(normalized: string): boolean {
 // ── IP address checking via ipaddr.js ──
 
 const BLOCKED_IPV4_RANGES = new Set([
-  'unspecified', 'broadcast', 'multicast', 'linkLocal',
-  'loopback', 'carrierGradeNat', 'private', 'reserved',
+  'unspecified',
+  'broadcast',
+  'multicast',
+  'linkLocal',
+  'loopback',
+  'carrierGradeNat',
+  'private',
+  'reserved',
 ]);
 
-const BLOCKED_IPV6_RANGES = new Set([
-  'unspecified', 'loopback', 'linkLocal', 'uniqueLocal', 'multicast',
-]);
+const BLOCKED_IPV6_RANGES = new Set(['unspecified', 'loopback', 'linkLocal', 'uniqueLocal', 'multicast']);
 
 const RFC2544_BENCHMARK_PREFIX: [ipaddr.IPv4, number] = [ipaddr.IPv4.parse('198.18.0.0'), 15];
 
-type IsPrivateIpOpts = { allowRfc2544BenchmarkRange?: boolean };
+interface IsPrivateIpOpts {
+  allowRfc2544BenchmarkRange?: boolean;
+}
 
 const EMBEDDED_IPV4_SENTINEL_RULES: {
   matches: (parts: number[]) => boolean;
@@ -100,12 +105,14 @@ const EMBEDDED_IPV4_SENTINEL_RULES: {
 }[] = [
   // IPv4-compatible (::a.b.c.d)
   {
-    matches: (parts) => parts[0] === 0 && parts[1] === 0 && parts[2] === 0 && parts[3] === 0 && parts[4] === 0 && parts[5] === 0,
+    matches: (parts) =>
+      parts[0] === 0 && parts[1] === 0 && parts[2] === 0 && parts[3] === 0 && parts[4] === 0 && parts[5] === 0,
     toHextets: (parts) => [parts[6], parts[7]],
   },
   // NAT64 local-use (64:ff9b:1::/48)
   {
-    matches: (parts) => parts[0] === 100 && parts[1] === 65435 && parts[2] === 1 && parts[3] === 0 && parts[4] === 0 && parts[5] === 0,
+    matches: (parts) =>
+      parts[0] === 100 && parts[1] === 65435 && parts[2] === 1 && parts[3] === 0 && parts[4] === 0 && parts[5] === 0,
     toHextets: (parts) => [parts[6], parts[7]],
   },
   // 6to4 (2002::/16)
@@ -148,13 +155,13 @@ function parseIpv6WithEmbeddedIpv4(raw: string): ipaddr.IPv6 | undefined {
 
 function normalizeIpParseInput(raw: string | undefined | null): string | undefined {
   const trimmed = raw?.trim();
-  if (!trimmed) return;
+  if (trimmed === undefined || trimmed === '') return;
   return stripIpv6Brackets(trimmed);
 }
 
 function parseCanonicalIpAddress(raw: string): ipaddr.IPv4 | ipaddr.IPv6 | undefined {
   const normalized = normalizeIpParseInput(raw);
-  if (!normalized) return;
+  if (normalized === undefined) return;
   if (ipaddr.IPv4.isValid(normalized)) {
     if (!ipaddr.IPv4.isValidFourPartDecimal(normalized)) return;
     return ipaddr.IPv4.parse(normalized);
@@ -165,22 +172,22 @@ function parseCanonicalIpAddress(raw: string): ipaddr.IPv4 | ipaddr.IPv6 | undef
 
 function parseLooseIpAddress(raw: string): ipaddr.IPv4 | ipaddr.IPv6 | undefined {
   const normalized = normalizeIpParseInput(raw);
-  if (!normalized) return;
+  if (normalized === undefined) return;
   if (ipaddr.isValid(normalized)) return ipaddr.parse(normalized);
   return parseIpv6WithEmbeddedIpv4(normalized);
 }
 
 function isCanonicalDottedDecimalIPv4(raw: string): boolean {
-  const trimmed = raw?.trim();
-  if (!trimmed) return false;
+  const trimmed = raw.trim();
+  if (trimmed === '') return false;
   const normalized = stripIpv6Brackets(trimmed);
   if (!normalized) return false;
   return ipaddr.IPv4.isValidFourPartDecimal(normalized);
 }
 
 function isLegacyIpv4Literal(raw: string): boolean {
-  const trimmed = raw?.trim();
-  if (!trimmed) return false;
+  const trimmed = raw.trim();
+  if (trimmed === '') return false;
   const normalized = stripIpv6Brackets(trimmed);
   if (!normalized || normalized.includes(':')) return false;
   if (isCanonicalDottedDecimalIPv4(normalized)) return false;
@@ -198,13 +205,6 @@ function looksLikeUnsupportedIpv4Literal(address: string): boolean {
   return parts.every((part) => /^[0-9]+$/.test(part) || /^0x/i.test(part));
 }
 
-function normalizeIpv4MappedAddress(address: ipaddr.IPv4 | ipaddr.IPv6): ipaddr.IPv4 | ipaddr.IPv6 {
-  if (address.kind() !== 'ipv6') return address;
-  const v6 = address as ipaddr.IPv6;
-  if (!v6.isIPv4MappedAddress()) return address;
-  return v6.toIPv4Address();
-}
-
 function isBlockedSpecialUseIpv4Address(address: ipaddr.IPv4, opts?: IsPrivateIpOpts): boolean {
   const inRfc2544 = address.match(RFC2544_BENCHMARK_PREFIX);
   if (inRfc2544 && opts?.allowRfc2544BenchmarkRange === true) return false;
@@ -217,12 +217,7 @@ function isBlockedSpecialUseIpv6Address(address: ipaddr.IPv6): boolean {
 }
 
 function decodeIpv4FromHextets(high: number, low: number): ipaddr.IPv4 {
-  const octets = [
-    (high >>> 8) & 0xff,
-    high & 0xff,
-    (low >>> 8) & 0xff,
-    low & 0xff,
-  ];
+  const octets = [(high >>> 8) & 0xff, high & 0xff, (low >>> 8) & 0xff, low & 0xff];
   return ipaddr.IPv4.parse(octets.join('.'));
 }
 
@@ -301,11 +296,7 @@ function normalizeHostnameSet(values?: string[]): Set<string> {
 function normalizeHostnameAllowlist(values?: string[]): string[] {
   if (!values || values.length === 0) return [];
   return Array.from(
-    new Set(
-      values
-        .map((v) => normalizeHostname(v))
-        .filter((v) => v !== '*' && v !== '*.' && v.length > 0)
-    )
+    new Set(values.map((v) => normalizeHostname(v)).filter((v) => v !== '*' && v !== '*.' && v.length > 0)),
   );
 }
 
@@ -351,28 +342,39 @@ export function createPinnedLookup(params: {
   const fallback = params.fallback ?? dnsLookupCb;
   const records = params.addresses.map((address) => ({
     address,
-    family: address.includes(':') ? 6 as const : 4 as const,
+    family: address.includes(':') ? (6 as const) : (4 as const),
   }));
   let index = 0;
 
-  return ((host: string, options: any, callback?: any) => {
-    const cb = typeof options === 'function' ? options : callback;
-    if (!cb) return;
+  // dns.lookup has complex overloads; we use a loosely-typed inner signature
+  // and cast the result back to the proper type at the boundary.
+  type DnsLookupArg = string | number | { all?: boolean; family?: number } | ((...a: unknown[]) => void) | undefined;
+  return ((_host: string, ...rest: DnsLookupArg[]) => {
+    const second = rest[0];
+    const third = rest[1];
+    const cb = typeof second === 'function' ? second : typeof third === 'function' ? third : undefined;
+    if (cb === undefined) return;
 
-    const normalized = normalizeHostname(host);
-    if (!normalized || normalized !== normalizedHost) {
-      if (typeof options === 'function' || options === undefined) return (fallback as any)(host, cb);
-      return (fallback as any)(host, options, cb);
+    const normalized = normalizeHostname(_host);
+    if (normalized === '' || normalized !== normalizedHost) {
+      if (typeof second === 'function' || second === undefined) {
+        (fallback as (...a: unknown[]) => void)(_host, cb);
+        return;
+      }
+      (fallback as (...a: unknown[]) => void)(_host, second, cb);
+      return;
     }
 
-    const opts = typeof options === 'object' && options !== null ? options : {};
-    const requestedFamily = typeof options === 'number' ? options : typeof opts.family === 'number' ? opts.family : 0;
-    const candidates = requestedFamily === 4 || requestedFamily === 6
-      ? records.filter((entry) => entry.family === requestedFamily)
-      : records;
+    const opts: { all?: boolean; family?: number } =
+      typeof second === 'object' ? (second as { all?: boolean; family?: number }) : {};
+    const requestedFamily = typeof second === 'number' ? second : typeof opts.family === 'number' ? opts.family : 0;
+    const candidates =
+      requestedFamily === 4 || requestedFamily === 6
+        ? records.filter((entry) => entry.family === requestedFamily)
+        : records;
     const usable = candidates.length > 0 ? candidates : records;
 
-    if (opts.all) {
+    if (opts.all === true) {
       cb(null, usable);
       return;
     }
@@ -386,10 +388,13 @@ export function createPinnedLookup(params: {
  * Resolve DNS for a hostname and validate resolved addresses against SSRF policy.
  * Returns a PinnedHostname with pre-resolved addresses and a pinned lookup function.
  */
-export async function resolvePinnedHostnameWithPolicy(hostname: string, params: {
-  lookupFn?: LookupFn;
-  policy?: SsrfPolicy;
-} = {}): Promise<PinnedHostname> {
+export async function resolvePinnedHostnameWithPolicy(
+  hostname: string,
+  params: {
+    lookupFn?: LookupFn;
+    policy?: SsrfPolicy;
+  } = {},
+): Promise<PinnedHostname> {
   const normalized = normalizeHostname(hostname);
   if (!normalized) throw new InvalidBrowserNavigationUrlError(`Invalid hostname: "${hostname}"`);
 
@@ -401,15 +406,13 @@ export async function resolvePinnedHostnameWithPolicy(hostname: string, params: 
 
   // hostnameAllowlist is a restriction: if specified, hostname must match a pattern
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
-    throw new InvalidBrowserNavigationUrlError(
-      `Navigation blocked: hostname "${hostname}" is not in the allowlist.`
-    );
+    throw new InvalidBrowserNavigationUrlError(`Navigation blocked: hostname "${hostname}" is not in the allowlist.`);
   }
 
   if (!skipPrivateNetworkChecks) {
     if (isBlockedHostnameOrIp(normalized, params.policy)) {
       throw new InvalidBrowserNavigationUrlError(
-        `Navigation to internal/loopback address blocked: "${hostname}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`
+        `Navigation to internal/loopback address blocked: "${hostname}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`,
       );
     }
   }
@@ -417,16 +420,16 @@ export async function resolvePinnedHostnameWithPolicy(hostname: string, params: 
   const lookupFn = params.lookupFn ?? dnsLookup;
   let results: { address: string; family: number }[];
   try {
-    results = await lookupFn(normalized, { all: true }) as unknown as { address: string; family: number }[];
+    results = (await lookupFn(normalized, { all: true })) as unknown as { address: string; family: number }[];
   } catch {
     throw new InvalidBrowserNavigationUrlError(
-      `Navigation to internal/loopback address blocked: unable to resolve "${hostname}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`
+      `Navigation to internal/loopback address blocked: unable to resolve "${hostname}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`,
     );
   }
 
-  if (!results || results.length === 0) {
+  if (results.length === 0) {
     throw new InvalidBrowserNavigationUrlError(
-      `Navigation to internal/loopback address blocked: unable to resolve "${hostname}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`
+      `Navigation to internal/loopback address blocked: unable to resolve "${hostname}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`,
     );
   }
 
@@ -434,7 +437,7 @@ export async function resolvePinnedHostnameWithPolicy(hostname: string, params: 
     for (const r of results) {
       if (isBlockedHostnameOrIp(r.address, params.policy)) {
         throw new InvalidBrowserNavigationUrlError(
-          `Navigation to internal/loopback address blocked: "${hostname}" resolves to "${r.address}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`
+          `Navigation to internal/loopback address blocked: "${hostname}" resolves to "${r.address}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`,
         );
       }
     }
@@ -443,7 +446,7 @@ export async function resolvePinnedHostnameWithPolicy(hostname: string, params: 
   const addresses = dedupeAndPreferIpv4(results);
   if (addresses.length === 0) {
     throw new InvalidBrowserNavigationUrlError(
-      `Navigation to internal/loopback address blocked: unable to resolve "${hostname}".`
+      `Navigation to internal/loopback address blocked: unable to resolve "${hostname}".`,
     );
   }
 
@@ -458,12 +461,14 @@ export async function resolvePinnedHostnameWithPolicy(hostname: string, params: 
  * Assert that a URL is allowed for browser navigation under the given SSRF policy.
  * Throws `InvalidBrowserNavigationUrlError` if the URL is blocked.
  */
-export async function assertBrowserNavigationAllowed(opts: {
-  url: string;
-  lookupFn?: LookupFn;
-} & BrowserNavigationPolicyOptions): Promise<void> {
-  const rawUrl = String(opts.url ?? '').trim();
-  if (!rawUrl) throw new InvalidBrowserNavigationUrlError('url is required');
+export async function assertBrowserNavigationAllowed(
+  opts: {
+    url: string;
+    lookupFn?: LookupFn;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
+  const rawUrl = opts.url.trim();
+  if (rawUrl === '') throw new InvalidBrowserNavigationUrlError('url is required');
 
   let parsed: URL;
   try {
@@ -481,7 +486,7 @@ export async function assertBrowserNavigationAllowed(opts: {
   // Fail closed when proxy env vars are set — SSRF checks cannot be reliably enforced
   if (hasProxyEnvConfigured() && !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy)) {
     throw new InvalidBrowserNavigationUrlError(
-      'Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set'
+      'Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set',
     );
   }
 
@@ -505,7 +510,7 @@ export async function assertSafeOutputPath(path: string, allowedRoots?: string[]
     throw new Error(`Unsafe output path: directory traversal detected in "${path}".`);
   }
 
-  if (allowedRoots?.length) {
+  if (allowedRoots !== undefined && allowedRoots.length > 0) {
     const resolved = resolve(normalized);
 
     let parentReal: string;
@@ -534,7 +539,7 @@ export async function assertSafeOutputPath(path: string, allowedRoots?: string[]
         } catch {
           return false;
         }
-      })
+      }),
     );
     if (!results.some(Boolean)) {
       throw new Error(`Unsafe output path: "${path}" is outside allowed directories.`);
@@ -584,8 +589,8 @@ export async function resolveStrictExistingUploadPaths(params: {
  * Sanitize an untrusted file name (e.g. from a download) to prevent path traversal.
  */
 export function sanitizeUntrustedFileName(fileName: string, fallbackName: string): string {
-  const trimmed = String(fileName ?? '').trim();
-  if (!trimmed) return fallbackName;
+  const trimmed = fileName.trim();
+  if (trimmed === '') return fallbackName;
 
   let base = posix.basename(trimmed);
   base = win32.basename(base);
@@ -645,7 +650,10 @@ export async function writeViaSiblingTempPath(params: {
     await rename(tempPath, targetPath);
     renameSucceeded = true;
   } finally {
-    if (!renameSucceeded) await rm(tempPath, { force: true }).catch(() => {});
+    if (!renameSucceeded)
+      await rm(tempPath, { force: true }).catch(() => {
+        /* noop */
+      });
   }
 }
 
@@ -656,12 +664,14 @@ function isAbsolute(p: string): boolean {
 /**
  * Best-effort post-navigation guard for the final page URL.
  */
-export async function assertBrowserNavigationResultAllowed(opts: {
-  url: string;
-  lookupFn?: LookupFn;
-} & BrowserNavigationPolicyOptions): Promise<void> {
-  const rawUrl = String(opts.url ?? '').trim();
-  if (!rawUrl) return;
+export async function assertBrowserNavigationResultAllowed(
+  opts: {
+    url: string;
+    lookupFn?: LookupFn;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
+  const rawUrl = opts.url.trim();
+  if (rawUrl === '') return;
 
   let parsed: URL;
   try {
@@ -678,10 +688,12 @@ export async function assertBrowserNavigationResultAllowed(opts: {
 /**
  * Walk the full redirect chain and validate each hop against the SSRF policy.
  */
-export async function assertBrowserNavigationRedirectChainAllowed(opts: {
-  request?: BrowserNavigationRequestLike | null;
-  lookupFn?: LookupFn;
-} & BrowserNavigationPolicyOptions): Promise<void> {
+export async function assertBrowserNavigationRedirectChainAllowed(
+  opts: {
+    request?: BrowserNavigationRequestLike | null;
+    lookupFn?: LookupFn;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
   const chain: string[] = [];
   let current = opts.request ?? null;
   while (current) {

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -1,7 +1,8 @@
 import { getPageForTargetId, ensurePageState, storeRoleRefsForTarget, normalizeTimeoutMs } from '../connection.js';
 import type { PageWithAI } from '../connection.js';
-import { buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
 import type { SnapshotResult, SnapshotOptions } from '../types.js';
+
+import { buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
 
 /**
  * Take an AI-readable snapshot using Playwright's _snapshotForAI.
@@ -29,13 +30,13 @@ export async function snapshotAi(opts: {
     track: 'response',
   });
 
-  let snapshot = String(result?.full ?? '');
+  let snapshot = String(result.full);
   const maxChars = opts.maxChars;
-  const limit = typeof maxChars === 'number' && Number.isFinite(maxChars) && maxChars > 0
-    ? Math.floor(maxChars) : undefined;
+  const limit =
+    typeof maxChars === 'number' && Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : undefined;
 
   let truncated = false;
-  if (limit && snapshot.length > limit) {
+  if (limit !== undefined && snapshot.length > limit) {
     const lastNewline = snapshot.lastIndexOf('\n', limit);
     const cutoff = lastNewline > 0 ? lastNewline : limit;
     snapshot = `${snapshot.slice(0, cutoff)}\n\n[...TRUNCATED - page too large]`;

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -1,11 +1,14 @@
-import { getPageForTargetId, ensurePageState, storeRoleRefsForTarget, normalizeTimeoutMs, withPlaywrightPageCdpSession } from '../connection.js';
-import type { PageWithAI } from '../connection.js';
 import {
-  buildRoleSnapshotFromAriaSnapshot,
-  buildRoleSnapshotFromAiSnapshot,
-  getRoleSnapshotStats,
-} from './ref-map.js';
+  getPageForTargetId,
+  ensurePageState,
+  storeRoleRefsForTarget,
+  normalizeTimeoutMs,
+  withPlaywrightPageCdpSession,
+} from '../connection.js';
+import type { PageWithAI } from '../connection.js';
 import type { SnapshotResult, AriaSnapshotResult, AriaNode } from '../types.js';
+
+import { buildRoleSnapshotFromAriaSnapshot, buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
 
 /**
  * Take a role-based snapshot using Playwright's ariaSnapshot().
@@ -34,7 +37,10 @@ export async function snapshotRole(opts: {
 
   // refs=aria sub-path: use _snapshotForAI instead of ariaSnapshot
   if (opts.refsMode === 'aria') {
-    if (opts.selector?.trim() || opts.frameSelector?.trim()) {
+    if (
+      (opts.selector !== undefined && opts.selector.trim() !== '') ||
+      (opts.frameSelector !== undefined && opts.frameSelector.trim() !== '')
+    ) {
       throw new Error('refs=aria does not support selector/frame snapshots yet.');
     }
     const maybe = page as PageWithAI;
@@ -42,7 +48,7 @@ export async function snapshotRole(opts: {
       throw new Error('refs=aria requires Playwright _snapshotForAI support.');
     }
     const result = await maybe._snapshotForAI({ timeout: 5000, track: 'response' });
-    const built = buildRoleSnapshotFromAiSnapshot(String(result?.full ?? ''), opts.options);
+    const built = buildRoleSnapshotFromAiSnapshot(String(result.full), opts.options);
 
     storeRoleRefsForTarget({
       page,
@@ -65,25 +71,25 @@ export async function snapshotRole(opts: {
     };
   }
 
-  const frameSelector = opts.frameSelector?.trim() || '';
-  const selector = opts.selector?.trim() || '';
+  const frameSelector = opts.frameSelector?.trim() ?? '';
+  const selector = opts.selector?.trim() ?? '';
   const locator = frameSelector
-    ? (selector
+    ? selector
       ? page.frameLocator(frameSelector).locator(selector)
-      : page.frameLocator(frameSelector).locator(':root'))
-    : (selector
+      : page.frameLocator(frameSelector).locator(':root')
+    : selector
       ? page.locator(selector)
-      : page.locator(':root'));
+      : page.locator(':root');
 
   const ariaSnapshot = await locator.ariaSnapshot({ timeout: normalizeTimeoutMs(opts.timeoutMs, 5000) });
-  const built = buildRoleSnapshotFromAriaSnapshot(String(ariaSnapshot ?? ''), opts.options);
+  const built = buildRoleSnapshotFromAriaSnapshot(ariaSnapshot, opts.options);
 
   storeRoleRefsForTarget({
     page,
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
     refs: built.refs,
-    frameSelector: frameSelector || undefined,
+    frameSelector: frameSelector !== '' ? frameSelector : undefined,
     mode: 'role',
   });
 
@@ -126,12 +132,16 @@ export async function snapshotAria(opts: {
   const sourceUrl = page.url();
 
   const res = await withPlaywrightPageCdpSession(page, async (session) => {
-    await session.send('Accessibility.enable' as any).catch(() => {});
-    return await session.send('Accessibility.getFullAXTree' as any) as { nodes?: CdpAXNode[] };
+    await session.send('Accessibility.enable' as unknown as Parameters<typeof session.send>[0]).catch(() => {
+      /* intentional no-op */
+    });
+    return (await session.send('Accessibility.getFullAXTree' as unknown as Parameters<typeof session.send>[0])) as {
+      nodes?: CdpAXNode[];
+    };
   });
 
   return {
-    nodes: formatAriaNodes(Array.isArray(res?.nodes) ? res.nodes : [], limit),
+    nodes: formatAriaNodes(Array.isArray(res.nodes) ? res.nodes : [], limit),
     untrusted: true,
     contentMeta: {
       sourceUrl,
@@ -156,11 +166,11 @@ function formatAriaNodes(nodes: CdpAXNode[], limit: number): AriaNode[] {
   const referenced = new Set<string>();
   for (const n of nodes) for (const c of n.childIds ?? []) referenced.add(c);
 
-  const root = nodes.find(n => n.nodeId && !referenced.has(n.nodeId)) ?? nodes[0];
-  if (!root?.nodeId) return [];
+  const root = nodes.find((n) => n.nodeId !== '' && !referenced.has(n.nodeId)) ?? nodes[0];
+  if (root.nodeId === '') return [];
 
   const out: AriaNode[] = [];
-  const stack: Array<{ id: string; depth: number }> = [{ id: root.nodeId, depth: 0 }];
+  const stack: { id: string; depth: number }[] = [{ id: root.nodeId, depth: 0 }];
 
   while (stack.length && out.length < limit) {
     const popped = stack.pop();
@@ -173,7 +183,7 @@ function formatAriaNodes(nodes: CdpAXNode[], limit: number): AriaNode[] {
     const name = axValue(n.name);
     const value = axValue(n.value);
     const description = axValue(n.description);
-    const ref = `ax${out.length + 1}`;
+    const ref = `ax${String(out.length + 1)}`;
 
     out.push({
       ref,

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -1,25 +1,62 @@
-import type { RoleRefs, RoleRefInfo } from '../types.js';
+import type { RoleRefs } from '../types.js';
 
 export const INTERACTIVE_ROLES = new Set([
-  'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'listbox',
-  'menuitem', 'menuitemcheckbox', 'menuitemradio', 'option', 'searchbox',
-  'slider', 'spinbutton', 'switch', 'tab', 'treeitem',
+  'button',
+  'link',
+  'textbox',
+  'checkbox',
+  'radio',
+  'combobox',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'treeitem',
 ]);
 
 export const CONTENT_ROLES = new Set([
-  'heading', 'cell', 'gridcell', 'columnheader', 'rowheader',
-  'listitem', 'article', 'region', 'main', 'navigation',
+  'heading',
+  'cell',
+  'gridcell',
+  'columnheader',
+  'rowheader',
+  'listitem',
+  'article',
+  'region',
+  'main',
+  'navigation',
 ]);
 
 export const STRUCTURAL_ROLES = new Set([
-  'generic', 'group', 'list', 'table', 'row', 'rowgroup', 'grid', 'treegrid',
-  'menu', 'menubar', 'toolbar', 'tablist', 'tree', 'directory', 'document',
-  'application', 'presentation', 'none',
+  'generic',
+  'group',
+  'list',
+  'table',
+  'row',
+  'rowgroup',
+  'grid',
+  'treegrid',
+  'menu',
+  'menubar',
+  'toolbar',
+  'tablist',
+  'tree',
+  'directory',
+  'document',
+  'application',
+  'presentation',
+  'none',
 ]);
 
 function getIndentLevel(line: string): number {
-  const match = line.match(/^(\s*)/);
-  return match ? Math.floor(match[1]!.length / 2) : 0;
+  const match = /^(\s*)/.exec(line);
+  return match ? Math.floor(match[1].length / 2) : 0;
 }
 
 interface ParsedSnapshotLine {
@@ -29,28 +66,25 @@ interface ParsedSnapshotLine {
   suffix: string;
 }
 
-function matchInteractiveSnapshotLine(
-  line: string,
-  options: SnapshotBuildOptions,
-): ParsedSnapshotLine | null {
+function matchInteractiveSnapshotLine(line: string, options: SnapshotBuildOptions): ParsedSnapshotLine | null {
   const depth = getIndentLevel(line);
   if (options.maxDepth !== undefined && depth > options.maxDepth) {
     return null;
   }
-  const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+  const match = /^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/.exec(line);
   if (!match) {
     return null;
   }
   const [, , roleRaw, name, suffix] = match;
-  if (roleRaw!.startsWith('/')) {
+  if (roleRaw.startsWith('/')) {
     return null;
   }
-  const role = roleRaw!.toLowerCase();
+  const role = roleRaw.toLowerCase();
   return {
-    roleRaw: roleRaw!,
+    roleRaw: roleRaw,
     role,
     ...(name ? { name } : {}),
-    suffix: suffix!,
+    suffix: suffix,
   };
 }
 
@@ -88,7 +122,7 @@ function removeNthFromNonDuplicates(refs: RoleRefs, tracker: ReturnType<typeof c
   const duplicates = tracker.getDuplicateKeys();
   for (const [ref, data] of Object.entries(refs)) {
     const key = tracker.getKey(data.role, data.name);
-    if (!duplicates.has(key)) delete refs[ref]?.nth;
+    if (!duplicates.has(key)) delete refs[ref].nth;
   }
 }
 
@@ -96,14 +130,23 @@ function compactTree(tree: string): string {
   const lines = tree.split('\n');
   const result: string[] = [];
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (line.includes('[ref=')) { result.push(line); continue; }
-    if (line.includes(':') && !line.trimEnd().endsWith(':')) { result.push(line); continue; }
+    const line = lines[i];
+    if (line.includes('[ref=')) {
+      result.push(line);
+      continue;
+    }
+    if (line.includes(':') && !line.trimEnd().endsWith(':')) {
+      result.push(line);
+      continue;
+    }
     const currentIndent = getIndentLevel(line);
     let hasRelevantChildren = false;
     for (let j = i + 1; j < lines.length; j++) {
-      if (getIndentLevel(lines[j]!) <= currentIndent) break;
-      if (lines[j]?.includes('[ref=')) { hasRelevantChildren = true; break; }
+      if (getIndentLevel(lines[j]) <= currentIndent) break;
+      if (lines[j]?.includes('[ref=')) {
+        hasRelevantChildren = true;
+        break;
+      }
     }
     if (hasRelevantChildren) result.push(line);
   }
@@ -128,24 +171,27 @@ export function buildRoleSnapshotFromAriaSnapshot(
   const refs: RoleRefs = {};
   const tracker = createRoleNameTracker();
   let counter = 0;
-  const nextRef = () => { counter++; return `e${counter}`; };
+  const nextRef = () => {
+    counter++;
+    return `e${String(counter)}`;
+  };
 
-  if (options.interactive) {
+  if (options.interactive === true) {
     const result: string[] = [];
     for (const line of lines) {
       const parsed = matchInteractiveSnapshotLine(line, options);
       if (!parsed) continue;
       const { roleRaw, role, name, suffix } = parsed;
       if (!INTERACTIVE_ROLES.has(role)) continue;
-      const prefix = line.match(/^(\s*-\s*)/)?.[1] ?? '';
+      const prefix = /^(\s*-\s*)/.exec(line)?.[1] ?? '';
       const ref = nextRef();
       const nth = tracker.getNextIndex(role, name);
       tracker.trackRef(role, name, ref);
       refs[ref] = { role, name, nth };
       let enhanced = `${prefix}${roleRaw}`;
-      if (name) enhanced += ` "${name}"`;
+      if (name !== undefined && name !== '') enhanced += ` "${name}"`;
       enhanced += ` [ref=${ref}]`;
-      if (nth > 0) enhanced += ` [nth=${nth}]`;
+      if (nth > 0) enhanced += ` [nth=${String(nth)}]`;
       if (suffix.includes('[')) enhanced += suffix;
       result.push(enhanced);
     }
@@ -157,16 +203,25 @@ export function buildRoleSnapshotFromAriaSnapshot(
   for (const line of lines) {
     const depth = getIndentLevel(line);
     if (options.maxDepth !== undefined && depth > options.maxDepth) continue;
-    const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
-    if (!match) { result.push(line); continue; }
+    const match = /^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/.exec(line);
+    if (!match) {
+      result.push(line);
+      continue;
+    }
     const [, prefix, roleRaw, name, suffix] = match;
-    if (roleRaw!.startsWith('/')) { result.push(line); continue; }
-    const role = roleRaw!.toLowerCase();
+    if (roleRaw.startsWith('/')) {
+      result.push(line);
+      continue;
+    }
+    const role = roleRaw.toLowerCase();
     const isInteractive = INTERACTIVE_ROLES.has(role);
     const isContent = CONTENT_ROLES.has(role);
     const isStructural = STRUCTURAL_ROLES.has(role);
-    if (options.compact && isStructural && !name) continue;
-    if (!(isInteractive || (isContent && name))) { result.push(line); continue; }
+    if (options.compact === true && isStructural && name === '') continue;
+    if (!(isInteractive || (isContent && name !== ''))) {
+      result.push(line);
+      continue;
+    }
 
     const ref = nextRef();
     const nth = tracker.getNextIndex(role, name);
@@ -174,15 +229,15 @@ export function buildRoleSnapshotFromAriaSnapshot(
     refs[ref] = { role, name, nth };
 
     let enhanced = `${prefix}${roleRaw}`;
-    if (name) enhanced += ` "${name}"`;
+    if (name !== '') enhanced += ` "${name}"`;
     enhanced += ` [ref=${ref}]`;
-    if (nth > 0) enhanced += ` [nth=${nth}]`;
-    if (suffix) enhanced += suffix;
+    if (nth > 0) enhanced += ` [nth=${String(nth)}]`;
+    if (suffix !== '') enhanced += suffix;
     result.push(enhanced);
   }
   removeNthFromNonDuplicates(refs, tracker);
   const tree = result.join('\n') || '(empty)';
-  return { snapshot: options.compact ? compactTree(tree) : tree, refs };
+  return { snapshot: options.compact === true ? compactTree(tree) : tree, refs };
 }
 
 /**
@@ -193,15 +248,15 @@ export function buildRoleSnapshotFromAiSnapshot(
   aiSnapshot: string,
   options: SnapshotBuildOptions = {},
 ): { snapshot: string; refs: RoleRefs } {
-  const lines = String(aiSnapshot ?? '').split('\n');
+  const lines = aiSnapshot.split('\n');
   const refs: RoleRefs = {};
 
   function parseAiSnapshotRef(suffix: string): string | null {
-    const match = suffix.match(/\[ref=(e\d+)\]/i);
-    return match ? match[1]! : null;
+    const match = /\[ref=(e\d+)\]/i.exec(suffix);
+    return match ? match[1] : null;
   }
 
-  if (options.interactive) {
+  if (options.interactive === true) {
     const out: string[] = [];
     for (const line of lines) {
       const parsed = matchInteractiveSnapshotLine(line, options);
@@ -209,10 +264,10 @@ export function buildRoleSnapshotFromAiSnapshot(
       const { roleRaw, role, name, suffix } = parsed;
       if (!INTERACTIVE_ROLES.has(role)) continue;
       const ref = parseAiSnapshotRef(suffix);
-      if (!ref) continue;
-      const prefix = line.match(/^(\s*-\s*)/)?.[1] ?? '';
-      refs[ref] = { role, ...(name ? { name } : {}) };
-      out.push(`${prefix}${roleRaw}${name ? ` "${name}"` : ''}${suffix}`);
+      if (ref === null) continue;
+      const prefix = /^(\s*-\s*)/.exec(line)?.[1] ?? '';
+      refs[ref] = { role, ...(name !== undefined && name !== '' ? { name } : {}) };
+      out.push(`${prefix}${roleRaw}${name !== undefined && name !== '' ? ` "${name}"` : ''}${suffix}`);
     }
     return { snapshot: out.join('\n') || '(no interactive elements)', refs };
   }
@@ -221,23 +276,29 @@ export function buildRoleSnapshotFromAiSnapshot(
   for (const line of lines) {
     const depth = getIndentLevel(line);
     if (options.maxDepth !== undefined && depth > options.maxDepth) continue;
-    const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
-    if (!match) { out.push(line); continue; }
+    const match = /^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/.exec(line);
+    if (!match) {
+      out.push(line);
+      continue;
+    }
     const [, , roleRaw, name, suffix] = match;
-    if (roleRaw!.startsWith('/')) { out.push(line); continue; }
-    const role = roleRaw!.toLowerCase();
+    if (roleRaw.startsWith('/')) {
+      out.push(line);
+      continue;
+    }
+    const role = roleRaw.toLowerCase();
     const isStructural = STRUCTURAL_ROLES.has(role);
-    if (options.compact && isStructural && !name) continue;
-    const ref = parseAiSnapshotRef(suffix!);
-    if (ref) refs[ref] = { role, ...(name ? { name } : {}) };
+    if (options.compact === true && isStructural && name === '') continue;
+    const ref = parseAiSnapshotRef(suffix);
+    if (ref !== null) refs[ref] = { role, ...(name !== '' ? { name } : {}) };
     out.push(line);
   }
   const tree = out.join('\n') || '(empty)';
-  return { snapshot: options.compact ? compactTree(tree) : tree, refs };
+  return { snapshot: options.compact === true ? compactTree(tree) : tree, refs };
 }
 
 export function getRoleSnapshotStats(snapshot: string, refs: RoleRefs) {
-  const interactive = Object.values(refs).filter(r => INTERACTIVE_ROLES.has(r.role)).length;
+  const interactive = Object.values(refs).filter((r) => INTERACTIVE_ROLES.has(r.role)).length;
   return {
     lines: snapshot.split('\n').length,
     chars: snapshot.length,

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,3 +1,5 @@
+import type { BrowserContext } from 'playwright-core';
+
 import { getPageForTargetId, ensurePageState } from '../connection.js';
 import type { CookieData, StorageKind } from '../types.js';
 
@@ -6,7 +8,7 @@ import type { CookieData, StorageKind } from '../types.js';
 export async function cookiesGetViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
-}): Promise<{ cookies: Awaited<ReturnType<import('playwright-core').BrowserContext['cookies']>> }> {
+}): Promise<{ cookies: Awaited<ReturnType<BrowserContext['cookies']>> }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   return { cookies: await page.context().cookies() };
@@ -20,17 +22,18 @@ export async function cookiesSetViaPlaywright(opts: {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   const cookie = opts.cookie;
-  if (!cookie.name || cookie.value === undefined) throw new Error('cookie name and value are required');
-  const hasUrl = typeof cookie.url === 'string' && cookie.url.trim();
-  const hasDomainPath = typeof cookie.domain === 'string' && cookie.domain.trim() && typeof cookie.path === 'string' && cookie.path.trim();
+  if (cookie.name === '') throw new Error('cookie name and value are required');
+  const hasUrl = typeof cookie.url === 'string' && cookie.url.trim() !== '';
+  const hasDomainPath =
+    typeof cookie.domain === 'string' &&
+    cookie.domain.trim() !== '' &&
+    typeof cookie.path === 'string' &&
+    cookie.path.trim() !== '';
   if (!hasUrl && !hasDomainPath) throw new Error('cookie requires url, or domain+path');
   await page.context().addCookies([cookie]);
 }
 
-export async function cookiesClearViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-}): Promise<void> {
+export async function cookiesClearViaPlaywright(opts: { cdpUrl: string; targetId?: string }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   await page.context().clearCookies();
@@ -50,21 +53,21 @@ export async function storageGetViaPlaywright(opts: {
     values: await page.evaluate(
       ({ kind, key }: { kind: string; key?: string }) => {
         const store = kind === 'session' ? window.sessionStorage : window.localStorage;
-        if (key) {
+        if (key !== undefined && key !== '') {
           const value = store.getItem(key);
           return value === null ? {} : { [key]: value };
         }
         const out: Record<string, string> = {};
         for (let i = 0; i < store.length; i++) {
           const k = store.key(i);
-          if (!k) continue;
+          if (k === null || k === '') continue;
           const v = store.getItem(k);
           if (v !== null) out[k] = v;
         }
         return out;
       },
       { kind: opts.kind, key: opts.key },
-    ) ?? {},
+    ),
   };
 }
 
@@ -75,15 +78,15 @@ export async function storageSetViaPlaywright(opts: {
   key: string;
   value: string;
 }): Promise<void> {
-  const key = String(opts.key ?? '');
-  if (!key) throw new Error('key is required');
+  const key = opts.key;
+  if (key === '') throw new Error('key is required');
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   await page.evaluate(
     ({ kind, key: k, value }: { kind: string; key: string; value: string }) => {
       (kind === 'session' ? window.sessionStorage : window.localStorage).setItem(k, value);
     },
-    { kind: opts.kind, key, value: String(opts.value ?? '') },
+    { kind: opts.kind, key, value: opts.value },
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import type { ChildProcess } from 'node:child_process';
+import type { lookup as dnsLookup } from 'node:dns';
+
 // ── SSRF Policy ──
 
 /**
@@ -54,7 +57,7 @@ export interface RunningChrome {
   /** Unix timestamp (ms) when the browser was started */
   startedAt: number;
   /** The child process handle */
-  proc: import('node:child_process').ChildProcess;
+  proc: ChildProcess;
 }
 
 /** Options for launching a new browser instance. */
@@ -506,5 +509,5 @@ export interface PageState {
 export interface PinnedHostname {
   hostname: string;
   addresses: string[];
-  lookup: typeof import('node:dns').lookup;
+  lookup: typeof dnsLookup;
 }


### PR DESCRIPTION
## Summary
- Add ESLint with `typescript-eslint` strict + stylistic type-checked presets
- Add Prettier with consistent formatting (single quotes, trailing commas, 120 width)
- Fix all 487 lint errors across 21 source files
- Bump to 0.6.0

## Rules enforced
- No `any` anywhere (explicit or inferred)
- No floating promises, no misused promises
- Strict boolean expressions (explicit null/undefined checks)
- Consistent type imports (`import type`)
- No non-null assertions
- Sorted, grouped imports
- Switch exhaustiveness checks