### PR TITLE
Bug fixes from agent feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -23,6 +23,7 @@ type MouseButton = 'left' | 'right' | 'middle';
 type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
 
 const MAX_CLICK_DELAY_MS = 5000;
+const DEFAULT_SCROLL_TIMEOUT_MS = 20_000;
 const CHECKABLE_ROLES = new Set(['menuitemcheckbox', 'menuitemradio', 'checkbox', 'switch']);
 
 function resolveLocator(page: Page, resolved: { ref?: string; selector?: string }) {
@@ -86,10 +87,12 @@ export async function clickByTextViaPlaywright(opts: {
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  const locator = page
+    .getByText(opts.text, { exact: opts.exact })
+    .or(page.getByTitle(opts.text, { exact: opts.exact }))
+    .first();
   try {
-    await page
-      .getByText(opts.text, { exact: opts.exact })
-      .click({ timeout, button: opts.button, modifiers: opts.modifiers });
+    await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
   } catch (err) {
     throw toAIFriendlyError(err, `text="${opts.text}"`);
   }
@@ -100,21 +103,21 @@ export async function clickByRoleViaPlaywright(opts: {
   targetId?: string;
   role: string;
   name?: string;
+  index?: number;
   button?: MouseButton;
   modifiers?: KeyModifier[];
   timeoutMs?: number;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  const label = `role=${opts.role}${opts.name !== undefined && opts.name !== '' ? ` name="${opts.name}"` : ''}`;
+  const locator = page
+    .getByRole(opts.role as Parameters<typeof page.getByRole>[0], { name: opts.name })
+    .nth(opts.index ?? 0);
   try {
-    await page
-      .getByRole(opts.role as Parameters<typeof page.getByRole>[0], { name: opts.name })
-      .click({ timeout, button: opts.button, modifiers: opts.modifiers });
+    await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
   } catch (err) {
-    throw toAIFriendlyError(
-      err,
-      `role=${opts.role}${opts.name !== undefined && opts.name !== '' ? ` name="${opts.name}"` : ''}`,
-    );
+    throw toAIFriendlyError(err, label);
   }
 }
 
@@ -128,6 +131,7 @@ export async function clickViaPlaywright(opts: {
   modifiers?: KeyModifier[];
   delayMs?: number;
   timeoutMs?: number;
+  force?: boolean;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -149,7 +153,7 @@ export async function clickViaPlaywright(opts: {
   try {
     const delayMs = resolveBoundedDelayMs(opts.delayMs, 'click delayMs', MAX_CLICK_DELAY_MS);
     if (delayMs > 0) {
-      await locator.hover({ timeout });
+      await locator.hover({ timeout, force: opts.force });
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
 
@@ -160,9 +164,9 @@ export async function clickViaPlaywright(opts: {
     }
 
     if (opts.doubleClick === true) {
-      await locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers });
+      await locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
     } else {
-      await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
+      await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
     }
 
     // If this is a checkable role and aria-checked didn't change, fall back to JS click.
@@ -315,7 +319,7 @@ export async function fillFormViaPlaywright(opts: {
     if (type === 'checkbox' || type === 'radio') {
       const checked = rawValue === true || rawValue === 1 || rawValue === '1' || rawValue === 'true';
       try {
-        await locator.setChecked(checked, { timeout });
+        await locator.setChecked(checked, { timeout, force: true });
       } catch (err) {
         throw toAIFriendlyError(err, ref);
       }
@@ -343,7 +347,13 @@ export async function scrollIntoViewViaPlaywright(opts: {
   const locator = resolveLocator(page, resolved);
 
   try {
-    await locator.scrollIntoViewIfNeeded({ timeout: normalizeTimeoutMs(opts.timeoutMs, 20000) });
+    await locator.waitFor({
+      state: 'attached',
+      timeout: normalizeTimeoutMs(opts.timeoutMs, DEFAULT_SCROLL_TIMEOUT_MS),
+    });
+    await locator.evaluate((el: Element) => {
+      el.scrollIntoView({ block: 'center', behavior: 'instant' });
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -18,7 +18,7 @@ export async function waitForViaPlaywright(opts: {
   selector?: string;
   url?: string;
   loadState?: 'load' | 'domcontentloaded' | 'networkidle';
-  fn?: string;
+  fn?: string | (() => unknown);
   timeoutMs?: number;
 }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
@@ -47,8 +47,12 @@ export async function waitForViaPlaywright(opts: {
   if (opts.loadState !== undefined) {
     await page.waitForLoadState(opts.loadState, { timeout });
   }
-  if (opts.fn !== undefined && opts.fn !== '') {
-    const fn = opts.fn.trim();
-    if (fn !== '') await page.waitForFunction(fn, undefined, { timeout });
+  if (opts.fn !== undefined) {
+    if (typeof opts.fn === 'function') {
+      await page.waitForFunction(opts.fn, undefined, { timeout });
+    } else {
+      const fn = opts.fn.trim();
+      if (fn !== '') await page.waitForFunction(fn, undefined, { timeout });
+    }
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -239,6 +239,7 @@ export class CrawlPage {
       modifiers: opts?.modifiers,
       delayMs: opts?.delayMs,
       timeoutMs: opts?.timeoutMs,
+      force: opts?.force,
     });
   }
 
@@ -266,6 +267,7 @@ export class CrawlPage {
       modifiers: opts?.modifiers,
       delayMs: opts?.delayMs,
       timeoutMs: opts?.timeoutMs,
+      force: opts?.force,
     });
   }
 
@@ -382,6 +384,7 @@ export class CrawlPage {
     role: string,
     name?: string,
     opts?: {
+      index?: number;
       button?: 'left' | 'right' | 'middle';
       modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[];
       timeoutMs?: number;
@@ -392,6 +395,7 @@ export class CrawlPage {
       targetId: this.targetId,
       role,
       name,
+      index: opts?.index,
       button: opts?.button,
       modifiers: opts?.modifiers,
       timeoutMs: opts?.timeoutMs,

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -681,6 +681,9 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     if (opts.noSandbox === true) {
       args.push('--no-sandbox', '--disable-setuid-sandbox');
     }
+    if (opts.ignoreHTTPSErrors === true) {
+      args.push('--ignore-certificate-errors');
+    }
     if (process.platform === 'linux') args.push('--disable-dev-shm-usage');
     const extraArgs = Array.isArray(opts.chromeArgs)
       ? opts.chromeArgs.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -986,7 +986,18 @@ export function toAIFriendlyError(error: unknown, selector: string): Error {
       `Element "${selector}" is not interactable (hidden or covered). Try scrolling it into view, closing overlays, or re-snapshotting.`,
     );
   }
-  return error instanceof Error ? error : new Error(message);
+  const timeoutMatch = /Timeout (\d+)ms exceeded/.exec(message);
+  if (timeoutMatch) {
+    return new Error(
+      `Element "${selector}" timed out after ${timeoutMatch[1]}ms — element may be hidden or not interactable. Run a new snapshot to see current page elements.`,
+    );
+  }
+  // Strip Playwright locator internals so AI agents don't see implementation details
+  const cleaned = message
+    .replace(/locator\([^)]*\)\./g, '')
+    .replace(/waiting for locator\([^)]*\)/g, '')
+    .trim();
+  return new Error(cleaned || message);
 }
 
 export function normalizeTimeoutMs(timeoutMs: number | undefined, fallback: number, maxMs = 120000): number {

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -1,4 +1,12 @@
-import type { RoleRefs } from '../types.js';
+import type { RoleRefInfo, RoleRefs } from '../types.js';
+
+function parseStateFromSuffix(suffix: string): Pick<RoleRefInfo, 'disabled' | 'checked'> {
+  const state: Pick<RoleRefInfo, 'disabled' | 'checked'> = {};
+  if (/\[disabled\]/i.test(suffix)) state.disabled = true;
+  if (/\[checked\s*=\s*"?mixed"?\]/i.test(suffix)) state.checked = 'mixed';
+  else if (/\[checked\]/i.test(suffix)) state.checked = true;
+  return state;
+}
 
 export const INTERACTIVE_ROLES = new Set([
   'button',
@@ -188,7 +196,8 @@ export function buildRoleSnapshotFromAriaSnapshot(
       const ref = nextRef();
       const nth = tracker.getNextIndex(role, name);
       tracker.trackRef(role, name, ref);
-      refs[ref] = { role, name, nth };
+      const state = parseStateFromSuffix(suffix);
+      refs[ref] = { role, name, nth, ...state };
       let enhanced = `${prefix}${roleRaw}`;
       if (name !== undefined && name !== '') enhanced += ` "${name}"`;
       enhanced += ` [ref=${ref}]`;
@@ -227,7 +236,8 @@ export function buildRoleSnapshotFromAriaSnapshot(
     const ref = nextRef();
     const nth = tracker.getNextIndex(role, name);
     tracker.trackRef(role, name, ref);
-    refs[ref] = { role, name, nth };
+    const state = parseStateFromSuffix(suffix);
+    refs[ref] = { role, name, nth, ...state };
 
     let enhanced = `${prefix}${roleRaw}`;
     if (name !== '') enhanced += ` "${name}"`;
@@ -277,12 +287,13 @@ export function buildRoleSnapshotFromAiSnapshot(
       if (!INTERACTIVE_ROLES.has(role)) continue;
       const ref = parseAiSnapshotRef(suffix);
       const prefix = /^(\s*-\s*)/.exec(line)?.[1] ?? '';
+      const state = parseStateFromSuffix(suffix);
       if (ref !== null) {
-        refs[ref] = { role, ...(name !== undefined && name !== '' ? { name } : {}) };
+        refs[ref] = { role, ...(name !== undefined && name !== '' ? { name } : {}), ...state };
         out.push(`${prefix}${roleRaw}${name !== undefined && name !== '' ? ` "${name}"` : ''}${suffix}`);
       } else {
         const generatedRef = nextInteractiveRef();
-        refs[generatedRef] = { role, ...(name !== undefined && name !== '' ? { name } : {}) };
+        refs[generatedRef] = { role, ...(name !== undefined && name !== '' ? { name } : {}), ...state };
         let enhanced = `${prefix}${roleRaw}`;
         if (name !== undefined && name !== '') enhanced += ` "${name}"`;
         enhanced += ` [ref=${generatedRef}]`;
@@ -322,12 +333,13 @@ export function buildRoleSnapshotFromAiSnapshot(
     const isStructural = STRUCTURAL_ROLES.has(role);
     if (options.compact === true && isStructural && name === '') continue;
     const ref = parseAiSnapshotRef(suffix);
+    const state = parseStateFromSuffix(suffix);
     if (ref !== null) {
-      refs[ref] = { role, ...(name !== '' ? { name } : {}) };
+      refs[ref] = { role, ...(name !== '' ? { name } : {}), ...state };
       out.push(line);
     } else if (INTERACTIVE_ROLES.has(role)) {
       const generatedRef = nextGeneratedRef();
-      refs[generatedRef] = { role, ...(name !== '' ? { name } : {}) };
+      refs[generatedRef] = { role, ...(name !== '' ? { name } : {}), ...state };
       let enhanced = `${prefix}${roleRaw}`;
       if (name !== '') enhanced += ` "${name}"`;
       enhanced += ` [ref=${generatedRef}]`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,8 @@ export interface LaunchOptions {
   profileColor?: string;
   /** Additional Chrome command-line arguments (e.g. `['--start-maximized']`). */
   chromeArgs?: string[];
+  /** Ignore HTTPS certificate errors (e.g. expired local dev certs). Default: `false` */
+  ignoreHTTPSErrors?: boolean;
   /**
    * SSRF policy controlling which URLs navigation is allowed to reach.
    * Defaults to trusted-network mode (private/internal addresses allowed).
@@ -135,6 +137,10 @@ export interface RoleRefInfo {
   name?: string;
   /** Disambiguation index when multiple elements share the same role + name */
   nth?: number;
+  /** Whether the element is disabled (from `[disabled]` or `aria-disabled`) */
+  disabled?: boolean;
+  /** Whether a checkbox/radio/switch is checked */
+  checked?: boolean | 'mixed';
 }
 
 /** Map of ref IDs (e.g. `'e1'`, `'e2'`) to their element information. */
@@ -272,6 +278,8 @@ export interface ClickOptions {
   delayMs?: number;
   /** Timeout in milliseconds. Default: `8000` */
   timeoutMs?: number;
+  /** Force click even if element is hidden or covered. Dispatches the event regardless of visibility. */
+  force?: boolean;
 }
 
 /** Options for type actions. */
@@ -301,8 +309,8 @@ export interface WaitOptions {
   url?: string;
   /** Wait for a specific page load state */
   loadState?: 'load' | 'domcontentloaded' | 'networkidle';
-  /** Wait until a JavaScript function returns truthy (evaluated in browser context) */
-  fn?: string;
+  /** Wait until a JavaScript function returns truthy (evaluated in browser context). Accepts a string or a serializable function. */
+  fn?: string | (() => unknown);
   /** Timeout for each condition in milliseconds. Default: `20000` */
   timeoutMs?: number;
 }


### PR DESCRIPTION
## Summary
- `clickByText` matches `title` attributes (`.or(getByTitle)`)
- `clickByRole` clicks first match instead of throwing on ambiguity (`.nth(index ?? 0)`)
- `click(ref)` supports `force: true` for hidden/covered elements
- `fill()` radio/checkbox uses `force: true` on `setChecked` for hidden inputs
- `scrollIntoView` uses native `Element.scrollIntoView()` — works inside scrollable containers
- `waitFor({ fn })` accepts functions, not just strings
- `ignoreHTTPSErrors` launch option (`--ignore-certificate-errors`)
- Error messages strip Playwright locator internals for AI agent clarity
- Snapshot refs include `disabled` and `checked` state metadata

## Version
0.10.0