### PR TITLE
Convert remaining JS files to TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: node scripts/check-exports.js
+      - run: npx tsx scripts/check-exports.ts

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
-    "check-exports": "node scripts/check-exports.js",
-    "prepublishOnly": "npm run build && node scripts/check-exports.js",
+    "check-exports": "npx tsx scripts/check-exports.ts",
+    "prepublishOnly": "npm run build && npx tsx scripts/check-exports.ts",
     "test": "echo \"No tests yet\" && exit 0"
   },
   "keywords": [

--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -26,13 +26,9 @@ const REQUIRED_EXPORTS = [
 ];
 
 // Methods that must exist on CrawlPage (checked via declaration in the .d.ts)
-const REQUIRED_METHODS = [
-  'pressAndHold',
-  'waitForRequest',
-  'waitForTab',
-];
+const REQUIRED_METHODS = ['pressAndHold', 'waitForRequest', 'waitForTab'];
 
-let dts;
+let dts: string;
 try {
   dts = readFileSync(DTS_PATH, 'utf8');
 } catch {
@@ -40,7 +36,7 @@ try {
   process.exit(1);
 }
 
-const failures = [];
+const failures: string[] = [];
 
 for (const name of REQUIRED_EXPORTS) {
   if (!dts.includes(name)) {
@@ -66,4 +62,6 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`Export check passed — ${REQUIRED_EXPORTS.length} exports and ${REQUIRED_METHODS.length} methods verified.`);
+console.log(
+  `Export check passed — ${REQUIRED_EXPORTS.length} exports and ${REQUIRED_METHODS.length} methods verified.`,
+);

--- a/test-skill.ts
+++ b/test-skill.ts
@@ -2,18 +2,20 @@
  * Browserclaw skill test: StreetEasy studio apartments in Chelsea under $4,500
  */
 
-const { BrowserClaw } = require('./dist/index.cjs');
-const fs = require('fs');
+import { BrowserClaw } from './src/index.js';
+import fs from 'fs';
 
-function log(msg) {
+function log(msg: string) {
   console.log(`[${new Date().toISOString()}] ${msg}`);
 }
 
-async function waitForLoad(page, label) {
+async function waitForLoad(page: Page, label: string) {
   await page.waitFor({ loadState: 'networkidle', timeoutMs: 20000 }).catch(() => log(`load timeout (${label})`));
 }
 
-async function snapshotWithRetry(page, label) {
+type Page = Awaited<ReturnType<BrowserClaw['currentPage']>>;
+
+async function snapshotWithRetry(page: Page, label: string) {
   for (let i = 0; i < 5; i++) {
     const { snapshot, refs } = await page.snapshot({ interactive: true, compact: true });
     const lines = snapshot.split('\n').filter((l) => l.trim());
@@ -31,7 +33,7 @@ async function snapshotWithRetry(page, label) {
 const BUTTON_Y_OFFSET = 60;
 const PRESS_HOLD_PATTERN = /press.*hold|hold.*to.*confirm/i;
 
-async function findPressHoldCoords(page) {
+async function findPressHoldCoords(page: Page) {
   const result = await page.evaluate(`
     (function() {
       var PATTERN = /press.*hold|verify.*human|hold.*to.*confirm|not a bot/i;
@@ -112,7 +114,7 @@ async function findPressHoldCoords(page) {
   return parsed.best;
 }
 
-async function handlePressAndHold(page) {
+async function handlePressAndHold(page: Page) {
   const coords = await findPressHoldCoords(page);
   if (!coords) {
     log('Press & Hold button not found');


### PR DESCRIPTION
## Summary
- Renamed `scripts/check-exports.js` → `.ts` with type annotations
- Converted `test-skill.cjs` → `.ts` with ESM imports and type annotations
- Updated `package.json` scripts to use `tsx` for check-exports
- Zero tracked JS/CJS files remain — 100% TypeScript