### PR TITLE
Fix clickByText and waitFor regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -89,6 +89,7 @@ export async function clickByTextViaPlaywright(opts: {
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   const locator = page
     .getByText(opts.text, { exact: opts.exact })
+    .and(page.locator(':visible'))
     .or(page.getByTitle(opts.text, { exact: opts.exact }))
     .first();
   try {

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -49,7 +49,7 @@ export async function waitForViaPlaywright(opts: {
   }
   if (opts.fn !== undefined) {
     if (typeof opts.fn === 'function') {
-      await page.waitForFunction(opts.fn, undefined, { timeout });
+      await page.waitForFunction(opts.fn, { timeout });
     } else {
       const fn = opts.fn.trim();
       if (fn !== '') await page.waitForFunction(fn, undefined, { timeout });


### PR DESCRIPTION
## Summary
Fixes two regressions reported against 0.10.0:

- **`clickByText` title matching** — `.or()` with `.first()` was picking hidden text elements over visible title elements. Fixed by filtering text matches to `:visible` first: `getByText().and(:visible).or(getByTitle()).first()`
- **`waitFor({ fn })` function form** — Playwright's `waitForFunction` has two overloads. Functions use `(fn, options)`, strings use `(fn, arg, options)`. We were passing `(fn, undefined, { timeout })` for both — the `undefined` was swallowing the options for function calls.

## Version
0.10.1