### PR TITLE
Restore stripped APIs

### DIFF
--- a/.claude/skills/sync-openclaw/SKILL.md
+++ b/.claude/skills/sync-openclaw/SKILL.md
@@ -57,7 +57,7 @@ Type signatures alone don't reveal logic changes — always read the JS bundle i
 
 Port each relevant change to browserclaw, adapting for architecture differences. Run `npx tsc --noEmit` to verify.
 
-**Sync is additive only.** If browserclaw has code that OpenClaw does not, that is a browserclaw-only feature — leave it alone. Never delete, overwrite, or modify code just because it is absent from OpenClaw.
+**Never remove browserclaw-only code.** If browserclaw has code that OpenClaw does not, that is a browserclaw-only feature — leave it alone. Never delete, overwrite, or modify it just because it is absent from OpenClaw. The only reason to change shared code is to port a bug fix or new feature from OpenClaw.
 
 ## 6. Bump, build, commit
 

--- a/.claude/skills/sync-openclaw/SKILL.md
+++ b/.claude/skills/sync-openclaw/SKILL.md
@@ -33,29 +33,34 @@ Skip anything that is:
 - Channel/messaging/plugin-specific
 - OpenClaw profile/decoration-specific (browserclaw has its own simpler profile system)
 
-## 4. Deep-compare implementations
+## 4. Diff OpenClaw against browserclaw
 
-For each potentially relevant change:
-1. Read the OpenClaw type definitions: `dist/plugin-sdk/browser/*.d.ts`
-2. Read the actual implementation bundles (filenames change per version): `dist/plugin-sdk/chrome-*.js`, `dist/plugin-sdk/ssrf-*.js`, `dist/plugin-sdk/pw-ai-*.js`, `dist/plugin-sdk/fs-safe-*.js`
-3. Compare against browserclaw source files:
-   - CDP/connection → `src/connection.ts`
-   - Chrome launching → `src/chrome-launcher.ts`
-   - Accessibility snapshots → `src/snapshot/aria-snapshot.ts`, `src/snapshot/ai-snapshot.ts`
-   - Ref map → `src/snapshot/ref-map.ts`
-   - Page interactions → `src/actions/interaction.ts`
-   - Navigation → `src/actions/navigation.ts`
-   - Security/SSRF → `src/security.ts`
-   - Downloads → `src/actions/download.ts`
-   - Traces → `src/capture/trace.ts`
-   - Types → `src/types.ts`
-   - Evaluate → `src/actions/evaluate.ts`
+For each potentially relevant change, **diff** the OpenClaw implementation against the corresponding browserclaw source to identify the specific lines that differ. Only carry forward the actual differences — new lines added or existing lines modified in OpenClaw.
+
+OpenClaw sources:
+- Type definitions: `dist/plugin-sdk/browser/*.d.ts`
+- Implementation bundles: `dist/plugin-sdk/chrome-*.js`, `dist/plugin-sdk/ssrf-*.js`, `dist/plugin-sdk/pw-ai-*.js`, `dist/plugin-sdk/fs-safe-*.js`
+
+Browserclaw source mapping:
+- CDP/connection → `src/connection.ts`
+- Chrome launching → `src/chrome-launcher.ts`
+- Accessibility snapshots → `src/snapshot/aria-snapshot.ts`, `src/snapshot/ai-snapshot.ts`
+- Ref map → `src/snapshot/ref-map.ts`
+- Page interactions → `src/actions/interaction.ts`
+- Navigation → `src/actions/navigation.ts`
+- Security/SSRF → `src/security.ts`
+- Downloads → `src/actions/download.ts`
+- Traces → `src/capture/trace.ts`
+- Types → `src/types.ts`
+- Evaluate → `src/actions/evaluate.ts`
 
 Type signatures alone don't reveal logic changes — always read the JS bundle implementation.
 
-## 5. Apply changes
+**Browserclaw will have code that OpenClaw does not.** That is expected — it's browserclaw-only functionality. If something exists in browserclaw but not in OpenClaw, that is not a diff to act on. Ignore it.
 
-For each change identified in step 4, apply it as a **targeted diff** to the browserclaw source. Read the relevant browserclaw file, identify the specific lines that need to change, and edit only those lines. Do not overwrite or rewrite entire files. Do not remove existing code — only add or modify. If you didn't write it, don't delete it.
+## 5. Apply diffs
+
+For each diff identified in step 4, edit only the specific lines that changed in OpenClaw. Do not overwrite or rewrite entire files or functions. Do not remove existing code — if you didn't write it, don't delete it.
 
 Run `npx tsc --noEmit` to verify after each file change.
 

--- a/.claude/skills/sync-openclaw/SKILL.md
+++ b/.claude/skills/sync-openclaw/SKILL.md
@@ -55,9 +55,9 @@ Type signatures alone don't reveal logic changes — always read the JS bundle i
 
 ## 5. Apply changes
 
-Port each relevant change to browserclaw, adapting for architecture differences. Run `npx tsc --noEmit` to verify.
+For each change identified in step 4, apply it as a **targeted diff** to the browserclaw source. Read the relevant browserclaw file, identify the specific lines that need to change, and edit only those lines. Do not overwrite or rewrite entire files. Do not remove existing code — only add or modify. If you didn't write it, don't delete it.
 
-**Do not remove existing code.** Only add or modify. If you didn't write it, don't delete it.
+Run `npx tsc --noEmit` to verify after each file change.
 
 ## 6. Bump, build, commit
 

--- a/.claude/skills/sync-openclaw/SKILL.md
+++ b/.claude/skills/sync-openclaw/SKILL.md
@@ -57,10 +57,13 @@ Type signatures alone don't reveal logic changes — always read the JS bundle i
 
 Port each relevant change to browserclaw, adapting for architecture differences. Run `npx tsc --noEmit` to verify.
 
+**Sync is additive only.** If browserclaw has code that OpenClaw does not, that is a browserclaw-only feature — leave it alone. Never delete, overwrite, or modify code just because it is absent from OpenClaw.
+
 ## 6. Bump, build, commit
 
 - Bump version in `package.json`
 - `npm run build`
+- Run `node scripts/check-exports.js` — **abort if it fails**
 - Commit as `"Updates from OpenClaw YYYY.M.DD"`
 - **ASK the user before running `npm publish`** — never publish without explicit approval
 
@@ -74,4 +77,5 @@ Before committing, verify:
 - [ ] TypeScript compiles clean (`npx tsc --noEmit`)
 - [ ] New exports added to `src/index.ts` if any public API was added
 - [ ] No unnecessary dependencies added
+- [ ] No browserclaw-only APIs were removed (run `node scripts/check-exports.js`)
 - [ ] Commit message follows format: `"Updates from OpenClaw YYYY.M.DD"`

--- a/.claude/skills/sync-openclaw/SKILL.md
+++ b/.claude/skills/sync-openclaw/SKILL.md
@@ -57,7 +57,7 @@ Type signatures alone don't reveal logic changes — always read the JS bundle i
 
 Port each relevant change to browserclaw, adapting for architecture differences. Run `npx tsc --noEmit` to verify.
 
-**Never remove browserclaw-only code.** If browserclaw has code that OpenClaw does not, that is a browserclaw-only feature — leave it alone. Never delete, overwrite, or modify it just because it is absent from OpenClaw. The only reason to change shared code is to port a bug fix or new feature from OpenClaw.
+**Do not remove existing code.** Only add or modify. If you didn't write it, don't delete it.
 
 ## 6. Bump, build, commit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,4 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - run: node scripts/check-exports.js

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
-    "prepublishOnly": "npm run build",
+    "check-exports": "node scripts/check-exports.js",
+    "prepublishOnly": "npm run build && node scripts/check-exports.js",
     "test": "echo \"No tests yet\" && exit 0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/check-exports.js
+++ b/scripts/check-exports.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that the built dist/index.d.ts contains all expected public APIs.
+ * Run after `npm run build` to catch accidental removals before publishing.
+ *
+ * To add a new required export:  add it to REQUIRED_EXPORTS below.
+ * To add a new required method:  add it to REQUIRED_METHODS below.
+ */
+
+import { readFileSync } from 'fs';
+
+const DTS_PATH = 'dist/index.d.ts';
+
+// Top-level exports that must appear in the export {} line
+const REQUIRED_EXPORTS = [
+  'BrowserClaw',
+  'CrawlPage',
+  'pressAndHoldViaCdp',
+  'RequestResult',
+  'batchViaPlaywright',
+  'executeSingleAction',
+  'detectChallengeViaPlaywright',
+  'waitForChallengeViaPlaywright',
+  'STEALTH_SCRIPT',
+];
+
+// Methods that must exist on CrawlPage (checked via declaration in the .d.ts)
+const REQUIRED_METHODS = [
+  'pressAndHold',
+  'waitForRequest',
+  'waitForTab',
+];
+
+let dts;
+try {
+  dts = readFileSync(DTS_PATH, 'utf8');
+} catch {
+  console.error(`ERROR: ${DTS_PATH} not found. Run "npm run build" first.`);
+  process.exit(1);
+}
+
+const failures = [];
+
+for (const name of REQUIRED_EXPORTS) {
+  if (!dts.includes(name)) {
+    failures.push(`Missing export: ${name}`);
+  }
+}
+
+for (const method of REQUIRED_METHODS) {
+  // Match method declarations like: methodName(  or methodName<
+  const pattern = new RegExp(`\\b${method}\\s*[(<]`);
+  if (!pattern.test(dts)) {
+    failures.push(`Missing method: ${method}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Export check FAILED — the following public APIs are missing from the build:\n');
+  for (const f of failures) {
+    console.error(`  ✗ ${f}`);
+  }
+  console.error('\nThis likely means a sync or refactor accidentally removed browserclaw-only code.');
+  console.error('Fix the source, rebuild, and re-run this check.');
+  process.exit(1);
+}
+
+console.log(`Export check passed — ${REQUIRED_EXPORTS.length} exports and ${REQUIRED_METHODS.length} methods verified.`);


### PR DESCRIPTION
## Summary

The published 0.10.5 npm package was missing several browserclaw-only APIs that were accidentally stripped during the OpenClaw sync (#32). The source code was correct, but `dist/` was built from a transient working tree state where the sync agent had temporarily overwritten files with OpenClaw's versions.

**APIs missing from published 0.10.5:**
- `pressAndHold` / `pressAndHoldViaCdp`
- `waitForRequest` / `RequestResult`
- `waitForTab`
- `ClickOptions.force`
- `RoleRefInfo.disabled` / `checked`
- `LaunchOptions.ignoreHTTPSErrors`
- `WaitOptions.fn` function support + `arg`

**This PR:**
- Bumps to 0.10.6 (rebuilding from correct source restores all APIs)
- Adds `scripts/check-exports.js` — verifies required public APIs exist in built `dist/index.d.ts`
- Wires export check into `prepublishOnly` so `npm publish` fails if any API is missing
- Adds export check to CI so PRs that strip APIs fail before merge
- Updates openclaw-sync skill: syncs are additive only, never delete browserclaw-only code

## Test plan

- [x] `npm run build` succeeds
- [x] `node scripts/check-exports.js` passes with all 9 exports and 3 methods verified
- [ ] `npm publish` (after merge — needs explicit approval)

https://claude.ai/code/session_01HzxskAtKGz5v2CobUnPv33