### PR TITLE
Bind CDP to loopback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.2",
+  "version": "0.9.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -662,6 +662,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   const spawnChrome = () => {
     const args = [
       `--remote-debugging-port=${String(cdpPort)}`,
+      '--remote-debugging-address=127.0.0.1',
       `--user-data-dir=${userDataDir}`,
       '--no-first-run',
       '--no-default-browser-check',


### PR DESCRIPTION
## Summary

- Add `--remote-debugging-address=127.0.0.1` to Chrome launch args so the CDP server always binds to loopback, matching the `127.0.0.1` the client uses to connect
- Without this flag, Chrome may bind to a different address (e.g. `::1`, `0.0.0.0`) in certain environments (containers, WSL), causing CDP connection failures
- Bump version to 0.9.2

## Test plan

- [ ] Launch browserclaw in a container/WSL environment and verify CDP connects successfully
- [ ] Launch browserclaw on macOS/Linux desktop and verify no regression
- [ ] Verify `--remote-debugging-address=127.0.0.1` appears in Chrome's process args

https://claude.ai/code/session_01137DmV8MtMK1xk2dgz1x6p