### PR TITLE
Make the code fully typescript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json linguist-generated


### PR DESCRIPTION
Marks package-lock.json as linguist-generated so GitHub stops counting it as JavaScript.