### PR TITLE
Add browserclaw interactive browsing skill

### DIFF
--- a/.claude/commands/openclaw-sync.md
+++ b/.claude/commands/openclaw-sync.md
@@ -1,0 +1,221 @@
+# OpenClaw Sync
+
+Sync browserclaw with the latest OpenClaw browser SDK changes. Creates a PR with a single commit.
+
+## Source of Truth
+
+OpenClaw's bundled JS files — NOT the changelog:
+- `pw-ai-*.js` — all browser action functions
+- `ssrf-*.js` — SSRF/IP security
+- `client-fetch-*.js` — connection, chrome launcher, navigation guards (previously `routes-*.js`, before that `thread-bindings-*.js`)
+
+Locate them by grepping for known functions:
+```
+OC_DIST=$(npm root -g)/openclaw/dist
+grep -rl 'clickViaPlaywright' "$OC_DIST" --include='*.js' | grep -v node_modules | grep -v plugin-sdk
+grep -rl 'isBlockedSpecialUseIpv6Address' "$OC_DIST" --include='*.js' | grep -v node_modules | grep -v plugin-sdk
+grep -rl 'isChromeReachable' "$OC_DIST" --include='*.js' | grep -v node_modules | grep -v plugin-sdk
+```
+Bundle filenames contain hashes that change between versions. Never hardcode them.
+
+## Known Differences Registry
+
+`sync/known-differences.md` tracks every intentional divergence. If a difference isn't in that file, it's a bug that needs porting.
+
+## Function Map
+
+`sync/function-map.md` maps every browserclaw function to its OpenClaw source. Update it if new functions appear.
+
+## Process
+
+### Phase 1: Discovery
+
+1. Check installed OpenClaw version: `npm list -g openclaw --depth=0`
+2. Locate the 3 bundle files (filenames contain hashes that change between versions)
+3. Read the changelog for context — but DO NOT rely on it as complete
+
+### Phase 2: Deterministic Inventory
+
+Before any agent-based comparison, build a complete mechanical inventory of what's in each OC bundle. This step is fully deterministic — no agent judgment involved.
+
+**Step 2a: Region extraction.** OC bundles contain `//#region src/...` and `//#endregion` markers. Extract all region names and line ranges from each bundle file:
+```bash
+grep -n '#region\|#endregion' "$BUNDLE_FILE"
+```
+Record every region and which bundle it lives in. OC restructures bundles between releases — code that was in one bundle last sync may have moved.
+
+**Step 2b: Export extraction.** Each bundle ends with an export line mapping internal names to exported names. Extract all exported symbols:
+```bash
+tail -5 "$BUNDLE_FILE" | grep 'export {'
+```
+
+**Step 2c: Function extraction.** Extract all `function functionName(` definitions from each bundle. This catches internal helpers that aren't exported:
+```bash
+grep -n 'function [a-zA-Z_][a-zA-Z0-9_]*(' "$BUNDLE_FILE"
+```
+
+**Step 2d: Cross-reference against browserclaw.** For every exported symbol AND every function name in the function map (`sync/function-map.md`), verify it exists in browserclaw's source files. Flag any OC function not found in browserclaw for investigation.
+
+**Step 2e: Discover new bundles.** Search ALL `.js` files in the OC dist directory for browserclaw-relevant function names (every function in `sync/function-map.md`). Flag any matches in bundles not previously known — OC moves code between bundles regularly.
+
+**Gate:** Complete inventory of all OC regions, exports, and functions. Every item mapped to a browserclaw file or flagged as "new/moved."
+
+### Phase 2f: Agent Comparison (3 parallel workstreams)
+
+Using the inventory from 2a-2e, run 3 parallel comparison workstreams. Each workstream receives the specific regions and line ranges it needs to compare — NOT "read the whole file and find things."
+
+**Chunking large files:** OC bundle files can be 3000+ lines. Agents miss things in large reads. When passing bundle content to a workstream agent, break it into chunks using the region markers from 2a. Each agent should read one region at a time (using line offsets), compare it against the corresponding browserclaw code, then move to the next region. Never ask an agent to "read the entire bundle" — always specify line ranges.
+
+**Workstream A: Security**
+- Read specific OC regions identified in 2a that map to `src/security.ts` (by line range)
+- Also read any OC bundle regions containing navigation guard functions (by line range)
+- Read browserclaw's `src/security.ts`
+- Compare every function, constant, IP range, hostname set
+
+**Workstream B: Browser Actions**
+- Read specific OC regions identified in 2a that map to action/capture/storage/snapshot (by line range)
+- Read ALL browserclaw action/capture/storage/snapshot files
+- Compare every `*ViaPlaywright` function and internal helpers
+
+**Workstream C: Connection & Chrome Launcher**
+- Read specific OC regions identified in 2a that map to connection/chrome-launcher (by line range)
+- Read browserclaw's `src/connection.ts` and `src/chrome-launcher.ts`
+- Compare every function
+
+Each workstream categorizes every difference as:
+- **In registry** — known intentional difference in `sync/known-differences.md`, skip
+- **New gap** — needs porting
+- **New function** — needs evaluation (port or add to registry as "not applicable")
+- **Browserclaw ahead** — browserclaw has something OpenClaw doesn't, keep
+
+**Evidence requirement for "New gap":** Every gap MUST include:
+1. The exact OpenClaw code (copy-pasted from the bundle, not paraphrased)
+2. The exact browserclaw code
+3. A clear description of what changed in OpenClaw
+
+If you cannot copy-paste the OpenClaw code that proves the gap exists, it is NOT a gap. Do not invent or infer changes — only report what you can see verbatim in the bundle files.
+
+**Per-function known-differences check:** For every function that has ANY difference (not just "New gap"), look up that function name in `sync/known-differences.md`. If it has an entry marked "Browserclaw ahead", "Browserclaw Additions", or any intentional divergence, that function's browserclaw code must be preserved — even if OpenClaw changed other parts of the same function. Log which functions were protected by this check.
+
+**Gate:** All 3 workstreams complete. Every difference categorized. Zero uncategorized items.
+
+### Phase 2g: Coverage Verification
+
+After workstreams complete, verify completeness:
+
+1. **Export coverage check:** Take the export list from 2b. For every exported symbol that maps to a browserclaw function, verify the workstreams compared it. Any symbol NOT mentioned in a workstream report is a coverage gap — investigate it directly.
+
+2. **New-function check:** Take the function list from 2c. Cross-reference against `sync/function-map.md`. Any function not in the map and not in a workstream report needs investigation.
+
+3. **Moved-code check:** Take the results from 2e. If any browserclaw-relevant function appeared in an unexpected bundle, verify the workstreams found it there.
+
+**Gate:** 100% of OC exports and mapped functions were covered by a workstream. Zero uncovered items.
+
+### Phase 3: Port Changes
+
+For each "New gap" and applicable "New function":
+
+**Provenance verification (MANDATORY before any edit):**
+For every gap you are about to port, re-read the specific function directly from the OpenClaw bundle file yourself. Do NOT rely on the workstream agent's report alone. Confirm with your own eyes that the OpenClaw code differs from browserclaw in the way the workstream described. If you cannot find the claimed difference in the actual bundle file, the gap is fabricated — discard it and move on.
+
+**Before touching any function, do the per-function known-differences check:**
+1. Search `sync/known-differences.md` for the function name
+2. If the function has an entry:
+   - **"Browserclaw ahead"** or **"Browserclaw Additions"** — DO NOT port OpenClaw's version of that code. The browserclaw implementation is intentionally better/newer. Preserve it exactly as-is, even if OpenClaw changed the surrounding function.
+   - **Other intentional divergence** — preserve the browserclaw side of the divergence. Only port parts of the function that are unrelated to the registered difference.
+3. If the function has NO entry, port the change normally
+
+**When porting:**
+- Never change a public function's return type or shape. If OpenClaw changed a return type, do NOT port that change — flag it for explicit user approval instead.
+- Never introduce OpenClaw branding. Any `openclaw` in data attributes (e.g. `data-openclaw-*`), CSS class names, IDs, or user-visible strings must be changed to `browserclaw` when porting.
+- If a new intentional difference is created, add it to `sync/known-differences.md` with reason
+
+**Gate:** All changes ported. `npm run typecheck` and `npm run build` pass.
+
+### Phase 4: Two Clean Passes
+
+The sync is not complete until TWO independent clean passes confirm zero unregistered gaps. Agent comparison is non-deterministic — a single pass can miss things. Two consecutive clean passes provide confidence.
+
+**Pass 1:** Re-run Phase 2 comparison (full deterministic inventory + agent workstreams) on the modified files. Every remaining difference must be in the known-differences registry. If there's an unregistered difference, port it or add it to the registry with justification, then restart Pass 1.
+
+**Pass 2:** Run a THIRD comparison with fresh agents (not continuations of previous agents). These agents must not see the results of Pass 1 — they start from scratch. If Pass 2 finds anything Pass 1 missed, port it, then restart from Pass 1.
+
+Only when both passes return zero unregistered gaps does the sync proceed to Phase 5.
+
+**Gate:** Two consecutive clean passes with zero unregistered differences.
+
+### Phase 5: Record & PR
+
+1. Update `sync/function-map.md` if new functions appeared
+2. Update `sync/known-differences.md` if new intentional differences added
+3. If no changes were needed, report "No changes needed" and stop
+4. If changes were made:
+   - Create branch: `sync/openclaw-YYYY.M.DD` (use the OpenClaw **release version date**, not today's date)
+   - Single commit: `Updates from OpenClaw YYYY.M.DD`
+   - Create PR with title: `Updates from OpenClaw YYYY.M.DD`
+   - PR body: summary of what changed
+
+## Phase 6: Self-Improvement
+
+After every sync run (whether changes were needed or not):
+
+### 1. Log the run
+Append an entry to `sync/run-log.md`:
+
+```
+## YYYY.M.DD — OpenClaw X.Y.Z
+
+**Result:** [Changes ported / No changes needed]
+**Gaps found:** [count and summary]
+**What went well:** [e.g., "workstream parallelization caught a missed constant"]
+**What was hard/slow:** [e.g., "thread-bindings search took 3 attempts to find the right region"]
+**False positives:** [differences flagged as gaps that turned out to be intentional]
+**Action taken:** [what was changed in the process files below]
+```
+
+### 2. Review and update the process
+Read `sync/run-log.md` for recurring patterns across runs. Then make changes:
+
+- **This skill file** (`.claude/commands/sync.md`) — if a phase was slow, unclear, or produced false positives, rewrite it. If a new step is needed, add it. If a step is wasteful, remove it.
+- **`sync/known-differences.md`** — if a false positive keeps appearing, add it to the registry so it's never flagged again. If a known difference is no longer valid, remove it.
+- **`sync/function-map.md`** — if functions were hard to find, add region line numbers or better search hints.
+
+### 3. Validate the changes
+Re-read the updated files and confirm they're internally consistent. Don't leave stale references.
+
+The goal: every run should make the next run faster and more accurate. If the same problem appears twice, the process has a bug.
+
+## Critical Rules
+
+- **Single commit, always.** Every sync PR must have exactly ONE commit. Never split changes across multiple commits. Stage everything, commit once: `Updates from OpenClaw YYYY.M.DD`
+- PR title = commit message
+- No Co-Authored-By, no AI mentions
+- Never publish to npm
+- If zero gaps found, just say "No changes needed" — don't create empty PRs
+- **Never revert "Browserclaw ahead" items.** If `sync/known-differences.md` says browserclaw's version is better/newer/correct (entries #7, #16, #17, #28-#36, and any in the "Browserclaw Additions" section), that code is OFF LIMITS. Do not replace it with OpenClaw's version under any circumstances. Do not remove functions, methods, or features that exist only in browserclaw.
+- **Never change public API return types.** If OpenClaw changed the return shape of a function that browserclaw exports, do NOT port that change. Flag it for user approval.
+- **No OpenClaw branding in browserclaw.** When porting code, replace any `openclaw` references in data attributes, class names, IDs, or user-visible strings with `browserclaw`.
+- **Never fabricate changes.** Every change you port MUST exist verbatim in the OpenClaw bundle files. If you cannot point to the exact line in the bundle that differs from browserclaw, the change does not exist. Do not invent improvements, fixes, or features and attribute them to OpenClaw. When in doubt, report "No changes needed" rather than guessing.
+
+## browserclaw Source Files
+
+- `src/security.ts` — SSRF, IP parsing, navigation guards, file safety
+- `src/connection.ts` — CDP connection, page state, ref storage
+- `src/chrome-launcher.ts` — Chrome detection, launch, CDP utilities
+- `src/actions/interaction.ts` — click, hover, type, drag, select, scroll, highlight, file upload
+- `src/actions/navigation.ts` — navigate, create/close/focus pages, resize
+- `src/actions/download.ts` — download with cancellable waiter
+- `src/actions/wait.ts` — wait conditions
+- `src/actions/evaluate.ts` — JS evaluation with timeout
+- `src/actions/emulation.ts` — device, locale, timezone, headers, geo, credentials
+- `src/actions/keyboard.ts` — key press
+- `src/capture/screenshot.ts` — screenshot with labels
+- `src/capture/trace.ts` — trace start/stop
+- `src/capture/response.ts` — response body interception
+- `src/capture/pdf.ts` — PDF generation
+- `src/capture/activity.ts` — console, errors, network
+- `src/snapshot/aria-snapshot.ts` — ARIA tree snapshot
+- `src/snapshot/ai-snapshot.ts` — AI snapshot
+- `src/snapshot/ref-map.ts` — ref building
+- `src/storage/index.ts` — cookies, storage
+- `src/types.ts` — type definitions

--- a/.claude/skills/browserclaw/SKILL.md
+++ b/.claude/skills/browserclaw/SKILL.md
@@ -13,7 +13,8 @@ You are operating a real browser. You can see pages through `snapshot()` and act
 import { BrowserClaw } from 'browserclaw';
 
 const browser = await BrowserClaw.launch({ headless: false });
-const page = await browser.open('https://example.com');
+const page = await browser.currentPage();  // reuse the existing tab Chrome opened
+await page.goto('https://example.com');    // don't use browser.open() — it opens a duplicate tab
 // or connect to existing: await BrowserClaw.connect('http://localhost:9222')
 ```
 
@@ -206,12 +207,15 @@ await page.waitFor({ timeMs: 2000 });                       // fixed delay (last
 ```typescript
 const tabs = await browser.tabs();  // list all tabs: [{ targetId, title, url }]
 
+// Open a new tab explicitly (only when you actually want a second tab)
 const page2 = await browser.open('https://other.example.com');
 // ... work on page2 ...
 
 await browser.focus(page.id);       // switch back to first tab
 await browser.close(page2.id);      // close a tab
 ```
+
+For tab lifecycle management in production (detecting new tabs opened by clicks, switching automatically), see [`tab-manager.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/tab-manager.ts).
 
 ---
 
@@ -260,6 +264,24 @@ const errors = await page.pageErrors();         // JS errors
 const logs = await page.consoleLogs();          // console.log output
 const requests = await page.networkRequests();  // XHR/fetch calls
 ```
+
+---
+
+## Production Skill Reference
+
+**Don't reinvent — reuse.** The browserclaw-agent repo contains battle-tested implementations for the hard problems. When you hit any of the scenarios below, read the relevant file before writing your own solution.
+
+All skills live at: https://github.com/idan-rubin/browserclaw-agent/tree/main/src/Services/Browser/src/skills
+
+| Scenario | File | What it handles |
+|---|---|---|
+| PerimeterX / "press and hold" challenge | [`press-and-hold.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/press-and-hold.ts) | Finds button at bottom-center +60px, holds 4–10s with randomized jitter and delay, refreshes and retries if still blocked |
+| Cloudflare "Verify you are human" checkbox | [`cloudflare-checkbox.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/cloudflare-checkbox.ts) | Locates the Cloudflare iframe checkbox and clicks it via CDP |
+| Cookie banners and generic popups | [`dismiss-popup.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/dismiss-popup.ts) | Detects and dismisses common cookie consent banners and modal overlays |
+| Tab opened by a click | [`tab-manager.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/tab-manager.ts) | Tracks known tab IDs, detects new tabs after clicks, switches focus automatically |
+| Agent stuck repeating the same action | [`loop-detection.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/loop-detection.ts) | Counts repeated action+ref pairs over a sliding window; escalates nudge from gentle → warning → urgent at 5/8/12 repetitions |
+
+**If you encounter an anti-bot challenge, popup, or tab management need: read the relevant file above first.** These are production implementations that handle edge cases you'll otherwise spend hours debugging.
 
 ---
 

--- a/.claude/skills/browserclaw/SKILL.md
+++ b/.claude/skills/browserclaw/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: browserclaw
+description: Browse websites interactively using the browserclaw library — launch, navigate, snapshot, interact, extract
+---
+
+# Browserclaw Interactive Browsing
+
+You are operating a real browser. You can see pages through `snapshot()` and act on them with `click()`, `type()`, `select()`, etc. Work step by step. Every action changes the page — re-snapshot to see what happened before acting again.
+
+## Setup
+
+```typescript
+import { BrowserClaw } from 'browserclaw';
+
+const browser = await BrowserClaw.launch({ headless: false });
+const page = await browser.open('https://example.com');
+// or connect to existing: await BrowserClaw.connect('http://localhost:9222')
+```
+
+When done: `await browser.stop()`
+
+---
+
+## The Core Loop
+
+**Perceive → Reason → Act → Repeat**
+
+```
+snapshot() → read the tree → decide what to do → click/type/etc → snapshot() again
+```
+
+Never assume an action worked. Always re-snapshot to confirm the page changed as expected.
+
+---
+
+## Snapshot — Your Eyes
+
+```typescript
+const { snapshot, refs } = await page.snapshot({ interactive: true, compact: true });
+```
+
+Always use `{ interactive: true, compact: true }`. This filters to actionable elements only and strips structural noise.
+
+**What snapshot returns:**
+
+`snapshot` — a text tree of the page. Example:
+```
+- heading "Search Results" [level=2]
+- link "Blue Widget - $24.99" [ref=e3]
+- link "Red Widget - $19.99" [ref=e5]
+- button "Next page" [ref=e8]
+- combobox "Sort by" [ref=e11]
+```
+
+`refs` — a map of ref → element info:
+```typescript
+{
+  "e3": { role: "link", name: "Blue Widget - $24.99" },
+  "e8": { role: "button", name: "Next page" },
+  "e11": { role: "combobox", name: "Sort by" }
+}
+```
+
+**Reading a snapshot:** Look for elements by their role and name. Every `[ref=eN]` marker means you can interact with that element using its ref string (`"e3"`, `"e8"`, etc.).
+
+**Refs are ephemeral.** After navigation or DOM changes, re-snapshot — old refs are invalid.
+
+**If the snapshot looks empty or skeleton-like** (few elements, very little text), the page is still loading. Wait and try again:
+```typescript
+await page.waitFor({ timeMs: 1500 });
+const { snapshot } = await page.snapshot({ interactive: true, compact: true });
+```
+
+---
+
+## Core Actions
+
+### Navigate
+```typescript
+await page.goto('https://example.com');
+// After navigation, always re-snapshot before acting
+```
+
+### Click
+```typescript
+await page.click('e8');  // ref from snapshot
+```
+
+### Type
+```typescript
+await page.type('e2', 'search query');
+// type() clears the field first, then types
+// Use { submit: true } to press Enter after:
+await page.type('e2', 'search query', { submit: true });
+// Use { slowly: true } for sites that need keystroke-by-keystroke input
+```
+
+**After typing in any field — check for autocomplete.** Re-snapshot immediately and look for `combobox`, `listbox`, or suggestion items. If a dropdown appeared, click the correct option — do NOT press Enter.
+
+### Select (dropdowns)
+```typescript
+await page.select('e11', 'Price: Low to High');
+// Pass the option's visible text or value
+```
+
+### Press a key
+```typescript
+await page.press('Enter');
+await page.press('Tab');
+await page.press('Escape');
+```
+
+### Scroll
+```typescript
+await page.evaluate('window.scrollBy(0, 500)');   // scroll down
+await page.evaluate('window.scrollBy(0, -500)');  // scroll up
+await page.scrollIntoView('e15');                  // scroll element into view
+```
+
+### Screenshot (visual check)
+```typescript
+const buf = await page.screenshot();
+// Returns a Buffer — write to file or display
+```
+
+### Evaluate arbitrary JS
+```typescript
+const text = await page.evaluate('document.title');
+const count = await page.evaluate('document.querySelectorAll(".item").length');
+```
+
+---
+
+## Common Patterns
+
+### Fill a form
+```typescript
+// Snapshot first to get refs
+const { snapshot } = await page.snapshot({ interactive: true, compact: true });
+// Identify fields in the snapshot, note their refs
+
+// Fill multiple fields at once
+await page.fill([
+  { ref: 'e2', value: 'Jane Doe' },
+  { ref: 'e4', value: 'jane@example.com' },
+  { ref: 'e6', type: 'checkbox', value: true },
+]);
+
+// Then find and click the submit button
+await page.click('e9');  // ref of submit button
+
+// Re-snapshot to confirm submission
+await page.waitFor({ timeMs: 1000 });
+const { snapshot: after } = await page.snapshot({ interactive: true, compact: true });
+```
+
+### Navigate a multi-page flow
+```typescript
+// Page 1: fill and submit
+await page.goto('https://checkout.example.com/step1');
+let { snapshot } = await page.snapshot({ interactive: true, compact: true });
+// ... fill fields, click Next ...
+await page.click('e12');
+
+// Wait for page 2
+await page.waitFor({ loadState: 'networkidle', timeoutMs: 10000 });
+({ snapshot } = await page.snapshot({ interactive: true, compact: true }));
+// ... continue on page 2 ...
+```
+
+### Extract data from a listing
+```typescript
+await page.goto('https://example.com/products');
+const { snapshot } = await page.snapshot({ interactive: true, compact: true });
+
+// Read all items from the snapshot text
+// The snapshot shows names, prices, links — parse or pass to an LLM
+// For structured extraction from raw DOM:
+const items = await page.evaluate(`
+  Array.from(document.querySelectorAll('.product-card')).map(el => ({
+    name: el.querySelector('.name')?.textContent?.trim(),
+    price: el.querySelector('.price')?.textContent?.trim(),
+    url: el.querySelector('a')?.href,
+  }))
+`);
+```
+
+### Handle a dialog (alert/confirm/prompt)
+```typescript
+// Arm before the action that triggers the dialog
+const dialogDone = page.armDialog({ accept: true });
+await page.click('e7');   // triggers confirm()
+await dialogDone;         // resolves when dialog is handled
+```
+
+### Wait for something specific
+```typescript
+await page.waitFor({ text: 'Order confirmed' });           // wait for text to appear
+await page.waitFor({ selector: '.results-list' });          // wait for element
+await page.waitFor({ url: 'checkout/success' });            // wait for URL
+await page.waitFor({ loadState: 'networkidle' });           // wait for network quiet
+await page.waitFor({ timeMs: 2000 });                       // fixed delay (last resort)
+```
+
+### Multi-tab browsing
+```typescript
+const tabs = await browser.tabs();  // list all tabs: [{ targetId, title, url }]
+
+const page2 = await browser.open('https://other.example.com');
+// ... work on page2 ...
+
+await browser.focus(page.id);       // switch back to first tab
+await browser.close(page2.id);      // close a tab
+```
+
+---
+
+## Error Handling
+
+**Click didn't work / element not found:**
+1. Re-snapshot — the page may have changed, the ref is stale
+2. Look for the element by a different ref
+3. Try `page.scrollIntoView(ref)` then click again
+4. Try `page.clickByText('Button Label')` as fallback
+
+**Page loads slowly:**
+```typescript
+await page.waitFor({ loadState: 'networkidle', timeoutMs: 15000 });
+// or poll with snapshot readiness check:
+for (let i = 0; i < 5; i++) {
+  const { snapshot } = await page.snapshot({ interactive: true, compact: true });
+  const lines = snapshot.split('\n').filter(l => l.trim());
+  if (lines.length > 10) break;  // page has content
+  await page.waitFor({ timeMs: 1500 });
+}
+```
+
+**Repeated action isn't making progress:**
+- You may be stuck in a loop. Try a different element, a different approach, or navigate away and back.
+- Check `await page.url()` and `await page.title()` to confirm you're on the expected page.
+
+**Autocomplete / search suggestions appeared:**
+- Do NOT press Enter — that usually submits without selecting
+- Re-snapshot to see the suggestions
+- Click the matching suggestion ref
+
+**Form submission succeeded but then nothing happened:**
+- Check for error messages in the next snapshot
+- Check `await page.consoleLogs()` for JS errors
+- Try `await page.waitFor({ loadState: 'networkidle' })` then re-snapshot
+
+---
+
+## Inspecting Page State
+
+```typescript
+const url = await page.url();
+const title = await page.title();
+const errors = await page.pageErrors();         // JS errors
+const logs = await page.consoleLogs();          // console.log output
+const requests = await page.networkRequests();  // XHR/fetch calls
+```
+
+---
+
+## Key Rules
+
+1. **Always re-snapshot after navigation or significant actions.** Refs change.
+2. **Use `{ interactive: true, compact: true }` for every snapshot.** Cleaner output, faster reasoning.
+3. **Trust what you see in the snapshot.** Don't assume elements exist — verify in the snapshot.
+4. **After typing, check for autocomplete before pressing Enter.**
+5. **One navigation = one snapshot cycle.** Goto → waitFor → snapshot → act.
+6. **Data grounding:** Every value you extract or report must appear verbatim in a snapshot you actually saw.

--- a/.claude/skills/sync-openclaw/SKILL.md
+++ b/.claude/skills/sync-openclaw/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: sync-openclaw
+description: Sync browserclaw with the latest OpenClaw browser SDK changes
+disable-model-invocation: true
+---
+
+# Sync from OpenClaw
+
+Sync browserclaw with upstream OpenClaw browser SDK changes. Follow every step.
+
+## 1. Check versions
+
+```bash
+npm root -g          # find global install
+npm view openclaw version  # latest on npm
+# check installed version in the global openclaw package.json
+```
+
+Compare installed vs latest. If outdated, run `npm install -g openclaw@latest`.
+
+## 2. Read the changelog
+
+Read `CHANGELOG.md` in the openclaw package. Check MEMORY.md sync history to know what version was last synced.
+
+## 3. Identify browser-relevant changes
+
+From the changelog, find entries tagged Browser/, Security/, or that mention CDP, SSRF, navigation, snapshot, accessibility, download, upload, trace, evaluate, form fields, or Playwright.
+
+Skip anything that is:
+- Extension-relay-specific
+- CLI/config-only
+- Gateway/server-side only
+- Channel/messaging/plugin-specific
+- OpenClaw profile/decoration-specific (browserclaw has its own simpler profile system)
+
+## 4. Deep-compare implementations
+
+For each potentially relevant change:
+1. Read the OpenClaw type definitions: `dist/plugin-sdk/browser/*.d.ts`
+2. Read the actual implementation bundles (filenames change per version): `dist/plugin-sdk/chrome-*.js`, `dist/plugin-sdk/ssrf-*.js`, `dist/plugin-sdk/pw-ai-*.js`, `dist/plugin-sdk/fs-safe-*.js`
+3. Compare against browserclaw source files:
+   - CDP/connection → `src/connection.ts`
+   - Chrome launching → `src/chrome-launcher.ts`
+   - Accessibility snapshots → `src/snapshot/aria-snapshot.ts`, `src/snapshot/ai-snapshot.ts`
+   - Ref map → `src/snapshot/ref-map.ts`
+   - Page interactions → `src/actions/interaction.ts`
+   - Navigation → `src/actions/navigation.ts`
+   - Security/SSRF → `src/security.ts`
+   - Downloads → `src/actions/download.ts`
+   - Traces → `src/capture/trace.ts`
+   - Types → `src/types.ts`
+   - Evaluate → `src/actions/evaluate.ts`
+
+Type signatures alone don't reveal logic changes — always read the JS bundle implementation.
+
+## 5. Apply changes
+
+Port each relevant change to browserclaw, adapting for architecture differences. Run `npx tsc --noEmit` to verify.
+
+## 6. Bump, build, commit
+
+- Bump version in `package.json`
+- `npm run build`
+- Commit as `"Updates from OpenClaw YYYY.M.DD"`
+- **ASK the user before running `npm publish`** — never publish without explicit approval
+
+## 7. Update memory
+
+Add a sync history entry to MEMORY.md with version, OpenClaw version, and summary of changes ported (and notable skips).
+
+## Double-check checklist
+
+Before committing, verify:
+- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
+- [ ] New exports added to `src/index.ts` if any public API was added
+- [ ] No unnecessary dependencies added
+- [ ] Commit message follows format: `"Updates from OpenClaw YYYY.M.DD"`

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .DS_Store
 .env
 .env.*
-.claude/
+.claude/settings.local.json
+.claude/worktrees/
 sync/
 internal/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ When you're running the same multi-step workflow hundreds of times — filling f
 
 [browserclaw.org](https://browserclaw.org) is an open-source playground where you can type a prompt and watch an AI agent use browserclaw in a real browser — live. No setup, no API keys, just a text box and a browser stream.
 
-Want to run it yourself? The source is at [github.com/idan-rubin/browserclaw.agent](https://github.com/idan-rubin/browserclaw.agent) — spin it up with Docker or Node.js. Supports Groq, Gemini, OpenAI, and Anthropic out of the box.
+Want to run it yourself? The source is at [github.com/idan-rubin/browserclaw-agent](https://github.com/idan-rubin/browserclaw-agent) — spin it up with Docker or Node.js. Supports Groq, Gemini, OpenAI, and Anthropic out of the box.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/browserclaw/SKILL.md` — a Claude Code skill that teaches step-by-step interactive browsing with the browserclaw library (launch, snapshot, click/type/select, form filling, multi-page flows, data extraction, error handling)
- Updates `.gitignore` to track `.claude/skills/` and `.claude/commands/` (previously the entire `.claude/` dir was ignored)
- As a result, also tracks the existing `sync-openclaw` skill and command file that were previously unversioned