### PR TITLE
Updates from OpenClaw 2026.3.24

### DIFF
--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -11,7 +11,7 @@ import {
   normalizeTimeoutMs,
   bumpDownloadArmId,
 } from '../connection.js';
-import { assertSafeOutputPath, writeViaSiblingTempPath } from '../security.js';
+import { assertSafeOutputPath, writeViaSiblingTempPath, sanitizeUntrustedFileName } from '../security.js';
 import type { DownloadResult, PageState } from '../types.js';
 
 function createPageDownloadWaiter(page: Page, timeoutMs: number) {
@@ -139,7 +139,7 @@ export async function waitForDownloadViaPlaywright(opts: {
   try {
     const download = await waiter.promise;
     if (state.armIdDownload !== armId) throw new Error('Download was superseded by another waiter');
-    const savePath = opts.path ?? download.suggestedFilename();
+    const savePath = opts.path ?? sanitizeUntrustedFileName(download.suggestedFilename() || 'download.bin', 'download.bin');
     await assertSafeOutputPath(savePath, opts.allowedOutputRoots);
     return await saveDownloadPayload(download, savePath);
   } catch (err) {

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -139,7 +139,8 @@ export async function waitForDownloadViaPlaywright(opts: {
   try {
     const download = await waiter.promise;
     if (state.armIdDownload !== armId) throw new Error('Download was superseded by another waiter');
-    const savePath = opts.path ?? sanitizeUntrustedFileName(download.suggestedFilename() || 'download.bin', 'download.bin');
+    const savePath =
+      opts.path ?? sanitizeUntrustedFileName(download.suggestedFilename() || 'download.bin', 'download.bin');
     await assertSafeOutputPath(savePath, opts.allowedOutputRoots);
     return await saveDownloadPayload(download, savePath);
   } catch (err) {

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -15,7 +15,7 @@ import {
   getRestoredPageForTarget,
   parseRoleRef,
 } from '../connection.js';
-import { resolveStrictExistingUploadPaths } from '../security.js';
+import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
 import type { FormField } from '../types.js';
 
 type MouseButton = 'left' | 'right' | 'middle';
@@ -290,9 +290,10 @@ export async function setInputFilesViaPlaywright(opts: {
 
   const locator = inputRef ? refLocator(page, inputRef) : page.locator(element).first();
 
-  const uploadPathsResult = await resolveStrictExistingUploadPaths({
+  const uploadPathsResult = await resolveStrictExistingPathsWithinRoot({
+    rootDir: DEFAULT_UPLOAD_DIR,
     requestedPaths: opts.paths,
-    scopeLabel: 'uploads directory',
+    scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
   });
   if (!uploadPathsResult.ok) throw new Error(uploadPathsResult.error);
   const resolvedPaths = uploadPathsResult.paths;
@@ -369,9 +370,10 @@ export async function armFileUploadViaPlaywright(opts: {
         return;
       }
 
-      const uploadPathsResult = await resolveStrictExistingUploadPaths({
+      const uploadPathsResult = await resolveStrictExistingPathsWithinRoot({
+        rootDir: DEFAULT_UPLOAD_DIR,
         requestedPaths: opts.paths,
-        scopeLabel: 'uploads directory',
+        scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
       });
       if (!uploadPathsResult.ok) {
         try {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -431,11 +431,14 @@ export function isLoopbackHost(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
 }
 
-export function hasProxyEnvConfigured(): boolean {
-  return (
-    (process.env.HTTP_PROXY ?? process.env.HTTPS_PROXY ?? process.env.http_proxy ?? process.env.https_proxy ?? '') !==
-    ''
-  );
+const PROXY_ENV_KEYS = ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy'];
+
+export function hasProxyEnvConfigured(env: Record<string, string | undefined> = process.env): boolean {
+  for (const key of PROXY_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value === 'string' && value.trim().length > 0) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/security.ts
+++ b/src/security.ts
@@ -3,7 +3,18 @@ import { lookup as dnsLookupCb } from 'node:dns';
 import { lookup as dnsLookup } from 'node:dns/promises';
 import { lstat, realpath, rename, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { resolve, normalize, dirname, basename, join, sep, relative, posix, win32, isAbsolute as pathIsAbsolute } from 'node:path';
+import {
+  resolve,
+  normalize,
+  dirname,
+  basename,
+  join,
+  sep,
+  relative,
+  posix,
+  win32,
+  isAbsolute as pathIsAbsolute,
+} from 'node:path';
 
 import * as ipaddr from 'ipaddr.js';
 
@@ -357,7 +368,8 @@ export function createPinnedLookup(params: {
   fallback?: typeof dnsLookupCb;
 }): typeof dnsLookupCb {
   const normalizedHost = normalizeHostname(params.hostname);
-  if (params.addresses.length === 0) throw new Error(`Pinned lookup requires at least one address for ${params.hostname}`);
+  if (params.addresses.length === 0)
+    throw new Error(`Pinned lookup requires at least one address for ${params.hostname}`);
   const fallback = params.fallback ?? dnsLookupCb;
   const records = params.addresses.map((address) => ({
     address,
@@ -618,7 +630,8 @@ export function resolvePathWithinRoot(params: {
 }): PathResult {
   const root = resolve(params.rootDir);
   const raw = params.requestedPath.trim();
-  const effectivePath = raw === '' && params.defaultFileName != null && params.defaultFileName !== '' ? params.defaultFileName : raw;
+  const effectivePath =
+    raw === '' && params.defaultFileName != null && params.defaultFileName !== '' ? params.defaultFileName : raw;
   if (effectivePath === '') return { ok: false, error: `Empty path is not allowed (${params.scopeLabel}).` };
 
   const resolved = resolve(root, effectivePath);
@@ -649,7 +662,10 @@ export async function resolveWritablePathWithinRoot(params: {
   try {
     parentReal = await realpath(dirname(target));
   } catch {
-    return { ok: false, error: `Parent directory is inaccessible for "${params.requestedPath}" (${params.scopeLabel}).` };
+    return {
+      ok: false,
+      error: `Parent directory is inaccessible for "${params.requestedPath}" (${params.scopeLabel}).`,
+    };
   }
 
   const parentRel = relative(root, parentReal);
@@ -664,7 +680,10 @@ export async function resolveWritablePathWithinRoot(params: {
     }
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-      return { ok: false, error: `Cannot stat "${params.requestedPath}" (${params.scopeLabel}): ${(e as Error).message}` };
+      return {
+        ok: false,
+        error: `Cannot stat "${params.requestedPath}" (${params.scopeLabel}): ${(e as Error).message}`,
+      };
     }
   }
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -2,11 +2,29 @@ import { randomUUID } from 'node:crypto';
 import { lookup as dnsLookupCb } from 'node:dns';
 import { lookup as dnsLookup } from 'node:dns/promises';
 import { lstat, realpath, rename, rm } from 'node:fs/promises';
-import { resolve, normalize, dirname, basename, join, sep, relative, posix, win32 } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolve, normalize, dirname, basename, join, sep, relative, posix, win32, isAbsolute as pathIsAbsolute } from 'node:path';
 
 import * as ipaddr from 'ipaddr.js';
 
 import type { SsrfPolicy, PinnedHostname } from './types.js';
+
+// ── Default temp directories for downloads/uploads ──
+
+function resolveDefaultBrowserTmpDir(): string {
+  try {
+    if (process.platform === 'linux' || process.platform === 'darwin') {
+      return '/tmp/browserclaw';
+    }
+  } catch {
+    /* fallback below */
+  }
+  return join(tmpdir(), 'browserclaw');
+}
+
+export const DEFAULT_BROWSER_TMP_DIR = resolveDefaultBrowserTmpDir();
+export const DEFAULT_DOWNLOAD_DIR = join(DEFAULT_BROWSER_TMP_DIR, 'downloads');
+export const DEFAULT_UPLOAD_DIR = join(DEFAULT_BROWSER_TMP_DIR, 'uploads');
 
 export type LookupFn = typeof dnsLookup;
 
@@ -339,6 +357,7 @@ export function createPinnedLookup(params: {
   fallback?: typeof dnsLookupCb;
 }): typeof dnsLookupCb {
   const normalizedHost = normalizeHostname(params.hostname);
+  if (params.addresses.length === 0) throw new Error(`Pinned lookup requires at least one address for ${params.hostname}`);
   const fallback = params.fallback ?? dnsLookupCb;
   const records = params.addresses.map((address) => ({
     address,
@@ -581,6 +600,154 @@ export async function resolveStrictExistingUploadPaths(params: {
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+// ── Path confinement utilities ──
+
+type PathResult = { ok: true; path: string } | { ok: false; error: string };
+type PathsResult = { ok: true; paths: string[] } | { ok: false; error: string };
+
+/**
+ * Lexical confinement: resolve(root, raw) must not escape root.
+ */
+export function resolvePathWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+}): PathResult {
+  const root = resolve(params.rootDir);
+  const raw = params.requestedPath.trim();
+  const effectivePath = raw === '' && params.defaultFileName ? params.defaultFileName : raw;
+  if (effectivePath === '') return { ok: false, error: `Empty path is not allowed (${params.scopeLabel}).` };
+
+  const resolved = resolve(root, effectivePath);
+  const rel = relative(root, resolved);
+  if (!rel || rel === '..' || rel.startsWith(`..${sep}`) || pathIsAbsolute(rel)) {
+    return { ok: false, error: `Path escapes ${params.scopeLabel}: "${params.requestedPath}".` };
+  }
+  return { ok: true, path: resolved };
+}
+
+/**
+ * Async writable-path check: verifies parent dir realpath is within root,
+ * and that the target (if it exists) is not a symlink.
+ */
+export async function resolveWritablePathWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+}): Promise<PathResult> {
+  const lexical = resolvePathWithinRoot(params);
+  if (!lexical.ok) return lexical;
+
+  const root = resolve(params.rootDir);
+  const target = lexical.path;
+
+  let parentReal: string;
+  try {
+    parentReal = await realpath(dirname(target));
+  } catch {
+    return { ok: false, error: `Parent directory is inaccessible for "${params.requestedPath}" (${params.scopeLabel}).` };
+  }
+
+  const parentRel = relative(root, parentReal);
+  if (parentRel === '..' || parentRel.startsWith(`..${sep}`) || pathIsAbsolute(parentRel)) {
+    return { ok: false, error: `Path escapes ${params.scopeLabel} via symlink: "${params.requestedPath}".` };
+  }
+
+  try {
+    const stat = await lstat(target);
+    if (stat.isSymbolicLink()) {
+      return { ok: false, error: `Path is a symbolic link (${params.scopeLabel}): "${params.requestedPath}".` };
+    }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return { ok: false, error: `Cannot stat "${params.requestedPath}" (${params.scopeLabel}): ${(e as Error).message}` };
+    }
+  }
+
+  return { ok: true, path: target };
+}
+
+/**
+ * For each path: lexical check then realpath check. Missing files are allowed
+ * (returns the fallback resolved path).
+ */
+export async function resolveExistingPathsWithinRoot(params: {
+  rootDir: string;
+  requestedPaths: string[];
+  scopeLabel: string;
+}): Promise<PathsResult> {
+  const root = resolve(params.rootDir);
+  const resolved: string[] = [];
+
+  for (const raw of params.requestedPaths) {
+    const lexical = resolvePathWithinRoot({ rootDir: root, requestedPath: raw, scopeLabel: params.scopeLabel });
+    if (!lexical.ok) return lexical;
+
+    try {
+      const real = await realpath(lexical.path);
+      const rel = relative(root, real);
+      if (rel === '..' || rel.startsWith(`..${sep}`) || pathIsAbsolute(rel)) {
+        return { ok: false, error: `Path escapes ${params.scopeLabel} via symlink: "${raw}".` };
+      }
+      resolved.push(real);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        resolved.push(lexical.path);
+      } else {
+        return { ok: false, error: `Cannot resolve "${raw}" (${params.scopeLabel}): ${(e as Error).message}` };
+      }
+    }
+  }
+
+  return { ok: true, paths: resolved };
+}
+
+/**
+ * Same as resolveExistingPathsWithinRoot but missing files are NOT allowed.
+ */
+export async function resolveStrictExistingPathsWithinRoot(params: {
+  rootDir: string;
+  requestedPaths: string[];
+  scopeLabel: string;
+}): Promise<PathsResult> {
+  const root = resolve(params.rootDir);
+  const resolved: string[] = [];
+
+  for (const raw of params.requestedPaths) {
+    const lexical = resolvePathWithinRoot({ rootDir: root, requestedPath: raw, scopeLabel: params.scopeLabel });
+    if (!lexical.ok) return lexical;
+
+    let real: string;
+    try {
+      real = await realpath(lexical.path);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { ok: false, error: `Path does not exist (${params.scopeLabel}): "${raw}".` };
+      }
+      return { ok: false, error: `Cannot resolve "${raw}" (${params.scopeLabel}): ${(e as Error).message}` };
+    }
+
+    const rel = relative(root, real);
+    if (rel === '..' || rel.startsWith(`..${sep}`) || pathIsAbsolute(rel)) {
+      return { ok: false, error: `Path escapes ${params.scopeLabel} via symlink: "${raw}".` };
+    }
+
+    const stat = await lstat(real);
+    if (stat.isSymbolicLink()) {
+      return { ok: false, error: `Path is a symbolic link (${params.scopeLabel}): "${raw}".` };
+    }
+    if (!stat.isFile()) {
+      return { ok: false, error: `Path is not a regular file (${params.scopeLabel}): "${raw}".` };
+    }
+
+    resolved.push(real);
+  }
+
+  return { ok: true, paths: resolved };
 }
 
 // ── Atomic file write utilities ──

--- a/src/security.ts
+++ b/src/security.ts
@@ -618,7 +618,7 @@ export function resolvePathWithinRoot(params: {
 }): PathResult {
   const root = resolve(params.rootDir);
   const raw = params.requestedPath.trim();
-  const effectivePath = raw === '' && params.defaultFileName ? params.defaultFileName : raw;
+  const effectivePath = raw === '' && params.defaultFileName != null && params.defaultFileName !== '' ? params.defaultFileName : raw;
   if (effectivePath === '') return { ok: false, error: `Empty path is not allowed (${params.scopeLabel}).` };
 
   const resolved = resolve(root, effectivePath);


### PR DESCRIPTION
Port security hardening missed by the automated 2026.3.24 sync:

- Path confinement functions: `resolvePathWithinRoot`, `resolveWritablePathWithinRoot`, `resolveExistingPathsWithinRoot`, `resolveStrictExistingPathsWithinRoot`
- Default temp directories: `DEFAULT_BROWSER_TMP_DIR`, `DEFAULT_DOWNLOAD_DIR`, `DEFAULT_UPLOAD_DIR`
- Upload validation switched to root-scoped `resolveStrictExistingPathsWithinRoot` with `DEFAULT_UPLOAD_DIR`
- Download fallback filename sanitized via `sanitizeUntrustedFileName`
- `createPinnedLookup` empty-addresses guard
- `hasProxyEnvConfigured` now checks `ALL_PROXY`/`all_proxy` + trims whitespace