### PR TITLE
Add pressAndHold primitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.9.0",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.9.0",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.4",
+  "version": "0.9.7",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -48,31 +48,29 @@ export async function mouseClickViaPlaywright(opts: {
   });
 }
 
-const MAX_HOLD_MS = 30_000;
-
 export async function pressAndHoldViaCdp(opts: {
   cdpUrl: string;
   targetId?: string;
   x: number;
   y: number;
+  delay?: number;
   holdMs?: number;
 }): Promise<void> {
-  const holdMs = resolveBoundedDelayMs(opts.holdMs ?? 1000, 'holdMs', MAX_HOLD_MS);
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  const pos = { x: opts.x, y: opts.y };
-  const btn = { button: 'left' as const, clickCount: 1 };
+  const { x, y } = opts;
 
   await withPageScopedCdpClient({
     cdpUrl: opts.cdpUrl,
     page,
     targetId: opts.targetId,
     fn: async (send) => {
-      await send('Input.dispatchMouseEvent', { type: 'mouseMoved', ...pos });
-      await send('Input.dispatchMouseEvent', { type: 'mousePressed', ...pos, ...btn });
-      await new Promise((r) => setTimeout(r, holdMs));
-      await send('Input.dispatchMouseEvent', { type: 'mouseReleased', ...pos, ...btn });
+      await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+      if (opts.delay !== undefined && opts.delay !== 0) await new Promise((r) => setTimeout(r, opts.delay));
+      await send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1 });
+      if (opts.holdMs !== undefined && opts.holdMs !== 0) await new Promise((r) => setTimeout(r, opts.holdMs));
+      await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 });
     },
   });
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -310,19 +310,20 @@ export class CrawlPage {
    *
    * @param x - X coordinate in CSS pixels
    * @param y - Y coordinate in CSS pixels
-   * @param opts - Options (holdMs: hold duration, default 1000, max 30000)
+   * @param opts - Options (delay: ms before press, holdMs: hold duration)
    *
    * @example
    * ```ts
-   * await page.pressAndHold(400, 300, { holdMs: 5000 });
+   * await page.pressAndHold(400, 300, { delay: 150, holdMs: 5000 });
    * ```
    */
-  async pressAndHold(x: number, y: number, opts?: { holdMs?: number }): Promise<void> {
+  async pressAndHold(x: number, y: number, opts?: { delay?: number; holdMs?: number }): Promise<void> {
     return pressAndHoldViaCdp({
       cdpUrl: this.cdpUrl,
       targetId: this.targetId,
       x,
       y,
+      delay: opts?.delay,
       holdMs: opts?.holdMs,
     });
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -60,7 +60,13 @@ function appendCdpPath(cdpUrl: string, cdpPath: string): string {
  * Run a function with a scoped Playwright CDP session, detaching when done.
  */
 export async function withPlaywrightPageCdpSession<T>(page: Page, fn: (session: CDPSession) => Promise<T>): Promise<T> {
-  const session = await page.context().newCDPSession(page);
+  const CDP_SESSION_TIMEOUT_MS = 10_000;
+  const session = await Promise.race([
+    page.context().newCDPSession(page),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('newCDPSession timed out after 10s')), CDP_SESSION_TIMEOUT_MS),
+    ),
+  ]);
   try {
     return await fn(session);
   } finally {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -63,9 +63,11 @@ export async function withPlaywrightPageCdpSession<T>(page: Page, fn: (session: 
   const CDP_SESSION_TIMEOUT_MS = 10_000;
   const session = await Promise.race([
     page.context().newCDPSession(page),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('newCDPSession timed out after 10s')), CDP_SESSION_TIMEOUT_MS),
-    ),
+    new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error('newCDPSession timed out after 10s'));
+      }, CDP_SESSION_TIMEOUT_MS);
+    }),
   ]);
   try {
     return await fn(session);


### PR DESCRIPTION
## Summary
- Match `pressAndHoldViaCdp` CDP events to agent's tested `cdpClick` implementation: `button: 'none'` on mouseMoved, optional pre-press delay
- Add 10s timeout to `withPlaywrightPageCdpSession` to prevent indefinite hang when `newCDPSession()` blocks
- Bump to 0.9.7