### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,6 +1,7 @@
 import type { Browser, BrowserContext } from 'playwright-core';
 
 import {
+  BrowserTabNotFoundError,
   connectBrowser,
   getPageForTargetId,
   ensurePageState,
@@ -158,7 +159,12 @@ export async function closePageViaPlaywright(opts: { cdpUrl: string; targetId?: 
 }
 
 export async function closePageByTargetIdViaPlaywright(opts: { cdpUrl: string; targetId: string }): Promise<void> {
-  await (await resolvePageByTargetIdOrThrow(opts)).close();
+  try {
+    await (await resolvePageByTargetIdOrThrow(opts)).close();
+  } catch (err) {
+    if (err instanceof BrowserTabNotFoundError) return;
+    throw err;
+  }
 }
 
 export async function focusPageByTargetIdViaPlaywright(opts: { cdpUrl: string; targetId: string }): Promise<void> {


### PR DESCRIPTION
## Summary

- Fix `BrowserTabNotFoundError` thrown when closing a tab that's already gone (race condition, script-initiated close, or navigation)
- Bump version to 0.9.3

## Details

`closePageByTargetIdViaPlaywright` calls `resolvePageByTargetIdOrThrow` which throws `BrowserTabNotFoundError` if the tab was already destroyed. Now catches that error and returns silently instead of propagating.

## Test plan

- [ ] Close a tab that was already closed by a script — should not throw
- [ ] Close a valid tab — should still work normally
- [ ] Verify `browser.stop()` completes without errors

https://claude.ai/code/session_01137DmV8MtMK1xk2dgz1x6p