### PR TITLE
Add radio to checkable roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -24,7 +24,7 @@ type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
 
 const MAX_CLICK_DELAY_MS = 5000;
 const DEFAULT_SCROLL_TIMEOUT_MS = 20_000;
-const CHECKABLE_ROLES = new Set(['menuitemcheckbox', 'menuitemradio', 'checkbox', 'switch']);
+const CHECKABLE_ROLES = new Set(['menuitemcheckbox', 'menuitemradio', 'checkbox', 'radio', 'switch']);
 
 /**
  * Fallback for setChecked on hidden styled inputs (opacity:0, position:absolute).


### PR DESCRIPTION
## Summary

- `radio` was missing from `CHECKABLE_ROLES`, so `click()` didn't apply checkable-element handling (aria-checked polling + JS fallback) for radio inputs
- Bumps to 0.10.4

## Test plan

- [ ] `click(ref, { force: true })` works on hidden styled radio inputs
- [ ] `fill([{ ref, type: 'radio', value: true }])` works on hidden styled radio inputs