### PR TITLE
Add url option to launch()

### DIFF
--- a/.claude/skills/browserclaw/SKILL.md
+++ b/.claude/skills/browserclaw/SKILL.md
@@ -12,9 +12,8 @@ You are operating a real browser. You can see pages through `snapshot()` and act
 ```typescript
 import { BrowserClaw } from 'browserclaw';
 
-const browser = await BrowserClaw.launch({ headless: false });
-const page = await browser.currentPage();  // reuse the existing tab Chrome opened
-await page.goto('https://example.com');    // don't use browser.open() — it opens a duplicate tab
+const browser = await BrowserClaw.launch({ url: 'https://example.com' });
+const page = await browser.currentPage();
 // or connect to existing: await BrowserClaw.connect('http://localhost:9222')
 ```
 
@@ -45,6 +44,7 @@ Always use `{ interactive: true, compact: true }`. This filters to actionable el
 **What snapshot returns:**
 
 `snapshot` — a text tree of the page. Example:
+
 ```
 - heading "Search Results" [level=2]
 - link "Blue Widget - $24.99" [ref=e3]
@@ -54,6 +54,7 @@ Always use `{ interactive: true, compact: true }`. This filters to actionable el
 ```
 
 `refs` — a map of ref → element info:
+
 ```typescript
 {
   "e3": { role: "link", name: "Blue Widget - $24.99" },
@@ -67,6 +68,7 @@ Always use `{ interactive: true, compact: true }`. This filters to actionable el
 **Refs are ephemeral.** After navigation or DOM changes, re-snapshot — old refs are invalid.
 
 **If the snapshot looks empty or skeleton-like** (few elements, very little text), the page is still loading. Wait and try again:
+
 ```typescript
 await page.waitFor({ timeMs: 1500 });
 const { snapshot } = await page.snapshot({ interactive: true, compact: true });
@@ -77,17 +79,20 @@ const { snapshot } = await page.snapshot({ interactive: true, compact: true });
 ## Core Actions
 
 ### Navigate
+
 ```typescript
 await page.goto('https://example.com');
 // After navigation, always re-snapshot before acting
 ```
 
 ### Click
+
 ```typescript
-await page.click('e8');  // ref from snapshot
+await page.click('e8'); // ref from snapshot
 ```
 
 ### Type
+
 ```typescript
 await page.type('e2', 'search query');
 // type() clears the field first, then types
@@ -99,12 +104,14 @@ await page.type('e2', 'search query', { submit: true });
 **After typing in any field — check for autocomplete.** Re-snapshot immediately and look for `combobox`, `listbox`, or suggestion items. If a dropdown appeared, click the correct option — do NOT press Enter.
 
 ### Select (dropdowns)
+
 ```typescript
 await page.select('e11', 'Price: Low to High');
 // Pass the option's visible text or value
 ```
 
 ### Press a key
+
 ```typescript
 await page.press('Enter');
 await page.press('Tab');
@@ -112,19 +119,22 @@ await page.press('Escape');
 ```
 
 ### Scroll
+
 ```typescript
-await page.evaluate('window.scrollBy(0, 500)');   // scroll down
-await page.evaluate('window.scrollBy(0, -500)');  // scroll up
-await page.scrollIntoView('e15');                  // scroll element into view
+await page.evaluate('window.scrollBy(0, 500)'); // scroll down
+await page.evaluate('window.scrollBy(0, -500)'); // scroll up
+await page.scrollIntoView('e15'); // scroll element into view
 ```
 
 ### Screenshot (visual check)
+
 ```typescript
 const buf = await page.screenshot();
 // Returns a Buffer — write to file or display
 ```
 
 ### Evaluate arbitrary JS
+
 ```typescript
 const text = await page.evaluate('document.title');
 const count = await page.evaluate('document.querySelectorAll(".item").length');
@@ -135,6 +145,7 @@ const count = await page.evaluate('document.querySelectorAll(".item").length');
 ## Common Patterns
 
 ### Fill a form
+
 ```typescript
 // Snapshot first to get refs
 const { snapshot } = await page.snapshot({ interactive: true, compact: true });
@@ -148,7 +159,7 @@ await page.fill([
 ]);
 
 // Then find and click the submit button
-await page.click('e9');  // ref of submit button
+await page.click('e9'); // ref of submit button
 
 // Re-snapshot to confirm submission
 await page.waitFor({ timeMs: 1000 });
@@ -156,6 +167,7 @@ const { snapshot: after } = await page.snapshot({ interactive: true, compact: tr
 ```
 
 ### Navigate a multi-page flow
+
 ```typescript
 // Page 1: fill and submit
 await page.goto('https://checkout.example.com/step1');
@@ -170,6 +182,7 @@ await page.waitFor({ loadState: 'networkidle', timeoutMs: 10000 });
 ```
 
 ### Extract data from a listing
+
 ```typescript
 await page.goto('https://example.com/products');
 const { snapshot } = await page.snapshot({ interactive: true, compact: true });
@@ -187,32 +200,35 @@ const items = await page.evaluate(`
 ```
 
 ### Handle a dialog (alert/confirm/prompt)
+
 ```typescript
 // Arm before the action that triggers the dialog
 const dialogDone = page.armDialog({ accept: true });
-await page.click('e7');   // triggers confirm()
-await dialogDone;         // resolves when dialog is handled
+await page.click('e7'); // triggers confirm()
+await dialogDone; // resolves when dialog is handled
 ```
 
 ### Wait for something specific
+
 ```typescript
-await page.waitFor({ text: 'Order confirmed' });           // wait for text to appear
-await page.waitFor({ selector: '.results-list' });          // wait for element
-await page.waitFor({ url: 'checkout/success' });            // wait for URL
-await page.waitFor({ loadState: 'networkidle' });           // wait for network quiet
-await page.waitFor({ timeMs: 2000 });                       // fixed delay (last resort)
+await page.waitFor({ text: 'Order confirmed' }); // wait for text to appear
+await page.waitFor({ selector: '.results-list' }); // wait for element
+await page.waitFor({ url: 'checkout/success' }); // wait for URL
+await page.waitFor({ loadState: 'networkidle' }); // wait for network quiet
+await page.waitFor({ timeMs: 2000 }); // fixed delay (last resort)
 ```
 
 ### Multi-tab browsing
+
 ```typescript
-const tabs = await browser.tabs();  // list all tabs: [{ targetId, title, url }]
+const tabs = await browser.tabs(); // list all tabs: [{ targetId, title, url }]
 
 // Open a new tab explicitly (only when you actually want a second tab)
 const page2 = await browser.open('https://other.example.com');
 // ... work on page2 ...
 
-await browser.focus(page.id);       // switch back to first tab
-await browser.close(page2.id);      // close a tab
+await browser.focus(page.id); // switch back to first tab
+await browser.close(page2.id); // close a tab
 ```
 
 For tab lifecycle management in production (detecting new tabs opened by clicks, switching automatically), see [`tab-manager.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/tab-manager.ts).
@@ -222,33 +238,38 @@ For tab lifecycle management in production (detecting new tabs opened by clicks,
 ## Error Handling
 
 **Click didn't work / element not found:**
+
 1. Re-snapshot — the page may have changed, the ref is stale
 2. Look for the element by a different ref
 3. Try `page.scrollIntoView(ref)` then click again
 4. Try `page.clickByText('Button Label')` as fallback
 
 **Page loads slowly:**
+
 ```typescript
 await page.waitFor({ loadState: 'networkidle', timeoutMs: 15000 });
 // or poll with snapshot readiness check:
 for (let i = 0; i < 5; i++) {
   const { snapshot } = await page.snapshot({ interactive: true, compact: true });
-  const lines = snapshot.split('\n').filter(l => l.trim());
-  if (lines.length > 10) break;  // page has content
+  const lines = snapshot.split('\n').filter((l) => l.trim());
+  if (lines.length > 10) break; // page has content
   await page.waitFor({ timeMs: 1500 });
 }
 ```
 
 **Repeated action isn't making progress:**
+
 - You may be stuck in a loop. Try a different element, a different approach, or navigate away and back.
 - Check `await page.url()` and `await page.title()` to confirm you're on the expected page.
 
 **Autocomplete / search suggestions appeared:**
+
 - Do NOT press Enter — that usually submits without selecting
 - Re-snapshot to see the suggestions
 - Click the matching suggestion ref
 
 **Form submission succeeded but then nothing happened:**
+
 - Check for error messages in the next snapshot
 - Check `await page.consoleLogs()` for JS errors
 - Try `await page.waitFor({ loadState: 'networkidle' })` then re-snapshot
@@ -260,9 +281,9 @@ for (let i = 0; i < 5; i++) {
 ```typescript
 const url = await page.url();
 const title = await page.title();
-const errors = await page.pageErrors();         // JS errors
-const logs = await page.consoleLogs();          // console.log output
-const requests = await page.networkRequests();  // XHR/fetch calls
+const errors = await page.pageErrors(); // JS errors
+const logs = await page.consoleLogs(); // console.log output
+const requests = await page.networkRequests(); // XHR/fetch calls
 ```
 
 ---
@@ -273,13 +294,13 @@ const requests = await page.networkRequests();  // XHR/fetch calls
 
 All skills live at: https://github.com/idan-rubin/browserclaw-agent/tree/main/src/Services/Browser/src/skills
 
-| Scenario | File | What it handles |
-|---|---|---|
-| PerimeterX / "press and hold" challenge | [`press-and-hold.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/press-and-hold.ts) | Finds button at bottom-center +60px, holds 4–10s with randomized jitter and delay, refreshes and retries if still blocked |
-| Cloudflare "Verify you are human" checkbox | [`cloudflare-checkbox.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/cloudflare-checkbox.ts) | Locates the Cloudflare iframe checkbox and clicks it via CDP |
-| Cookie banners and generic popups | [`dismiss-popup.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/dismiss-popup.ts) | Detects and dismisses common cookie consent banners and modal overlays |
-| Tab opened by a click | [`tab-manager.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/tab-manager.ts) | Tracks known tab IDs, detects new tabs after clicks, switches focus automatically |
-| Agent stuck repeating the same action | [`loop-detection.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/loop-detection.ts) | Counts repeated action+ref pairs over a sliding window; escalates nudge from gentle → warning → urgent at 5/8/12 repetitions |
+| Scenario                                   | File                                                                                                                                         | What it handles                                                                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| PerimeterX / "press and hold" challenge    | [`press-and-hold.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/press-and-hold.ts)           | Finds button at bottom-center +60px, holds 4–10s with randomized jitter and delay, refreshes and retries if still blocked    |
+| Cloudflare "Verify you are human" checkbox | [`cloudflare-checkbox.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/cloudflare-checkbox.ts) | Locates the Cloudflare iframe checkbox and clicks it via CDP                                                                 |
+| Cookie banners and generic popups          | [`dismiss-popup.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/dismiss-popup.ts)             | Detects and dismisses common cookie consent banners and modal overlays                                                       |
+| Tab opened by a click                      | [`tab-manager.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/tab-manager.ts)                 | Tracks known tab IDs, detects new tabs after clicks, switches focus automatically                                            |
+| Agent stuck repeating the same action      | [`loop-detection.ts`](https://github.com/idan-rubin/browserclaw-agent/blob/main/src/Services/Browser/src/skills/loop-detection.ts)           | Counts repeated action+ref pairs over a sliding window; escalates nudge from gentle → warning → urgent at 5/8/12 repetitions |
 
 **If you encounter an anti-bot challenge, popup, or tab management need: read the relevant file above first.** These are production implementations that handle edge cases you'll otherwise spend hours debugging.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The AI-native browser automation library — born from [OpenClaw](https://github
 ```typescript
 import { BrowserClaw } from 'browserclaw';
 
-const browser = await BrowserClaw.launch({ headless: false });
-const page = await browser.open('https://example.com');
+const browser = await BrowserClaw.launch({ url: 'https://example.com' });
+const page = await browser.currentPage();
 
 // Snapshot — the core feature
 const { snapshot, refs } = await page.snapshot();
@@ -133,6 +133,7 @@ Requires a Chromium-based browser installed on the system (Chrome, Brave, Edge, 
 ```typescript
 // Launch a new Chrome instance (auto-detects Chrome/Brave/Edge/Chromium)
 const browser = await BrowserClaw.launch({
+  url: 'https://example.com', // navigate initial tab (no extra tabs)
   headless: false, // default: false (visible window)
   executablePath: '...', // optional: specific browser path
   cdpPort: 9222, // default: 9222

--- a/examples/ai-agent.ts
+++ b/examples/ai-agent.ts
@@ -12,7 +12,11 @@
 import { BrowserClaw, type SnapshotResult } from '../src/index.js';
 
 // Placeholder for your AI/LLM integration
-async function askAI(snapshot: string, refs: Record<string, any>, task: string): Promise<{
+async function askAI(
+  snapshot: string,
+  refs: Record<string, any>,
+  task: string,
+): Promise<{
   action: 'click' | 'type' | 'done';
   ref?: string;
   text?: string;
@@ -34,10 +38,10 @@ async function askAI(snapshot: string, refs: Record<string, any>, task: string):
 }
 
 async function main() {
-  const browser = await BrowserClaw.launch({ headless: false });
+  const browser = await BrowserClaw.launch({ url: 'https://example.com' });
 
   try {
-    const page = await browser.open('https://example.com');
+    const page = await browser.currentPage();
     const task = 'Find and click the "More information" link';
 
     let done = false;

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,12 +1,11 @@
 import { BrowserClaw } from '../src/index.js';
 
 async function main() {
-  // Launch Chrome
-  const browser = await BrowserClaw.launch({ headless: false });
+  // Launch Chrome and navigate
+  const browser = await BrowserClaw.launch({ url: 'https://example.com' });
 
   try {
-    // Open a page
-    const page = await browser.open('https://example.com');
+    const page = await browser.currentPage();
 
     // Take a snapshot — get AI-readable text with numbered refs
     const { snapshot, refs } = await page.snapshot();

--- a/examples/form-fill.ts
+++ b/examples/form-fill.ts
@@ -1,11 +1,10 @@
 import { BrowserClaw } from '../src/index.js';
 
 async function main() {
-  const browser = await BrowserClaw.launch({ headless: false });
+  const browser = await BrowserClaw.launch({ url: 'https://httpbin.org/forms/post' });
 
   try {
-    // Open a page with a form
-    const page = await browser.open('https://httpbin.org/forms/post');
+    const page = await browser.currentPage();
 
     // Take a snapshot to see form fields
     const { snapshot, refs } = await page.snapshot();
@@ -22,10 +21,14 @@ async function main() {
     const fields = textboxes.map(([ref, info]) => ({
       ref,
       type: 'text' as const,
-      value: info.name === 'Customer name' ? 'Jane Doe'
-        : info.name === 'Telephone' ? '555-1234'
-          : info.name === 'E-mail address' ? 'jane@example.com'
-            : 'test',
+      value:
+        info.name === 'Customer name'
+          ? 'Jane Doe'
+          : info.name === 'Telephone'
+            ? '555-1234'
+            : info.name === 'E-mail address'
+              ? 'jane@example.com'
+              : 'test',
     }));
 
     console.log('\nBatch filling fields:');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1454,8 +1454,8 @@ export class CrawlPage {
  * ```ts
  * import { BrowserClaw } from 'browserclaw';
  *
- * const browser = await BrowserClaw.launch({ headless: false });
- * const page = await browser.open('https://example.com');
+ * const browser = await BrowserClaw.launch({ url: 'https://example.com' });
+ * const page = await browser.currentPage();
  *
  * const { snapshot, refs } = await page.snapshot();
  * console.log(snapshot); // AI-readable page tree
@@ -1494,14 +1494,15 @@ export class BrowserClaw {
    *
    * @example
    * ```ts
-   * // Default: visible Chrome window
-   * const browser = await BrowserClaw.launch();
+   * // Launch and navigate to a URL
+   * const browser = await BrowserClaw.launch({ url: 'https://example.com' });
    *
    * // Headless mode
-   * const browser = await BrowserClaw.launch({ headless: true });
+   * const browser = await BrowserClaw.launch({ url: 'https://example.com', headless: true });
    *
    * // Specific browser
    * const browser = await BrowserClaw.launch({
+   *   url: 'https://example.com',
    *   executablePath: '/usr/bin/google-chrome',
    * });
    * ```
@@ -1513,7 +1514,12 @@ export class BrowserClaw {
     const ssrfPolicy =
       opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
     /* eslint-enable @typescript-eslint/no-deprecated */
-    return new BrowserClaw(cdpUrl, chrome, ssrfPolicy, opts.recordVideo);
+    const browser = new BrowserClaw(cdpUrl, chrome, ssrfPolicy, opts.recordVideo);
+    if (opts.url !== undefined && opts.url !== '') {
+      const page = await browser.currentPage();
+      await page.goto(opts.url);
+    }
+    return browser;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface RunningChrome {
 
 /** Options for launching a new browser instance. */
 export interface LaunchOptions {
+  /** URL to navigate to after launch. If omitted, the initial tab stays on `about:blank`. */
+  url?: string;
   /** Run in headless mode (no visible window). Default: `false` */
   headless?: boolean;
   /** Path to a specific browser executable. Auto-detected if omitted. */


### PR DESCRIPTION
## Summary
- `BrowserClaw.launch({ url: '...' })` navigates the initial tab before returning
- Avoids the 2-tab problem where agents call `open()` after `launch()` and end up with a stale `about:blank` tab
- Version bump to 0.11.0