### PR TITLE
Fix: explicitly bind remote debugging to 127.0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -662,6 +662,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   const spawnChrome = () => {
     const args = [
       `--remote-debugging-port=${String(cdpPort)}`,
+      '--remote-debugging-address=127.0.0.1',
       `--user-data-dir=${userDataDir}`,
       '--no-first-run',
       '--no-default-browser-check',


### PR DESCRIPTION
Without --remote-debugging-address=127.0.0.1, Chrome may bind the
DevTools port to 0.0.0.0 in certain environments (containers, WSL),
exposing it to the network. The code already assumes 127.0.0.1 when
connecting, so this makes the server side match.

https://claude.ai/code/session_01137DmV8MtMK1xk2dgz1x6p