### PR TITLE
Remove node shebang causing JS classification

### DIFF
--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * Verifies that the built dist/index.d.ts contains all expected public APIs.
  * Run after `npm run build` to catch accidental removals before publishing.


### PR DESCRIPTION
The shebang line makes GitHub Linguist classify check-exports.ts as JavaScript. Removing it — we run it with tsx, not directly.