### PR TITLE
Fix bugs found in code review

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.11.3",
+  "version": "0.11.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -47,8 +47,8 @@ export async function evaluateInAllFramesViaPlaywright(opts: {
         frameName: frame.name(),
         result,
       });
-    } catch {
-      // Frame may have been detached or navigation in progress — skip
+    } catch (err) {
+      console.warn('[browserclaw] frame evaluate failed:', err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -105,8 +105,8 @@ export async function clickByTextViaPlaywright(opts: {
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   const locator = page
     .getByText(opts.text, { exact: opts.exact })
-    .and(page.locator(':visible'))
     .or(page.getByTitle(opts.text, { exact: opts.exact }))
+    .and(page.locator(':visible'))
     .first();
   try {
     await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -160,6 +160,8 @@ function axValue(v: { value?: string | number | boolean } | undefined): string {
 }
 
 function formatAriaNodes(nodes: CdpAXNode[], limit: number): AriaNode[] {
+  if (nodes.length === 0) return [];
+
   const byId = new Map<string, CdpAXNode>();
   for (const n of nodes) if (n.nodeId) byId.set(n.nodeId, n);
 
@@ -167,7 +169,7 @@ function formatAriaNodes(nodes: CdpAXNode[], limit: number): AriaNode[] {
   for (const n of nodes) for (const c of n.childIds ?? []) referenced.add(c);
 
   const root = nodes.find((n) => n.nodeId !== '' && !referenced.has(n.nodeId)) ?? nodes[0];
-  if (!root || root.nodeId === '') return [];
+  if (root.nodeId === '') return [];
 
   const out: AriaNode[] = [];
   const stack: { id: string; depth: number }[] = [{ id: root.nodeId, depth: 0 }];

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -167,7 +167,7 @@ function formatAriaNodes(nodes: CdpAXNode[], limit: number): AriaNode[] {
   for (const n of nodes) for (const c of n.childIds ?? []) referenced.add(c);
 
   const root = nodes.find((n) => n.nodeId !== '' && !referenced.has(n.nodeId)) ?? nodes[0];
-  if (root.nodeId === '') return [];
+  if (!root || root.nodeId === '') return [];
 
   const out: AriaNode[] = [];
   const stack: { id: string; depth: number }[] = [{ id: root.nodeId, depth: 0 }];


### PR DESCRIPTION
## Summary
- **formatAriaNodes crash**: Guard against empty nodes array — `root` was `undefined` when CDP returned no accessibility nodes
- **clickByTextViaPlaywright locator**: Fix operator precedence — visibility check now applies to both text and title matches: `(text ∪ title) ∩ visible` instead of `(text ∩ visible) ∪ title`
- **evaluateInAllFramesViaPlaywright**: Log warning on frame eval failure instead of silently swallowing errors

Bumps to 0.11.3.

## Test plan
- [ ] Run `clickByText` against a page with hidden title-matching elements — should no longer match them
- [ ] Call `snapshot()` on a page where CDP returns empty nodes array — should return `[]` without crashing
- [ ] Call `evaluateInAllFrames` with invalid JS — should see `[browserclaw]` warning in console