### PR TITLE
Guard against prototype pollution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -445,11 +445,15 @@ function safeWriteJson(filePath: string, data: Record<string, unknown>): void {
 function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown): void {
   let node: Record<string, unknown> = obj;
   for (const key of keys.slice(0, -1)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') return;
     const next = node[key];
     if (typeof next !== 'object' || next === null || Array.isArray(next)) node[key] = {};
+    // nosemgrep: prototype-pollution-loop -- guarded above
     node = node[key] as Record<string, unknown>;
   }
-  node[keys[keys.length - 1]] = value;
+  const lastKey = keys[keys.length - 1];
+  if (lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') return;
+  node[lastKey] = value;
 }
 
 function parseHexRgbToSignedArgbInt(hex: string): number | null {


### PR DESCRIPTION
## Summary
- Adds prototype pollution guards to `setDeep` in `chrome-launcher.ts`
- Rejects dangerous keys (`__proto__`, `constructor`, `prototype`) that could modify `Object.prototype`
- Found by Semgrep SAST scan (`prototype-pollution-loop` rule)

## Context
All current callers use hardcoded key paths so there's no active exploit — this is a defensive hardening against future misuse.