### PR TITLE
Fix linguist attributes for 100% TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-package-lock.json linguist-generated
+package-lock.json linguist-generated=true linguist-vendored=true


### PR DESCRIPTION
Adds =true and linguist-vendored to properly exclude package-lock.json from language stats.