### PR TITLE
Updates from OpenClaw 2026.3.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/security.ts
+++ b/src/security.ts
@@ -120,7 +120,17 @@ const BLOCKED_IPV4_RANGES = new Set([
   'reserved',
 ]);
 
-const BLOCKED_IPV6_RANGES = new Set(['unspecified', 'loopback', 'linkLocal', 'uniqueLocal', 'multicast']);
+const BLOCKED_IPV6_RANGES = new Set([
+  'unspecified',
+  'loopback',
+  'linkLocal',
+  'uniqueLocal',
+  'multicast',
+  'reserved',
+  'benchmarking',
+  'discard',
+  'orchid2',
+]);
 
 const RFC2544_BENCHMARK_PREFIX: [ipaddr.IPv4, number] = [ipaddr.IPv4.parse('198.18.0.0'), 15];
 

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -36,6 +36,7 @@ export const CONTENT_ROLES = new Set([
 export const STRUCTURAL_ROLES = new Set([
   'generic',
   'group',
+  'ignored',
   'list',
   'table',
   'row',


### PR DESCRIPTION
## Summary
- Add 4 missing IPv6 special-use ranges to `BLOCKED_IPV6_RANGES`: `reserved`, `benchmarking`, `discard`, `orchid2`
- Add missing `ignored` role to `STRUCTURAL_ROLES` in snapshot ref-map
- Register `textbox` in `INTERACTIVE_ROLES` as intentional BC-ahead difference (#37)

## Source
OpenClaw 2026.3.28:
- `ip-Bta3TOaV.js` — `BLOCKED_IPV6_SPECIAL_USE_RANGES` constant
- `auth-profiles-B5ypC5S-.js` — `STRUCTURAL_ROLES` in snapshot-roles region

## Verification
- Typecheck: pass
- Build: pass
- Format: pass
- Manual re-review caught the `STRUCTURAL_ROLES` gap that 6 comparison agents missed