### PR TITLE
Export pressAndHoldViaCdp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export {
   parseRoleRef,
   BrowserTabNotFoundError,
 } from './connection.js';
+export { pressAndHoldViaCdp } from './actions/interaction.js';
 export type { FrameEvalResult } from './actions/evaluate.js';
 export { batchViaPlaywright, executeSingleAction } from './actions/batch.js';
 export type { BatchAction, BatchActionResult } from './actions/batch.js';


### PR DESCRIPTION
## Summary
- Export `pressAndHoldViaCdp` from package index (was missing from PR #19)
- Bump version to 0.9.4