### PR TITLE
Add pressAndHold primitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -58,29 +58,21 @@ export async function pressAndHoldViaCdp(opts: {
   holdMs?: number;
 }): Promise<void> {
   const holdMs = resolveBoundedDelayMs(opts.holdMs ?? 1000, 'holdMs', MAX_HOLD_MS);
-  const page = await getRestoredPageForTarget(opts);
+  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  ensurePageState(page);
+
+  const pos = { x: opts.x, y: opts.y };
+  const btn = { button: 'left' as const, clickCount: 1 };
 
   await withPageScopedCdpClient({
     cdpUrl: opts.cdpUrl,
     page,
     targetId: opts.targetId,
     fn: async (send) => {
-      await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: opts.x, y: opts.y });
-      await send('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: opts.x,
-        y: opts.y,
-        button: 'left',
-        clickCount: 1,
-      });
+      await send('Input.dispatchMouseEvent', { type: 'mouseMoved', ...pos });
+      await send('Input.dispatchMouseEvent', { type: 'mousePressed', ...pos, ...btn });
       await new Promise((r) => setTimeout(r, holdMs));
-      await send('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: opts.x,
-        y: opts.y,
-        button: 'left',
-        clickCount: 1,
-      });
+      await send('Input.dispatchMouseEvent', { type: 'mouseReleased', ...pos, ...btn });
     },
   });
 }

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -14,6 +14,7 @@ import {
   resolveBoundedDelayMs,
   getRestoredPageForTarget,
   parseRoleRef,
+  withPageScopedCdpClient,
 } from '../connection.js';
 import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
 import type { FormField } from '../types.js';
@@ -44,6 +45,43 @@ export async function mouseClickViaPlaywright(opts: {
     button: opts.button,
     clickCount: opts.clickCount,
     delay: opts.delayMs,
+  });
+}
+
+const MAX_HOLD_MS = 30_000;
+
+export async function pressAndHoldViaCdp(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  x: number;
+  y: number;
+  holdMs?: number;
+}): Promise<void> {
+  const holdMs = resolveBoundedDelayMs(opts.holdMs ?? 1000, 'holdMs', MAX_HOLD_MS);
+  const page = await getRestoredPageForTarget(opts);
+
+  await withPageScopedCdpClient({
+    cdpUrl: opts.cdpUrl,
+    page,
+    targetId: opts.targetId,
+    fn: async (send) => {
+      await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: opts.x, y: opts.y });
+      await send('Input.dispatchMouseEvent', {
+        type: 'mousePressed',
+        x: opts.x,
+        y: opts.y,
+        button: 'left',
+        clickCount: 1,
+      });
+      await new Promise((r) => setTimeout(r, holdMs));
+      await send('Input.dispatchMouseEvent', {
+        type: 'mouseReleased',
+        x: opts.x,
+        y: opts.y,
+        button: 'left',
+        clickCount: 1,
+      });
+    },
   });
 }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -17,6 +17,7 @@ import { evaluateViaPlaywright, evaluateInAllFramesViaPlaywright, type FrameEval
 import {
   clickViaPlaywright,
   mouseClickViaPlaywright,
+  pressAndHoldViaCdp,
   clickByTextViaPlaywright,
   clickByRoleViaPlaywright,
   hoverViaPlaywright,
@@ -297,6 +298,32 @@ export class CrawlPage {
       button: opts?.button,
       clickCount: opts?.clickCount,
       delayMs: opts?.delayMs,
+    });
+  }
+
+  /**
+   * Press and hold at page coordinates using raw CDP events.
+   *
+   * Bypasses Playwright's automation layer by dispatching CDP
+   * `Input.dispatchMouseEvent` directly — useful for anti-bot challenges
+   * that detect automated clicks.
+   *
+   * @param x - X coordinate in CSS pixels
+   * @param y - Y coordinate in CSS pixels
+   * @param opts - Options (holdMs: hold duration, default 1000, max 30000)
+   *
+   * @example
+   * ```ts
+   * await page.pressAndHold(400, 300, { holdMs: 5000 });
+   * ```
+   */
+  async pressAndHold(x: number, y: number, opts?: { holdMs?: number }): Promise<void> {
+    return pressAndHoldViaCdp({
+      cdpUrl: this.cdpUrl,
+      targetId: this.targetId,
+      x,
+      y,
+      holdMs: opts?.holdMs,
     });
   }
 


### PR DESCRIPTION
Adds page.pressAndHold(x, y, { holdMs }) which dispatches raw CDP
Input.dispatchMouseEvent (mouseMoved → mousePressed → sleep → mouseReleased),
bypassing Playwright's automation layer. This enables browserclaw.agent's
press_and_hold skill to use a library primitive instead of opening its own
raw CDP WebSocket connections.

https://claude.ai/code/session_01H1LqieAuFNZpZRR6dV2QDm