### PR TITLE
Updates from OpenClaw 2026.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,7 +1,8 @@
-import type { Browser, BrowserContext } from 'playwright-core';
+import type { Browser, BrowserContext, Page, Route, Request } from 'playwright-core';
 
 import {
   BrowserTabNotFoundError,
+  BlockedBrowserTargetError,
   connectBrowser,
   getPageForTargetId,
   ensurePageState,
@@ -12,8 +13,15 @@ import {
   forceDisconnectPlaywrightForTarget,
   resolvePageByTargetIdOrThrow,
   withPageScopedCdpClient,
+  isBlockedTarget,
+  isBlockedPageRef,
+  markTargetBlocked,
+  markPageRefBlocked,
+  clearBlockedPageRef,
+  clearBlockedTarget,
 } from '../connection.js';
 import {
+  InvalidBrowserNavigationUrlError,
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
   assertBrowserNavigationRedirectChainAllowed,
@@ -44,6 +52,100 @@ function isRetryableNavigateError(err: unknown): boolean {
   return msg.includes('frame has been detached') || msg.includes('target page, context or browser has been closed');
 }
 
+function isPolicyDenyNavigationError(err: unknown): boolean {
+  return err instanceof InvalidBrowserNavigationUrlError;
+}
+
+function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
+  if (!request.isNavigationRequest()) return false;
+  try {
+    return request.frame() === page.mainFrame();
+  } catch {
+    return true;
+  }
+}
+
+async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page; targetId?: string }): Promise<void> {
+  markPageRefBlocked(opts.cdpUrl, opts.page);
+  const resolvedTargetId = await pageTargetId(opts.page).catch(() => null);
+  const fallbackTargetId = opts.targetId?.trim() ?? '';
+  const targetIdToBlock = resolvedTargetId ?? fallbackTargetId;
+  if (targetIdToBlock) markTargetBlocked(opts.cdpUrl, targetIdToBlock);
+  await opts.page.close().catch((e: unknown) => {
+    console.warn('[browserclaw] failed to close blocked page', e);
+  });
+}
+
+async function assertPageNavigationCompletedSafely(opts: {
+  cdpUrl: string;
+  page: Page;
+  response: Awaited<ReturnType<Page['goto']>>;
+  ssrfPolicy?: SsrfPolicy;
+  targetId?: string;
+}): Promise<void> {
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
+  try {
+    await assertBrowserNavigationRedirectChainAllowed({ request: opts.response?.request(), ...navigationPolicy });
+    await assertBrowserNavigationResultAllowed({ url: opts.page.url(), ...navigationPolicy });
+  } catch (err) {
+    if (isPolicyDenyNavigationError(err))
+      await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page: opts.page, targetId: opts.targetId });
+    throw err;
+  }
+}
+
+async function gotoPageWithNavigationGuard(opts: {
+  cdpUrl: string;
+  page: Page;
+  url: string;
+  timeoutMs: number;
+  ssrfPolicy?: SsrfPolicy;
+  targetId?: string;
+}): Promise<Awaited<ReturnType<Page['goto']>>> {
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
+  const state: { blocked: Error | null } = { blocked: null };
+  const handler = async (route: Route, request: Request) => {
+    if (state.blocked !== null) {
+      await route.abort().catch((e: unknown) => {
+        console.warn('[browserclaw] route abort failed', e);
+      });
+      return;
+    }
+    if (!isTopLevelNavigationRequest(opts.page, request)) {
+      await route.continue();
+      return;
+    }
+    try {
+      await assertBrowserNavigationAllowed({ url: request.url(), ...navigationPolicy });
+    } catch (err) {
+      if (isPolicyDenyNavigationError(err)) {
+        state.blocked = err as Error;
+        await route.abort().catch((e: unknown) => {
+          console.warn('[browserclaw] route abort failed', e);
+        });
+        return;
+      }
+      throw err;
+    }
+    await route.continue();
+  };
+  await opts.page.route('**', handler);
+  try {
+    const response = await opts.page.goto(opts.url, { timeout: opts.timeoutMs });
+    if (state.blocked !== null) throw state.blocked;
+    return response;
+  } catch (err) {
+    if (state.blocked !== null) throw state.blocked;
+    throw err;
+  } finally {
+    await opts.page.unroute('**', handler).catch((e: unknown) => {
+      console.warn('[browserclaw] route unroute failed', e);
+    });
+    if (state.blocked !== null)
+      await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page: opts.page, targetId: opts.targetId });
+  }
+}
+
 export async function navigateViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -65,7 +167,15 @@ export async function navigateViaPlaywright(opts: {
   let page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  const navigate = async () => await page.goto(url, { timeout });
+  const navigate = async () =>
+    await gotoPageWithNavigationGuard({
+      cdpUrl: opts.cdpUrl,
+      page,
+      url,
+      timeoutMs: timeout,
+      ssrfPolicy: policy,
+      targetId: opts.targetId,
+    });
 
   let response;
   try {
@@ -84,13 +194,14 @@ export async function navigateViaPlaywright(opts: {
     response = await navigate();
   }
 
-  await assertBrowserNavigationRedirectChainAllowed({
-    request: response?.request(),
-    ...withBrowserNavigationPolicy(policy),
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page,
+    response,
+    ssrfPolicy: policy,
+    targetId: opts.targetId,
   });
-  const finalUrl = page.url();
-  await assertBrowserNavigationResultAllowed({ url: finalUrl, ...withBrowserNavigationPolicy(policy) });
-  return { url: finalUrl };
+  return { url: page.url() };
 }
 
 export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<BrowserTab[]> {
@@ -98,8 +209,9 @@ export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
   const pages = getAllPages(browser);
   const results: BrowserTab[] = [];
   for (const page of pages) {
+    if (isBlockedPageRef(opts.cdpUrl, page)) continue;
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid !== null && tid !== '')
+    if (tid !== null && tid !== '' && !isBlockedTarget(opts.cdpUrl, tid))
       results.push({
         targetId: tid,
         title: await page.title().catch(() => ''),
@@ -125,6 +237,9 @@ export async function createPageViaPlaywright(opts: {
   ensureContextState(context);
   const page = await context.newPage();
   ensurePageState(page);
+  clearBlockedPageRef(opts.cdpUrl, page);
+  const createdTargetId = await pageTargetId(page).catch(() => null);
+  clearBlockedTarget(opts.cdpUrl, createdTargetId ?? undefined);
 
   const targetUrl = (opts.url ?? '').trim() || 'about:blank';
   /* eslint-disable @typescript-eslint/no-deprecated */
@@ -133,16 +248,30 @@ export async function createPageViaPlaywright(opts: {
   /* eslint-enable @typescript-eslint/no-deprecated */
 
   if (targetUrl !== 'about:blank') {
-    const navigationPolicy = withBrowserNavigationPolicy(policy);
-    await assertBrowserNavigationAllowed({ url: targetUrl, ...navigationPolicy });
-    await assertBrowserNavigationRedirectChainAllowed({
-      request: (await page.goto(targetUrl, { timeout: 30000 }).catch(() => null))?.request(),
-      ...navigationPolicy,
+    await assertBrowserNavigationAllowed({ url: targetUrl, ...withBrowserNavigationPolicy(policy) });
+    let response: Awaited<ReturnType<Page['goto']>> = null;
+    try {
+      response = await gotoPageWithNavigationGuard({
+        cdpUrl: opts.cdpUrl,
+        page,
+        url: targetUrl,
+        timeoutMs: 30000,
+        ssrfPolicy: policy,
+        targetId: createdTargetId ?? undefined,
+      });
+    } catch (err) {
+      if (isPolicyDenyNavigationError(err) || err instanceof BlockedBrowserTargetError) throw err;
+    }
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response,
+      ssrfPolicy: policy,
+      targetId: createdTargetId ?? undefined,
     });
-    await assertBrowserNavigationResultAllowed({ url: page.url(), ...navigationPolicy });
   }
 
-  const tid = await pageTargetId(page).catch(() => null);
+  const tid = createdTargetId ?? (await pageTargetId(page).catch(() => null));
   if (tid === null || tid === '') throw new Error('Failed to get targetId for new page');
   return {
     targetId: tid,

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -516,7 +516,8 @@ function isWebSocketUrl(url: string): boolean {
 }
 
 export function isLoopbackHost(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+  const h = hostname.replace(/\.+$/, '');
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '[::1]';
 }
 
 const PROXY_ENV_KEYS = ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy'];

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -239,6 +239,88 @@ export function bumpDownloadArmId(): number {
   return nextDownloadArmId;
 }
 
+// ── Blocked Target Tracking ──
+
+export class BlockedBrowserTargetError extends Error {
+  constructor() {
+    super('Browser target is unavailable after SSRF policy blocked its navigation.');
+    this.name = 'BlockedBrowserTargetError';
+  }
+}
+
+const blockedTargetsByCdpUrl = new Set<string>();
+const blockedPageRefsByCdpUrl = new Map<string, WeakSet<Page>>();
+
+function blockedTargetKey(cdpUrl: string, targetId: string): string {
+  return `${normalizeCdpUrl(cdpUrl)}::${targetId}`;
+}
+
+export function isBlockedTarget(cdpUrl: string, targetId?: string): boolean {
+  const normalized = targetId?.trim() ?? '';
+  if (normalized === '') return false;
+  return blockedTargetsByCdpUrl.has(blockedTargetKey(cdpUrl, normalized));
+}
+
+export function markTargetBlocked(cdpUrl: string, targetId?: string): void {
+  const normalized = targetId?.trim() ?? '';
+  if (normalized === '') return;
+  blockedTargetsByCdpUrl.add(blockedTargetKey(cdpUrl, normalized));
+}
+
+export function clearBlockedTarget(cdpUrl: string, targetId?: string): void {
+  const normalized = targetId?.trim() ?? '';
+  if (normalized === '') return;
+  blockedTargetsByCdpUrl.delete(blockedTargetKey(cdpUrl, normalized));
+}
+
+function hasBlockedTargetsForCdpUrl(cdpUrl: string): boolean {
+  const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
+  for (const key of blockedTargetsByCdpUrl) {
+    if (key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function clearBlockedTargetsForCdpUrl(cdpUrl?: string): void {
+  if (cdpUrl === undefined) {
+    blockedTargetsByCdpUrl.clear();
+    return;
+  }
+  const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
+  for (const key of blockedTargetsByCdpUrl) {
+    if (key.startsWith(prefix)) blockedTargetsByCdpUrl.delete(key);
+  }
+}
+
+function blockedPageRefsForCdpUrl(cdpUrl: string): WeakSet<Page> {
+  const normalized = normalizeCdpUrl(cdpUrl);
+  const existing = blockedPageRefsByCdpUrl.get(normalized);
+  if (existing) return existing;
+  const created = new WeakSet<Page>();
+  blockedPageRefsByCdpUrl.set(normalized, created);
+  return created;
+}
+
+export function isBlockedPageRef(cdpUrl: string, page: Page): boolean {
+  return blockedPageRefsByCdpUrl.get(normalizeCdpUrl(cdpUrl))?.has(page) ?? false;
+}
+
+export function markPageRefBlocked(cdpUrl: string, page: Page): void {
+  blockedPageRefsForCdpUrl(cdpUrl).add(page);
+}
+
+function clearBlockedPageRefsForCdpUrl(cdpUrl?: string): void {
+  if (cdpUrl === undefined) {
+    blockedPageRefsByCdpUrl.clear();
+    return;
+  }
+  blockedPageRefsByCdpUrl.delete(normalizeCdpUrl(cdpUrl));
+}
+
+export function clearBlockedPageRef(cdpUrl: string, page: Page): void {
+  blockedPageRefsByCdpUrl.get(normalizeCdpUrl(cdpUrl))?.delete(page);
+}
+
 // ── Context State Management ──
 
 export function ensureContextState(context: BrowserContext): ContextState {
@@ -602,6 +684,8 @@ export async function disconnectBrowser(): Promise<void> {
 export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string }): Promise<void> {
   if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
     const normalized = normalizeCdpUrl(opts.cdpUrl);
+    clearBlockedTargetsForCdpUrl(normalized);
+    clearBlockedPageRefsForCdpUrl(normalized);
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
@@ -612,6 +696,8 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
       /* noop */
     });
   } else {
+    clearBlockedTargetsForCdpUrl();
+    clearBlockedPageRefsForCdpUrl();
     await disconnectBrowser();
   }
 }
@@ -833,11 +919,47 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
   return null;
 }
 
+async function partitionAccessiblePages(opts: {
+  cdpUrl: string;
+  pages: Page[];
+}): Promise<{ accessible: Page[]; blockedCount: number }> {
+  const accessible: Page[] = [];
+  let blockedCount = 0;
+  for (const page of opts.pages) {
+    if (isBlockedPageRef(opts.cdpUrl, page)) {
+      blockedCount += 1;
+      continue;
+    }
+    const targetId = await pageTargetId(page).catch(() => null);
+    if (targetId === null || targetId === '') {
+      if (hasBlockedTargetsForCdpUrl(opts.cdpUrl)) {
+        blockedCount += 1;
+        continue;
+      }
+      accessible.push(page);
+      continue;
+    }
+    if (isBlockedTarget(opts.cdpUrl, targetId)) {
+      blockedCount += 1;
+      continue;
+    }
+    accessible.push(page);
+  }
+  return { accessible, blockedCount };
+}
+
 export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string }) {
+  if (opts.targetId !== undefined && opts.targetId !== '' && isBlockedTarget(opts.cdpUrl, opts.targetId))
+    throw new BlockedBrowserTargetError();
   const { browser } = await connectBrowser(opts.cdpUrl);
   const pages = getAllPages(browser);
   if (!pages.length) throw new Error('No pages available in the connected browser.');
-  const first = pages[0];
+  const { accessible, blockedCount } = await partitionAccessiblePages({ cdpUrl: opts.cdpUrl, pages });
+  if (!accessible.length) {
+    if (blockedCount > 0) throw new BlockedBrowserTargetError();
+    throw new Error('No pages available in the connected browser.');
+  }
+  const first = accessible[0];
   if (opts.targetId === undefined || opts.targetId === '') return first;
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
@@ -846,6 +968,10 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
       `Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`,
     );
   }
+  if (isBlockedPageRef(opts.cdpUrl, found)) throw new BlockedBrowserTargetError();
+  const foundTargetId = await pageTargetId(found).catch(() => null);
+  if (foundTargetId !== null && foundTargetId !== '' && isBlockedTarget(opts.cdpUrl, foundTargetId))
+    throw new BlockedBrowserTargetError();
   return found;
 }
 


### PR DESCRIPTION
## Summary

Ports security fixes from OpenClaw 2026.4.2:

- **Real-time SSRF redirect interception** (#58771) — `gotoPageWithNavigationGuard` installs a Playwright route handler before `page.goto()` to intercept and abort navigation to private/internal IPs mid-redirect, instead of checking post-hoc. Closes a TOCTOU window where a 302 redirect to a private IP could exfiltrate internal data before the post-navigation check runs.
- **Blocked-target tracking** — Pages/targets that had SSRF-blocked navigations are quarantined. `getPageForTargetId`, `listPagesViaPlaywright` skip blocked entries. `closePlaywrightBrowserConnection` cleans up tracked state.
- **`isLoopbackHost` trailing-dot normalization** (#59236) — Strips trailing dots so `localhost.` is recognized as loopback, fixing CDP websocket URL rewriting for absolute-form hostnames.
- **Version bump** to 0.11.1

### Skipped (cosmetic, not applicable)
- Profile decoration extra color keys + `isProfileDecorated` guard (known diff #45)

### Known differences updated
- #21 updated (trailing-dot now handled)
- #45 added (profile decoration)