### PR TITLE
Feature enhancements from feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 <h2 align="center">🦞 BrowserClaw — Standalone OpenClaw browser module</h2>
 
 <p align="center">
-  <a href="https://browserclaw.agent"><img src="https://img.shields.io/badge/Live-browserclaw.agent-orange" alt="Live" /></a>
+  <a href="https://browserclaw.org"><img src="https://img.shields.io/badge/Live-browserclaw.org-orange" alt="Live" /></a>
   <a href="https://www.npmjs.com/package/browserclaw"><img src="https://img.shields.io/npm/v/browserclaw.svg" alt="npm version" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
   <a href="https://www.npmjs.com/package/browserclaw"><img src="https://img.shields.io/npm/dw/browserclaw" alt="npm downloads" /></a>
   <a href="https://github.com/idan-rubin/browserclaw/stargazers"><img src="https://img.shields.io/github/stars/idan-rubin/browserclaw" alt="GitHub stars" /></a>
 </p>
+
+> **DISCLAIMER: This project is NOT affiliated with browserclaw.com in any form. We have no connection to that site and recommend treating it with caution.**
 
 Extracted and refined from [OpenClaw](https://github.com/openclaw/openclaw)'s browser automation module. A standalone, typed library for AI-friendly browser control with **snapshot + ref targeting** — no CSS selectors, no XPath, no vision, just numbered refs that map to interactive elements.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -71,57 +71,62 @@ async function awaitEvalWithAbort(evalPromise: Promise<unknown>, abortPromise?: 
   }
 }
 
-// Browser-side evaluator that wraps async results with a timeout via Promise.race.
-// This runs inside the browser sandbox (not Node.js) — `new Function` is the standard
-// pattern for browser-context evaluation with timeout, matching OpenClaw's implementation.
+// Browser-side evaluators: intentionally use eval() to execute user-provided
+// browser-side code. This is the core purpose — running arbitrary JS in the
+// page sandbox. The fallback path handles statement-form code (template
+// literals, multi-statement blocks) that fail expression-mode eval.
 
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
 const BROWSER_EVALUATOR = new Function(
   'args',
-  `
-  "use strict";
-  var fnBody = args.fnBody, timeoutMs = args.timeoutMs;
-  try {
-    var candidate = eval("(" + fnBody + ")");
-    var result = typeof candidate === "function" ? candidate() : candidate;
-    if (result && typeof result.then === "function") {
-      return Promise.race([
-        result,
-        new Promise(function(_, reject) {
-          setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);
-        })
-      ]);
-    }
-    return result;
-  } catch (err) {
-    throw new Error("Invalid evaluate function: " + (err && err.message ? err.message : String(err)));
-  }
-`,
+  [
+    '"use strict";',
+    'var fnBody = args.fnBody, timeoutMs = args.timeoutMs;',
+    'try {',
+    '  var candidate;',
+    '  try { candidate = eval("(" + fnBody + ")"); }',
+    '  catch (_) { candidate = (0, eval)(fnBody); }',
+    '  var result = typeof candidate === "function" ? candidate() : candidate;',
+    '  if (result && typeof result.then === "function") {',
+    '    return Promise.race([',
+    '      result,',
+    '      new Promise(function(_, reject) {',
+    '        setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);',
+    '      })',
+    '    ]);',
+    '  }',
+    '  return result;',
+    '} catch (err) {',
+    '  throw new Error("Invalid evaluate function: " + (err && err.message ? err.message : String(err)));',
+    '}',
+  ].join('\n'),
 );
 
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
 const ELEMENT_EVALUATOR = new Function(
   'el',
   'args',
-  `
-  "use strict";
-  var fnBody = args.fnBody, timeoutMs = args.timeoutMs;
-  try {
-    var candidate = eval("(" + fnBody + ")");
-    var result = typeof candidate === "function" ? candidate(el) : candidate;
-    if (result && typeof result.then === "function") {
-      return Promise.race([
-        result,
-        new Promise(function(_, reject) {
-          setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);
-        })
-      ]);
-    }
-    return result;
-  } catch (err) {
-    throw new Error("Invalid evaluate function: " + (err && err.message ? err.message : String(err)));
-  }
-`,
+  [
+    '"use strict";',
+    'var fnBody = args.fnBody, timeoutMs = args.timeoutMs;',
+    'try {',
+    '  var candidate;',
+    '  try { candidate = eval("(" + fnBody + ")"); }',
+    '  catch (_) { candidate = (0, eval)(fnBody); }',
+    '  var result = typeof candidate === "function" ? candidate(el) : candidate;',
+    '  if (result && typeof result.then === "function") {',
+    '    return Promise.race([',
+    '      result,',
+    '      new Promise(function(_, reject) {',
+    '        setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);',
+    '      })',
+    '    ]);',
+    '  }',
+    '  return result;',
+    '} catch (err) {',
+    '  throw new Error("Invalid evaluate function: " + (err && err.message ? err.message : String(err)));',
+    '}',
+  ].join('\n'),
 );
 
 /**

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -30,6 +30,66 @@ function resolveLocator(page: Page, resolved: { ref?: string; selector?: string 
   return page.locator(sel);
 }
 
+export async function mouseClickViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  x: number;
+  y: number;
+  button?: MouseButton;
+  clickCount?: number;
+  delayMs?: number;
+}): Promise<void> {
+  const page = await getRestoredPageForTarget(opts);
+  await page.mouse.click(opts.x, opts.y, {
+    button: opts.button,
+    clickCount: opts.clickCount,
+    delay: opts.delayMs,
+  });
+}
+
+export async function clickByTextViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  text: string;
+  exact?: boolean;
+  button?: MouseButton;
+  modifiers?: KeyModifier[];
+  timeoutMs?: number;
+}): Promise<void> {
+  const page = await getRestoredPageForTarget(opts);
+  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  try {
+    await page
+      .getByText(opts.text, { exact: opts.exact })
+      .click({ timeout, button: opts.button, modifiers: opts.modifiers });
+  } catch (err) {
+    throw toAIFriendlyError(err, `text="${opts.text}"`);
+  }
+}
+
+export async function clickByRoleViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  role: string;
+  name?: string;
+  button?: MouseButton;
+  modifiers?: KeyModifier[];
+  timeoutMs?: number;
+}): Promise<void> {
+  const page = await getRestoredPageForTarget(opts);
+  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  try {
+    await page
+      .getByRole(opts.role as Parameters<typeof page.getByRole>[0], { name: opts.name })
+      .click({ timeout, button: opts.button, modifiers: opts.modifiers });
+  } catch (err) {
+    throw toAIFriendlyError(
+      err,
+      `role=${opts.role}${opts.name !== undefined && opts.name !== '' ? ` name="${opts.name}"` : ''}`,
+    );
+  }
+}
+
 export async function clickViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -334,11 +394,15 @@ export async function armDialogViaPlaywright(opts: {
     .waitForEvent('dialog', { timeout })
     .then(async (dialog) => {
       if (state.armIdDialog !== armId) return;
-      if (opts.accept) await dialog.accept(opts.promptText);
-      else await dialog.dismiss();
+      try {
+        if (opts.accept) await dialog.accept(opts.promptText);
+        else await dialog.dismiss();
+      } finally {
+        if (state.armIdDialog === armId) state.armIdDialog = 0;
+      }
     })
     .catch(() => {
-      /* intentional no-op */
+      if (state.armIdDialog === armId) state.armIdDialog = 0;
     });
 }
 

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,8 +1,11 @@
+import type { Browser, BrowserContext } from 'playwright-core';
+
 import {
   connectBrowser,
   getPageForTargetId,
   ensurePageState,
   ensureContextState,
+  observeContext,
   pageTargetId,
   getAllPages,
   forceDisconnectPlaywrightForTarget,
@@ -16,6 +19,24 @@ import {
   withBrowserNavigationPolicy,
 } from '../security.js';
 import type { BrowserTab, SsrfPolicy } from '../types.js';
+
+const recordingContexts = new Map<string, BrowserContext>();
+
+export function clearRecordingContext(cdpUrl: string): void {
+  recordingContexts.delete(cdpUrl);
+}
+
+async function createRecordingContext(
+  browser: Browser,
+  cdpUrl: string,
+  recordVideo: { dir: string; size?: { width: number; height: number } },
+): Promise<BrowserContext> {
+  const context = await browser.newContext({ recordVideo });
+  observeContext(context);
+  recordingContexts.set(cdpUrl, context);
+  context.on('close', () => recordingContexts.delete(cdpUrl));
+  return context;
+}
 
 function isRetryableNavigateError(err: unknown): boolean {
   const msg = typeof err === 'string' ? err.toLowerCase() : err instanceof Error ? err.message.toLowerCase() : '';
@@ -94,9 +115,12 @@ export async function createPageViaPlaywright(opts: {
   ssrfPolicy?: SsrfPolicy;
   /** @deprecated Use ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } instead */
   allowInternal?: boolean;
+  recordVideo?: { dir: string; size?: { width: number; height: number } };
 }): Promise<BrowserTab> {
   const { browser } = await connectBrowser(opts.cdpUrl);
-  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const context = opts.recordVideo
+    ? (recordingContexts.get(opts.cdpUrl) ?? (await createRecordingContext(browser, opts.cdpUrl, opts.recordVideo)))
+    : (browser.contexts()[0] ?? (await browser.newContext()));
   ensureContextState(context);
   const page = await context.newPage();
   ensurePageState(page);

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -29,10 +29,12 @@ export async function waitForViaPlaywright(opts: {
     await page.waitForTimeout(resolveBoundedDelayMs(opts.timeMs, 'wait timeMs', MAX_WAIT_TIME_MS));
   }
   if (opts.text !== undefined && opts.text !== '') {
-    await page.getByText(opts.text).first().waitFor({ state: 'visible', timeout });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- document.body is null before DOM ready
+    await page.waitForFunction((text) => (document.body?.innerText ?? '').includes(text), opts.text, { timeout });
   }
   if (opts.textGone !== undefined && opts.textGone !== '') {
-    await page.getByText(opts.textGone).first().waitFor({ state: 'hidden', timeout });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- document.body is null before DOM ready
+    await page.waitForFunction((text) => !(document.body?.innerText ?? '').includes(text), opts.textGone, { timeout });
   }
   if (opts.selector !== undefined && opts.selector !== '') {
     const selector = opts.selector.trim();

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,6 +16,9 @@ import {
 import { evaluateViaPlaywright, evaluateInAllFramesViaPlaywright, type FrameEvalResult } from './actions/evaluate.js';
 import {
   clickViaPlaywright,
+  mouseClickViaPlaywright,
+  clickByTextViaPlaywright,
+  clickByRoleViaPlaywright,
   hoverViaPlaywright,
   typeViaPlaywright,
   selectOptionViaPlaywright,
@@ -35,6 +38,7 @@ import {
   closePageByTargetIdViaPlaywright,
   focusPageByTargetIdViaPlaywright,
   resizeViewportViaPlaywright,
+  clearRecordingContext,
 } from './actions/navigation.js';
 import { waitForViaPlaywright } from './actions/wait.js';
 import { detectChallengeViaPlaywright, waitForChallengeViaPlaywright } from './anti-bot.js';
@@ -47,7 +51,7 @@ import { pdfViaPlaywright } from './capture/pdf.js';
 import { responseBodyViaPlaywright } from './capture/response.js';
 import { takeScreenshotViaPlaywright, screenshotWithLabelsViaPlaywright } from './capture/screenshot.js';
 import { traceStartViaPlaywright, traceStopViaPlaywright } from './capture/trace.js';
-import { launchChrome, stopChrome, isChromeReachable } from './chrome-launcher.js';
+import { launchChrome, stopChrome, isChromeReachable, discoverChromeCdpUrl } from './chrome-launcher.js';
 import {
   connectBrowser,
   disconnectBrowser,
@@ -230,6 +234,108 @@ export class CrawlPage {
       button: opts?.button,
       modifiers: opts?.modifiers,
       delayMs: opts?.delayMs,
+      timeoutMs: opts?.timeoutMs,
+    });
+  }
+
+  /**
+   * Click at specific page coordinates.
+   *
+   * Useful for canvas elements, custom widgets, or elements without ARIA roles.
+   *
+   * @param x - X coordinate in pixels
+   * @param y - Y coordinate in pixels
+   * @param opts - Click options (button, clickCount, delayMs)
+   *
+   * @example
+   * ```ts
+   * await page.mouseClick(100, 200);
+   * await page.mouseClick(100, 200, { button: 'right' });
+   * await page.mouseClick(100, 200, { clickCount: 2 }); // double-click
+   * ```
+   */
+  async mouseClick(
+    x: number,
+    y: number,
+    opts?: { button?: 'left' | 'right' | 'middle'; clickCount?: number; delayMs?: number },
+  ): Promise<void> {
+    return mouseClickViaPlaywright({
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      x,
+      y,
+      button: opts?.button,
+      clickCount: opts?.clickCount,
+      delayMs: opts?.delayMs,
+    });
+  }
+
+  /**
+   * Click an element by its visible text content (no snapshot/ref needed).
+   *
+   * Finds and clicks atomically — no stale ref problem.
+   *
+   * @param text - Text content to match
+   * @param opts - Options (exact: require full match, button, modifiers)
+   *
+   * @example
+   * ```ts
+   * await page.clickByText('Submit');
+   * await page.clickByText('Save Changes', { exact: true });
+   * ```
+   */
+  async clickByText(
+    text: string,
+    opts?: {
+      exact?: boolean;
+      button?: 'left' | 'right' | 'middle';
+      modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[];
+      timeoutMs?: number;
+    },
+  ): Promise<void> {
+    return clickByTextViaPlaywright({
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      text,
+      exact: opts?.exact,
+      button: opts?.button,
+      modifiers: opts?.modifiers,
+      timeoutMs: opts?.timeoutMs,
+    });
+  }
+
+  /**
+   * Click an element by its ARIA role and accessible name (no snapshot/ref needed).
+   *
+   * Finds and clicks atomically — no stale ref problem.
+   *
+   * @param role - ARIA role (e.g. `'button'`, `'link'`, `'menuitem'`)
+   * @param name - Accessible name to match (optional)
+   * @param opts - Click options
+   *
+   * @example
+   * ```ts
+   * await page.clickByRole('button', 'Save');
+   * await page.clickByRole('link', 'Settings');
+   * await page.clickByRole('menuitem', 'Delete');
+   * ```
+   */
+  async clickByRole(
+    role: string,
+    name?: string,
+    opts?: {
+      button?: 'left' | 'right' | 'middle';
+      modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[];
+      timeoutMs?: number;
+    },
+  ): Promise<void> {
+    return clickByRoleViaPlaywright({
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      role,
+      name,
+      button: opts?.button,
+      modifiers: opts?.modifiers,
       timeoutMs: opts?.timeoutMs,
     });
   }
@@ -1167,12 +1273,19 @@ export class CrawlPage {
 export class BrowserClaw {
   private readonly cdpUrl: string;
   private readonly ssrfPolicy: SsrfPolicy | undefined;
+  private readonly recordVideo: { dir: string; size?: { width: number; height: number } } | undefined;
   private chrome: RunningChrome | null;
 
-  private constructor(cdpUrl: string, chrome: RunningChrome | null, ssrfPolicy?: SsrfPolicy) {
+  private constructor(
+    cdpUrl: string,
+    chrome: RunningChrome | null,
+    ssrfPolicy?: SsrfPolicy,
+    recordVideo?: { dir: string; size?: { width: number; height: number } },
+  ) {
     this.cdpUrl = cdpUrl;
     this.chrome = chrome;
     this.ssrfPolicy = ssrfPolicy;
+    this.recordVideo = recordVideo;
   }
 
   /**
@@ -1205,7 +1318,7 @@ export class BrowserClaw {
     const ssrfPolicy =
       opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
     /* eslint-enable @typescript-eslint/no-deprecated */
-    return new BrowserClaw(cdpUrl, chrome, ssrfPolicy);
+    return new BrowserClaw(cdpUrl, chrome, ssrfPolicy, opts.recordVideo);
   }
 
   /**
@@ -1222,16 +1335,26 @@ export class BrowserClaw {
    * const browser = await BrowserClaw.connect('http://localhost:9222');
    * ```
    */
-  static async connect(cdpUrl: string, opts?: ConnectOptions): Promise<BrowserClaw> {
-    if (!(await isChromeReachable(cdpUrl, 3000, opts?.authToken))) {
-      throw new Error(`Cannot connect to Chrome at ${cdpUrl}. Is Chrome running with --remote-debugging-port?`);
+  static async connect(cdpUrl?: string, opts?: ConnectOptions): Promise<BrowserClaw> {
+    let resolvedUrl = cdpUrl;
+    if (resolvedUrl === undefined || resolvedUrl === '') {
+      const discovered = await discoverChromeCdpUrl();
+      if (discovered === null) {
+        throw new Error(
+          'No Chrome instance found on common CDP ports (9222-9226, 9229). Start Chrome with --remote-debugging-port=9222, or pass a CDP URL.',
+        );
+      }
+      resolvedUrl = discovered;
     }
-    await connectBrowser(cdpUrl, opts?.authToken);
+    if (!(await isChromeReachable(resolvedUrl, 3000, opts?.authToken))) {
+      throw new Error(`Cannot connect to Chrome at ${resolvedUrl}. Is Chrome running with --remote-debugging-port?`);
+    }
+    await connectBrowser(resolvedUrl, opts?.authToken);
     /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
     const ssrfPolicy =
       opts?.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts?.ssrfPolicy;
     /* eslint-enable @typescript-eslint/no-deprecated */
-    return new BrowserClaw(cdpUrl, null, ssrfPolicy);
+    return new BrowserClaw(resolvedUrl, null, ssrfPolicy, opts?.recordVideo);
   }
 
   /**
@@ -1247,7 +1370,12 @@ export class BrowserClaw {
    * ```
    */
   async open(url: string): Promise<CrawlPage> {
-    const tab = await createPageViaPlaywright({ cdpUrl: this.cdpUrl, url, ssrfPolicy: this.ssrfPolicy });
+    const tab = await createPageViaPlaywright({
+      cdpUrl: this.cdpUrl,
+      url,
+      ssrfPolicy: this.ssrfPolicy,
+      recordVideo: this.recordVideo,
+    });
     return new CrawlPage(this.cdpUrl, tab.targetId, this.ssrfPolicy);
   }
 
@@ -1317,6 +1445,7 @@ export class BrowserClaw {
    * Playwright connection is closed.
    */
   async stop(): Promise<void> {
+    clearRecordingContext(this.cdpUrl);
     await disconnectBrowser();
     if (this.chrome) {
       await stopChrome(this.chrome);

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -552,6 +552,18 @@ async function fetchChromeVersion(
   }
 }
 
+const COMMON_CDP_PORTS = [9222, 9223, 9224, 9225, 9226, 9229];
+
+export async function discoverChromeCdpUrl(timeoutMs = 500): Promise<string | null> {
+  const results = await Promise.all(
+    COMMON_CDP_PORTS.map(async (port) => {
+      const url = `http://127.0.0.1:${String(port)}`;
+      return (await isChromeReachable(url, timeoutMs)) ? url : null;
+    }),
+  );
+  return results.find((url) => url !== null) ?? null;
+}
+
 export async function isChromeReachable(cdpUrl: string, timeoutMs = 500, authToken?: string): Promise<boolean> {
   if (isWebSocketUrl(cdpUrl)) return await canOpenWebSocket(cdpUrl, timeoutMs);
   const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -349,6 +349,13 @@ export function ensurePageState(page: Page): PageState {
       }
     });
 
+    page.on('dialog', (dialog) => {
+      if (state.armIdDialog > 0) return;
+      dialog.dismiss().catch((err: unknown) => {
+        console.warn(`[browserclaw] Failed to dismiss dialog: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    });
+
     page.on('close', () => {
       pageStates.delete(page);
       observedPages.delete(page);
@@ -367,7 +374,7 @@ function applyStealthToPage(page: Page): void {
   });
 }
 
-function observeContext(context: BrowserContext): void {
+export function observeContext(context: BrowserContext): void {
   if (observedContexts.has(context)) return;
   observedContexts.add(context);
   ensureContextState(context);

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -257,6 +257,17 @@ export function buildRoleSnapshotFromAiSnapshot(
   }
 
   if (options.interactive === true) {
+    let interactiveMaxRef = 0;
+    for (const line of lines) {
+      const refMatch = /\[ref=e(\d+)\]/.exec(line);
+      if (refMatch) interactiveMaxRef = Math.max(interactiveMaxRef, Number.parseInt(refMatch[1], 10));
+    }
+    let interactiveCounter = interactiveMaxRef;
+    const nextInteractiveRef = () => {
+      interactiveCounter++;
+      return `e${String(interactiveCounter)}`;
+    };
+
     const out: string[] = [];
     for (const line of lines) {
       const parsed = matchInteractiveSnapshotLine(line, options);
@@ -264,13 +275,33 @@ export function buildRoleSnapshotFromAiSnapshot(
       const { roleRaw, role, name, suffix } = parsed;
       if (!INTERACTIVE_ROLES.has(role)) continue;
       const ref = parseAiSnapshotRef(suffix);
-      if (ref === null) continue;
       const prefix = /^(\s*-\s*)/.exec(line)?.[1] ?? '';
-      refs[ref] = { role, ...(name !== undefined && name !== '' ? { name } : {}) };
-      out.push(`${prefix}${roleRaw}${name !== undefined && name !== '' ? ` "${name}"` : ''}${suffix}`);
+      if (ref !== null) {
+        refs[ref] = { role, ...(name !== undefined && name !== '' ? { name } : {}) };
+        out.push(`${prefix}${roleRaw}${name !== undefined && name !== '' ? ` "${name}"` : ''}${suffix}`);
+      } else {
+        const generatedRef = nextInteractiveRef();
+        refs[generatedRef] = { role, ...(name !== undefined && name !== '' ? { name } : {}) };
+        let enhanced = `${prefix}${roleRaw}`;
+        if (name !== undefined && name !== '') enhanced += ` "${name}"`;
+        enhanced += ` [ref=${generatedRef}]`;
+        if (suffix.trim() !== '') enhanced += suffix;
+        out.push(enhanced);
+      }
     }
     return { snapshot: out.join('\n') || '(no interactive elements)', refs };
   }
+
+  let maxRef = 0;
+  for (const line of lines) {
+    const refMatch = /\[ref=e(\d+)\]/.exec(line);
+    if (refMatch) maxRef = Math.max(maxRef, Number.parseInt(refMatch[1], 10));
+  }
+  let generatedCounter = maxRef;
+  const nextGeneratedRef = () => {
+    generatedCounter++;
+    return `e${String(generatedCounter)}`;
+  };
 
   const out: string[] = [];
   for (const line of lines) {
@@ -281,7 +312,7 @@ export function buildRoleSnapshotFromAiSnapshot(
       out.push(line);
       continue;
     }
-    const [, , roleRaw, name, suffix] = match;
+    const [, prefix, roleRaw, name, suffix] = match;
     if (roleRaw.startsWith('/')) {
       out.push(line);
       continue;
@@ -290,8 +321,20 @@ export function buildRoleSnapshotFromAiSnapshot(
     const isStructural = STRUCTURAL_ROLES.has(role);
     if (options.compact === true && isStructural && name === '') continue;
     const ref = parseAiSnapshotRef(suffix);
-    if (ref !== null) refs[ref] = { role, ...(name !== '' ? { name } : {}) };
-    out.push(line);
+    if (ref !== null) {
+      refs[ref] = { role, ...(name !== '' ? { name } : {}) };
+      out.push(line);
+    } else if (INTERACTIVE_ROLES.has(role)) {
+      const generatedRef = nextGeneratedRef();
+      refs[generatedRef] = { role, ...(name !== '' ? { name } : {}) };
+      let enhanced = `${prefix}${roleRaw}`;
+      if (name !== '') enhanced += ` "${name}"`;
+      enhanced += ` [ref=${generatedRef}]`;
+      if (suffix.trim() !== '') enhanced += suffix;
+      out.push(enhanced);
+    } else {
+      out.push(line);
+    }
   }
   const tree = out.join('\n') || '(empty)';
   return { snapshot: options.compact === true ? compactTree(tree) : tree, refs };

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,11 @@ export interface LaunchOptions {
    * @deprecated Use `ssrfPolicy: { dangerouslyAllowPrivateNetwork: true }` instead.
    */
   allowInternal?: boolean;
+  /**
+   * Record video for all pages. Requires a directory to save video files.
+   * Videos are saved when the page or context is closed.
+   */
+  recordVideo?: { dir: string; size?: { width: number; height: number } };
 }
 
 /** Options for connecting to an existing browser instance. */
@@ -110,6 +115,11 @@ export interface ConnectOptions {
    * (e.g. OpenClaw browser control with gateway.auth.token).
    */
   authToken?: string;
+  /**
+   * Record video for all pages. Requires a directory to save video files.
+   * Videos are saved when the page or context is closed.
+   */
+  recordVideo?: { dir: string; size?: { width: number; height: number } };
 }
 
 // ── Snapshot ──


### PR DESCRIPTION
Add mouseClick, clickByText, clickByRole, auto-connect, video recording, dialog auto-dismiss, visible-only waitFor, input ref generation

## Changes

- **mouseClick(x, y)** — click at page coordinates for canvas/custom widgets (#2)
- **clickByText / clickByRole** — atomic find-and-click, no snapshot needed, no stale refs (#8)
- **Auto-discovery connect** — `BrowserClaw.connect()` scans common CDP ports (#7)
- **Video recording** — `recordVideo: { dir }` in launch/connect options (#10)
- **Dialog auto-dismiss** — unexpected dialogs dismissed gracefully instead of crashing (#4)
- **Visible-only waitFor** — `waitFor({ text })` uses `innerText` to skip hidden elements (#6)
- **Input ref generation** — interactive elements (radio, checkbox) get refs even when Playwright skips them (#5)
- **Evaluate fallback** — template literals and statement-form code now work via indirect eval fallback (#3)
- **README** — browserclaw.org label, browserclaw.com disclaimer