### PR TITLE
Updates from OpenClaw 2026.3.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -513,7 +513,8 @@ export async function disconnectBrowser(): Promise<void> {
     }
   }
   for (const cur of cachedByCdpUrl.values()) {
-    if (cur.onDisconnected && typeof cur.browser.off === 'function') cur.browser.off('disconnected', cur.onDisconnected);
+    if (cur.onDisconnected && typeof cur.browser.off === 'function')
+      cur.browser.off('disconnected', cur.onDisconnected);
     await cur.browser.close().catch(() => {
       /* noop */
     });
@@ -531,7 +532,8 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
     if (!cur) return;
-    if (cur.onDisconnected && typeof cur.browser.off === 'function') cur.browser.off('disconnected', cur.onDisconnected);
+    if (cur.onDisconnected && typeof cur.browser.off === 'function')
+      cur.browser.off('disconnected', cur.onDisconnected);
     await cur.browser.close().catch(() => {
       /* noop */
     });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -513,6 +513,7 @@ export async function disconnectBrowser(): Promise<void> {
     }
   }
   for (const cur of cachedByCdpUrl.values()) {
+    if (cur.onDisconnected && typeof cur.browser.off === 'function') cur.browser.off('disconnected', cur.onDisconnected);
     await cur.browser.close().catch(() => {
       /* noop */
     });
@@ -529,10 +530,11 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
-    if (cur)
-      await cur.browser.close().catch(() => {
-        /* noop */
-      });
+    if (!cur) return;
+    if (cur.onDisconnected && typeof cur.browser.off === 'function') cur.browser.off('disconnected', cur.onDisconnected);
+    await cur.browser.close().catch(() => {
+      /* noop */
+    });
   } else {
     await disconnectBrowser();
   }


### PR DESCRIPTION
## Summary
- Unregister `onDisconnected` handler before closing browser connections in `closePlaywrightBrowserConnection` and `disconnectBrowser` — prevents spurious disconnect callbacks during intentional close