### PR TITLE
Add security.ts test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "prettier": "^3.8.1",
         "tsup": "^8.0.0",
         "typescript": "^5.7.0",
-        "typescript-eslint": "^8.57.2"
+        "typescript-eslint": "^8.57.2",
+        "vitest": "^4.1.2"
       },
       "engines": {
         "node": ">=18"
@@ -703,10 +704,301 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@package-json/types": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1060,6 +1352,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1070,6 +1369,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1604,6 +1921,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1650,6 +2080,16 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1698,6 +2138,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -1753,6 +2203,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1790,6 +2247,23 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2105,6 +2579,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2113,6 +2597,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2382,6 +2876,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2486,6 +3241,25 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -2518,6 +3292,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2650,6 +3435,35 @@
         "node": ">=18"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
@@ -2763,6 +3577,40 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -2844,6 +3692,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -2852,6 +3707,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stable-hash-x": {
@@ -2863,6 +3728,20 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2910,6 +3789,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -2932,6 +3818,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -3135,6 +4031,176 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3149,6 +4215,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "format:check": "prettier --check src/",
     "check-exports": "npx tsx scripts/check-exports.ts",
     "prepublishOnly": "npm run build && npx tsx scripts/check-exports.ts",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "vitest run"
   },
   "keywords": [
     "browser",
@@ -75,6 +75,7 @@
     "prettier": "^3.8.1",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
-    "typescript-eslint": "^8.57.2"
+    "typescript-eslint": "^8.57.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile, symlink, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
 import {
   isInternalUrl,
   createPinnedLookup,
@@ -22,11 +28,8 @@ import {
   DEFAULT_DOWNLOAD_DIR,
   DEFAULT_UPLOAD_DIR,
 } from './security.js';
+import type { LookupFn } from './security.js';
 import type { SsrfPolicy } from './types.js';
-import { resolve, join, sep } from 'node:path';
-import { mkdir, writeFile, symlink, rm, realpath } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { randomUUID } from 'node:crypto';
 
 // ── Helpers ──
 
@@ -36,26 +39,64 @@ const STRICT_POLICY: SsrfPolicy = { dangerouslyAllowPrivateNetwork: false };
 /** Permissive policy: private network allowed */
 const PERMISSIVE_POLICY: SsrfPolicy = { dangerouslyAllowPrivateNetwork: true };
 
-/** Mock DNS lookup that resolves to the given addresses */
-function mockLookup(addresses: { address: string; family: number }[]): any {
-  return async (_hostname: string, _opts?: any) => addresses;
-}
-
 /** Mock DNS lookup that resolves a hostname to a single public IP */
-function mockPublicLookup(): any {
-  return async (_hostname: string, _opts?: any) => [{ address: '93.184.216.34', family: 4 }];
+function mockPublicLookup(): LookupFn {
+  return (() => Promise.resolve([{ address: '93.184.216.34', family: 4 }])) as unknown as LookupFn;
 }
 
 /** Mock DNS lookup that resolves a hostname to a loopback IP */
-function mockLoopbackLookup(): any {
-  return async (_hostname: string, _opts?: any) => [{ address: '127.0.0.1', family: 4 }];
+function mockLoopbackLookup(): LookupFn {
+  return (() => Promise.resolve([{ address: '127.0.0.1', family: 4 }])) as unknown as LookupFn;
 }
 
 /** Mock DNS lookup that throws (simulating failed resolution) */
-function mockFailingLookup(): any {
-  return async () => {
-    throw new Error('DNS resolution failed');
-  };
+function mockFailingLookup(): LookupFn {
+  return (() => Promise.reject(new Error('DNS resolution failed'))) as unknown as LookupFn;
+}
+
+/** DNS record shape returned by pinned lookup */
+interface DnsRecord {
+  address: string;
+  family: number;
+}
+
+// Typed callback overloads for calling pinned lookup in tests.
+// dns.lookup has complex overloads; these narrow them for test convenience.
+
+type SingleCb = (
+  hostname: string,
+  cb: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+) => void;
+
+type AllCb = (
+  hostname: string,
+  opts: { all: true; family?: number },
+  cb: (err: NodeJS.ErrnoException | null, records: DnsRecord[]) => void,
+) => void;
+
+/** Invoke pinned lookup (single-result, 2-arg form) and return a promise */
+function callPinnedSingle(
+  lookup: ReturnType<typeof createPinnedLookup>,
+  hostname: string,
+): Promise<{ err: NodeJS.ErrnoException | null; address: string; family: number }> {
+  return new Promise((res) => {
+    (lookup as unknown as SingleCb)(hostname, (err, address, family) => {
+      res({ err, address, family });
+    });
+  });
+}
+
+/** Invoke pinned lookup with { all: true } and return a promise */
+function callPinnedAll(
+  lookup: ReturnType<typeof createPinnedLookup>,
+  hostname: string,
+  opts?: { family?: number },
+): Promise<DnsRecord[]> {
+  return new Promise((res) => {
+    (lookup as unknown as AllCb)(hostname, { all: true, ...opts }, (_err, records) => {
+      res(records);
+    });
+  });
 }
 
 // ── Temp directory helpers for filesystem tests ──
@@ -483,7 +524,6 @@ describe('security.ts', () => {
     });
 
     it('should reject javascript: protocol', async () => {
-      // eslint-disable-next-line no-script-url
       await expect(assertBrowserNavigationAllowed({ url: 'javascript:alert(1)' })).rejects.toThrow(
         'unsupported protocol',
       );
@@ -596,7 +636,7 @@ describe('security.ts', () => {
     });
 
     it('should block when DNS returns empty results', async () => {
-      const emptyLookup: any = async () => [];
+      const emptyLookup = (() => Promise.resolve([])) as unknown as LookupFn;
       await expect(
         resolvePinnedHostnameWithPolicy('empty.com', {
           lookupFn: emptyLookup,
@@ -615,11 +655,12 @@ describe('security.ts', () => {
     });
 
     it('should prefer IPv4 addresses over IPv6 in deduplication', async () => {
-      const multiLookup: any = async () => [
-        { address: '2607:f8b0:4004:800::200e', family: 6 },
-        { address: '93.184.216.34', family: 4 },
-        { address: '2607:f8b0:4004:800::200f', family: 6 },
-      ];
+      const multiLookup = (() =>
+        Promise.resolve([
+          { address: '2607:f8b0:4004:800::200e', family: 6 },
+          { address: '93.184.216.34', family: 4 },
+          { address: '2607:f8b0:4004:800::200f', family: 6 },
+        ])) as unknown as LookupFn;
       const result = await resolvePinnedHostnameWithPolicy('multi.com', {
         lookupFn: multiLookup,
         policy: STRICT_POLICY,
@@ -629,10 +670,11 @@ describe('security.ts', () => {
     });
 
     it('should deduplicate addresses', async () => {
-      const dupLookup: any = async () => [
-        { address: '93.184.216.34', family: 4 },
-        { address: '93.184.216.34', family: 4 },
-      ];
+      const dupLookup = (() =>
+        Promise.resolve([
+          { address: '93.184.216.34', family: 4 },
+          { address: '93.184.216.34', family: 4 },
+        ])) as unknown as LookupFn;
       const result = await resolvePinnedHostnameWithPolicy('dup.com', {
         lookupFn: dupLookup,
         policy: STRICT_POLICY,
@@ -697,11 +739,7 @@ describe('security.ts', () => {
         hostname: 'test.com',
         addresses: ['1.2.3.4'],
       });
-      const result = await new Promise<{ err: any; address: string; family: number }>((resolve) => {
-        (lookup as any)('test.com', (err: any, address: string, family: number) => {
-          resolve({ err, address, family });
-        });
-      });
+      const result = await callPinnedSingle(lookup, 'test.com');
       expect(result.err).toBeNull();
       expect(result.address).toBe('1.2.3.4');
       expect(result.family).toBe(4);
@@ -712,11 +750,7 @@ describe('security.ts', () => {
         hostname: 'test.com',
         addresses: ['1.2.3.4', '2001:db8::1'],
       });
-      const results = await new Promise<any[]>((resolve) => {
-        (lookup as any)('test.com', { all: true }, (err: any, records: any[]) => {
-          resolve(records);
-        });
-      });
+      const results = await callPinnedAll(lookup, 'test.com');
       expect(results).toHaveLength(2);
       expect(results[0]).toEqual({ address: '1.2.3.4', family: 4 });
       expect(results[1]).toEqual({ address: '2001:db8::1', family: 6 });
@@ -727,11 +761,7 @@ describe('security.ts', () => {
         hostname: 'test.com',
         addresses: ['1.2.3.4', '2001:db8::1'],
       });
-      const results = await new Promise<any[]>((resolve) => {
-        (lookup as any)('test.com', { all: true, family: 4 }, (err: any, records: any[]) => {
-          resolve(records);
-        });
-      });
+      const results = await callPinnedAll(lookup, 'test.com', { family: 4 });
       expect(results).toHaveLength(1);
       expect(results[0].address).toBe('1.2.3.4');
     });
@@ -741,11 +771,7 @@ describe('security.ts', () => {
         hostname: 'test.com',
         addresses: ['1.2.3.4'], // only IPv4
       });
-      const results = await new Promise<any[]>((resolve) => {
-        (lookup as any)('test.com', { all: true, family: 6 }, (err: any, records: any[]) => {
-          resolve(records);
-        });
-      });
+      const results = await callPinnedAll(lookup, 'test.com', { family: 6 });
       expect(results).toHaveLength(1);
       expect(results[0].address).toBe('1.2.3.4');
     });
@@ -757,7 +783,7 @@ describe('security.ts', () => {
       });
       const addresses: string[] = [];
       for (let i = 0; i < 3; i++) {
-        (lookup as any)('test.com', (_err: any, addr: string) => {
+        (lookup as unknown as SingleCb)('test.com', (_err, addr) => {
           addresses.push(addr);
         });
       }
@@ -767,19 +793,15 @@ describe('security.ts', () => {
     });
 
     it('should use fallback for non-matching hostnames', async () => {
-      const fallback = ((_host: string, cb: any) => {
+      const fallback = ((_host: string, cb: (err: null, address: string, family: number) => void) => {
         cb(null, '9.9.9.9', 4);
-      }) as any;
+      }) as unknown as ReturnType<typeof createPinnedLookup>;
       const lookup = createPinnedLookup({
         hostname: 'pinned.com',
         addresses: ['1.2.3.4'],
         fallback,
       });
-      const result = await new Promise<{ err: any; address: string }>((resolve) => {
-        (lookup as any)('other.com', (err: any, address: string) => {
-          resolve({ err, address });
-        });
-      });
+      const result = await callPinnedSingle(lookup, 'other.com');
       expect(result.err).toBeNull();
       expect(result.address).toBe('9.9.9.9');
     });
@@ -789,11 +811,7 @@ describe('security.ts', () => {
         hostname: 'Test.Com',
         addresses: ['1.2.3.4'],
       });
-      const result = await new Promise<{ err: any; address: string }>((resolve) => {
-        (lookup as any)('test.com', (err: any, address: string) => {
-          resolve({ err, address });
-        });
-      });
+      const result = await callPinnedSingle(lookup, 'test.com');
       expect(result.err).toBeNull();
       expect(result.address).toBe('1.2.3.4');
     });
@@ -1036,7 +1054,7 @@ describe('security.ts', () => {
     });
 
     it('should reject null-ish path', async () => {
-      await expect(assertSafeOutputPath(null as any)).rejects.toThrow('Output path is required');
+      await expect(assertSafeOutputPath(null as unknown as string)).rejects.toThrow('Output path is required');
     });
 
     it('should reject path with directory traversal', async () => {
@@ -1395,9 +1413,7 @@ describe('security.ts', () => {
         writeViaSiblingTempPath({
           rootDir: tempRoot,
           targetPath,
-          writeTemp: async () => {
-            throw new Error('Write failed');
-          },
+          writeTemp: () => Promise.reject(new Error('Write failed')),
         }),
       ).rejects.toThrow('Write failed');
       // Verify temp file is cleaned up

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -1,0 +1,1463 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isInternalUrl,
+  createPinnedLookup,
+  resolvePinnedHostnameWithPolicy,
+  assertBrowserNavigationAllowed,
+  assertSafeOutputPath,
+  assertSafeUploadPaths,
+  resolveStrictExistingUploadPaths,
+  resolvePathWithinRoot,
+  resolveWritablePathWithinRoot,
+  resolveExistingPathsWithinRoot,
+  resolveStrictExistingPathsWithinRoot,
+  sanitizeUntrustedFileName,
+  writeViaSiblingTempPath,
+  assertBrowserNavigationResultAllowed,
+  assertBrowserNavigationRedirectChainAllowed,
+  requiresInspectableBrowserNavigationRedirects,
+  withBrowserNavigationPolicy,
+  InvalidBrowserNavigationUrlError,
+  DEFAULT_BROWSER_TMP_DIR,
+  DEFAULT_DOWNLOAD_DIR,
+  DEFAULT_UPLOAD_DIR,
+} from './security.js';
+import type { SsrfPolicy } from './types.js';
+import { resolve, join, sep } from 'node:path';
+import { mkdir, writeFile, symlink, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+// ── Helpers ──
+
+/** Strict policy: private network NOT allowed */
+const STRICT_POLICY: SsrfPolicy = { dangerouslyAllowPrivateNetwork: false };
+
+/** Permissive policy: private network allowed */
+const PERMISSIVE_POLICY: SsrfPolicy = { dangerouslyAllowPrivateNetwork: true };
+
+/** Mock DNS lookup that resolves to the given addresses */
+function mockLookup(addresses: { address: string; family: number }[]): any {
+  return async (_hostname: string, _opts?: any) => addresses;
+}
+
+/** Mock DNS lookup that resolves a hostname to a single public IP */
+function mockPublicLookup(): any {
+  return async (_hostname: string, _opts?: any) => [{ address: '93.184.216.34', family: 4 }];
+}
+
+/** Mock DNS lookup that resolves a hostname to a loopback IP */
+function mockLoopbackLookup(): any {
+  return async (_hostname: string, _opts?: any) => [{ address: '127.0.0.1', family: 4 }];
+}
+
+/** Mock DNS lookup that throws (simulating failed resolution) */
+function mockFailingLookup(): any {
+  return async () => {
+    throw new Error('DNS resolution failed');
+  };
+}
+
+// ── Temp directory helpers for filesystem tests ──
+
+async function createTempRoot(): Promise<string> {
+  const root = join(tmpdir(), `browserclaw-test-${randomUUID()}`);
+  await mkdir(root, { recursive: true });
+  // Resolve symlinks (macOS /tmp -> /private/tmp) so path confinement checks work
+  return realpath(root);
+}
+
+// ── Tests ──
+
+describe('security.ts', () => {
+  // ────────────────────────────────────────────────
+  // Default constants
+  // ────────────────────────────────────────────────
+
+  describe('default constants', () => {
+    it('should export DEFAULT_BROWSER_TMP_DIR', () => {
+      expect(typeof DEFAULT_BROWSER_TMP_DIR).toBe('string');
+      expect(DEFAULT_BROWSER_TMP_DIR.length).toBeGreaterThan(0);
+    });
+
+    it('should export DEFAULT_DOWNLOAD_DIR as a subdirectory of DEFAULT_BROWSER_TMP_DIR', () => {
+      expect(DEFAULT_DOWNLOAD_DIR).toContain(DEFAULT_BROWSER_TMP_DIR);
+      expect(DEFAULT_DOWNLOAD_DIR).toContain('downloads');
+    });
+
+    it('should export DEFAULT_UPLOAD_DIR as a subdirectory of DEFAULT_BROWSER_TMP_DIR', () => {
+      expect(DEFAULT_UPLOAD_DIR).toContain(DEFAULT_BROWSER_TMP_DIR);
+      expect(DEFAULT_UPLOAD_DIR).toContain('uploads');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // InvalidBrowserNavigationUrlError
+  // ────────────────────────────────────────────────
+
+  describe('InvalidBrowserNavigationUrlError', () => {
+    it('should be an instance of Error', () => {
+      const err = new InvalidBrowserNavigationUrlError('test');
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('InvalidBrowserNavigationUrlError');
+      expect(err.message).toBe('test');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // withBrowserNavigationPolicy
+  // ────────────────────────────────────────────────
+
+  describe('withBrowserNavigationPolicy', () => {
+    it('should return policy options when policy is provided', () => {
+      const result = withBrowserNavigationPolicy(STRICT_POLICY);
+      expect(result).toEqual({ ssrfPolicy: STRICT_POLICY });
+    });
+
+    it('should return empty options when policy is undefined', () => {
+      const result = withBrowserNavigationPolicy(undefined);
+      expect(result).toEqual({});
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // isInternalUrl — IPv4 private/reserved ranges
+  // ────────────────────────────────────────────────
+
+  describe('isInternalUrl', () => {
+    describe('IPv4 loopback (127.0.0.0/8)', () => {
+      it('should block 127.0.0.1', () => {
+        expect(isInternalUrl('http://127.0.0.1')).toBe(true);
+      });
+
+      it('should block 127.255.255.255', () => {
+        expect(isInternalUrl('http://127.255.255.255')).toBe(true);
+      });
+
+      it('should block 127.0.0.1 with port', () => {
+        expect(isInternalUrl('http://127.0.0.1:8080')).toBe(true);
+      });
+
+      it('should block 127.1.2.3 (non-standard loopback)', () => {
+        expect(isInternalUrl('http://127.1.2.3')).toBe(true);
+      });
+    });
+
+    describe('IPv4 link-local (169.254.0.0/16)', () => {
+      it('should block 169.254.0.1', () => {
+        expect(isInternalUrl('http://169.254.0.1')).toBe(true);
+      });
+
+      it('should block 169.254.169.254 (cloud metadata)', () => {
+        expect(isInternalUrl('http://169.254.169.254')).toBe(true);
+      });
+
+      it('should block 169.254.255.255', () => {
+        expect(isInternalUrl('http://169.254.255.255')).toBe(true);
+      });
+    });
+
+    describe('IPv4 RFC1918 private ranges', () => {
+      it('should block 10.0.0.0/8 start', () => {
+        expect(isInternalUrl('http://10.0.0.1')).toBe(true);
+      });
+
+      it('should block 10.255.255.255 end', () => {
+        expect(isInternalUrl('http://10.255.255.255')).toBe(true);
+      });
+
+      it('should block 172.16.0.1 (/12 start)', () => {
+        expect(isInternalUrl('http://172.16.0.1')).toBe(true);
+      });
+
+      it('should block 172.31.255.255 (/12 end)', () => {
+        expect(isInternalUrl('http://172.31.255.255')).toBe(true);
+      });
+
+      it('should NOT block 172.32.0.1 (just outside /12)', () => {
+        expect(isInternalUrl('http://172.32.0.1')).toBe(false);
+      });
+
+      it('should block 192.168.0.1', () => {
+        expect(isInternalUrl('http://192.168.0.1')).toBe(true);
+      });
+
+      it('should block 192.168.255.255', () => {
+        expect(isInternalUrl('http://192.168.255.255')).toBe(true);
+      });
+    });
+
+    describe('IPv4 broadcast', () => {
+      it('should block 255.255.255.255', () => {
+        expect(isInternalUrl('http://255.255.255.255')).toBe(true);
+      });
+    });
+
+    describe('IPv4 unspecified', () => {
+      it('should block 0.0.0.0', () => {
+        expect(isInternalUrl('http://0.0.0.0')).toBe(true);
+      });
+    });
+
+    describe('IPv4 carrier-grade NAT (100.64.0.0/10)', () => {
+      it('should block 100.64.0.1', () => {
+        expect(isInternalUrl('http://100.64.0.1')).toBe(true);
+      });
+
+      it('should block 100.127.255.255', () => {
+        expect(isInternalUrl('http://100.127.255.255')).toBe(true);
+      });
+    });
+
+    describe('IPv4 multicast (224.0.0.0/4)', () => {
+      it('should block 224.0.0.1', () => {
+        expect(isInternalUrl('http://224.0.0.1')).toBe(true);
+      });
+
+      it('should block 239.255.255.255', () => {
+        expect(isInternalUrl('http://239.255.255.255')).toBe(true);
+      });
+    });
+
+    describe('IPv4 RFC2544 benchmark (198.18.0.0/15)', () => {
+      it('should block 198.18.0.1 by default', () => {
+        expect(isInternalUrl('http://198.18.0.1')).toBe(true);
+      });
+
+      it('should block 198.19.255.255 by default', () => {
+        expect(isInternalUrl('http://198.19.255.255')).toBe(true);
+      });
+
+      it('should allow 198.18.0.1 when allowRfc2544BenchmarkRange is true', () => {
+        expect(isInternalUrl('http://198.18.0.1', { allowRfc2544BenchmarkRange: true })).toBe(false);
+      });
+
+      it('should NOT allow 198.18.0.1 when policy does not explicitly allow it', () => {
+        expect(isInternalUrl('http://198.18.0.1', {})).toBe(true);
+      });
+    });
+
+    describe('valid public IPv4 addresses', () => {
+      it('should allow 8.8.8.8 (Google DNS)', () => {
+        expect(isInternalUrl('http://8.8.8.8')).toBe(false);
+      });
+
+      it('should allow 93.184.216.34 (example.com)', () => {
+        expect(isInternalUrl('http://93.184.216.34')).toBe(false);
+      });
+
+      it('should allow 1.1.1.1 (Cloudflare DNS)', () => {
+        expect(isInternalUrl('http://1.1.1.1')).toBe(false);
+      });
+    });
+
+    // ────────────────────────────────────────────────
+    // isInternalUrl — IPv6 ranges
+    // ────────────────────────────────────────────────
+
+    describe('IPv6 loopback', () => {
+      it('should block ::1', () => {
+        expect(isInternalUrl('http://[::1]')).toBe(true);
+      });
+
+      it('should block ::1 with port', () => {
+        expect(isInternalUrl('http://[::1]:8080')).toBe(true);
+      });
+    });
+
+    describe('IPv6 unspecified', () => {
+      it('should block [::]', () => {
+        expect(isInternalUrl('http://[::]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 link-local (fe80::/10)', () => {
+      it('should block fe80::1', () => {
+        expect(isInternalUrl('http://[fe80::1]')).toBe(true);
+      });
+
+      it('should block febf::1 (end of link-local)', () => {
+        expect(isInternalUrl('http://[febf::1]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 unique-local (fc00::/7)', () => {
+      it('should block fc00::1', () => {
+        expect(isInternalUrl('http://[fc00::1]')).toBe(true);
+      });
+
+      it('should block fd00::1', () => {
+        expect(isInternalUrl('http://[fd00::1]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 multicast (ff00::/8)', () => {
+      it('should block ff02::1', () => {
+        expect(isInternalUrl('http://[ff02::1]')).toBe(true);
+      });
+
+      it('should block ff05::1', () => {
+        expect(isInternalUrl('http://[ff05::1]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 deprecated site-local (fec0::/10)', () => {
+      it('should block fec0::1', () => {
+        expect(isInternalUrl('http://[fec0::1]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 IPv4-mapped addresses (::ffff:x.x.x.x)', () => {
+      it('should block ::ffff:127.0.0.1 (mapped loopback)', () => {
+        expect(isInternalUrl('http://[::ffff:127.0.0.1]')).toBe(true);
+      });
+
+      it('should block ::ffff:192.168.1.1 (mapped private)', () => {
+        expect(isInternalUrl('http://[::ffff:192.168.1.1]')).toBe(true);
+      });
+
+      it('should block ::ffff:10.0.0.1 (mapped RFC1918)', () => {
+        expect(isInternalUrl('http://[::ffff:10.0.0.1]')).toBe(true);
+      });
+
+      it('should allow ::ffff:8.8.8.8 (mapped public)', () => {
+        expect(isInternalUrl('http://[::ffff:8.8.8.8]')).toBe(false);
+      });
+    });
+
+    describe('IPv6 6to4 (2002::/16) with embedded private IPv4', () => {
+      // 2002:7f00:0001:: encodes 127.0.0.1
+      it('should block 2002:7f00:0001:: (encodes 127.0.0.1)', () => {
+        expect(isInternalUrl('http://[2002:7f00:0001::]')).toBe(true);
+      });
+
+      // 2002:c0a8:0101:: encodes 192.168.1.1
+      it('should block 2002:c0a8:0101:: (encodes 192.168.1.1)', () => {
+        expect(isInternalUrl('http://[2002:c0a8:0101::]')).toBe(true);
+      });
+
+      // 2002:0a00:0001:: encodes 10.0.0.1
+      it('should block 2002:0a00:0001:: (encodes 10.0.0.1)', () => {
+        expect(isInternalUrl('http://[2002:0a00:0001::]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 Teredo (2001:0000::/32) with embedded private IPv4', () => {
+      // Teredo encodes IPv4 as XOR with 0xFFFF in last 32 bits
+      // 127.0.0.1 = 7f.00.00.01 XOR ffff = 80ff:fffe
+      it('should block 2001:0000::80ff:fffe (Teredo loopback)', () => {
+        expect(isInternalUrl('http://[2001:0000::80ff:fffe]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 NAT64 (64:ff9b::/96)', () => {
+      // 64:ff9b::127.0.0.1 — rfc6052 range with embedded loopback
+      it('should block 64:ff9b::7f00:1 (NAT64 loopback)', () => {
+        expect(isInternalUrl('http://[64:ff9b::7f00:1]')).toBe(true);
+      });
+    });
+
+    describe('IPv6 ISATAP embedded IPv4', () => {
+      // ISATAP: parts[4]=0x0000, parts[5]=0x5efe, followed by IPv4
+      it('should block ::0:5efe:7f00:1 (ISATAP loopback)', () => {
+        expect(isInternalUrl('http://[::5efe:127.0.0.1]')).toBe(true);
+      });
+    });
+
+    describe('valid public IPv6', () => {
+      it('should allow 2607:f8b0:4004:800::200e (Google)', () => {
+        expect(isInternalUrl('http://[2607:f8b0:4004:800::200e]')).toBe(false);
+      });
+    });
+
+    // ────────────────────────────────────────────────
+    // isInternalUrl — Hostname blocking
+    // ────────────────────────────────────────────────
+
+    describe('hostname blocking', () => {
+      it('should block localhost', () => {
+        expect(isInternalUrl('http://localhost')).toBe(true);
+      });
+
+      it('should block localhost.localdomain', () => {
+        expect(isInternalUrl('http://localhost.localdomain')).toBe(true);
+      });
+
+      it('should block metadata.google.internal', () => {
+        expect(isInternalUrl('http://metadata.google.internal')).toBe(true);
+      });
+
+      it('should block *.localhost subdomains', () => {
+        expect(isInternalUrl('http://foo.localhost')).toBe(true);
+        expect(isInternalUrl('http://bar.baz.localhost')).toBe(true);
+      });
+
+      it('should block *.local domains', () => {
+        expect(isInternalUrl('http://myhost.local')).toBe(true);
+      });
+
+      it('should block *.internal domains', () => {
+        expect(isInternalUrl('http://my-service.internal')).toBe(true);
+      });
+
+      it('should block LOCALHOST (case-insensitive)', () => {
+        expect(isInternalUrl('http://LOCALHOST')).toBe(true);
+      });
+
+      it('should block localhost. (trailing dot)', () => {
+        expect(isInternalUrl('http://localhost.')).toBe(true);
+      });
+    });
+
+    describe('valid public hostnames', () => {
+      it('should allow example.com', () => {
+        expect(isInternalUrl('http://example.com')).toBe(false);
+      });
+
+      it('should allow google.com', () => {
+        expect(isInternalUrl('https://google.com')).toBe(false);
+      });
+    });
+
+    // ────────────────────────────────────────────────
+    // isInternalUrl — Edge cases
+    // ────────────────────────────────────────────────
+
+    describe('edge cases', () => {
+      it('should treat invalid URL as internal (fail-closed)', () => {
+        expect(isInternalUrl('not-a-url')).toBe(true);
+      });
+
+      it('should treat empty string as internal (fail-closed)', () => {
+        expect(isInternalUrl('')).toBe(true);
+      });
+
+      it('should handle URL with path', () => {
+        expect(isInternalUrl('http://127.0.0.1/admin')).toBe(true);
+      });
+
+      it('should handle URL with query string', () => {
+        expect(isInternalUrl('http://192.168.1.1?foo=bar')).toBe(true);
+      });
+
+      it('should handle URL with credentials', () => {
+        expect(isInternalUrl('http://user:pass@127.0.0.1')).toBe(true);
+      });
+    });
+
+    // ────────────────────────────────────────────────
+    // isInternalUrl — Legacy/non-canonical IPv4 literals
+    // ────────────────────────────────────────────────
+
+    describe('legacy IPv4 literals (non-canonical formats)', () => {
+      it('should block octal IP format like 0177.0.0.1', () => {
+        // Non-canonical formats should be blocked (fail-closed)
+        expect(isInternalUrl('http://0177.0.0.1')).toBe(true);
+      });
+
+      it('should block hex IP format like 0x7f.0.0.1', () => {
+        expect(isInternalUrl('http://0x7f.0.0.1')).toBe(true);
+      });
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // assertBrowserNavigationAllowed
+  // ────────────────────────────────────────────────
+
+  describe('assertBrowserNavigationAllowed', () => {
+    it('should reject empty URL', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: '' })).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should reject invalid URL', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'not-a-url' })).rejects.toThrow(
+        InvalidBrowserNavigationUrlError,
+      );
+    });
+
+    it('should reject file: protocol', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'file:///etc/passwd' })).rejects.toThrow(
+        'unsupported protocol',
+      );
+    });
+
+    it('should reject javascript: protocol', async () => {
+      // eslint-disable-next-line no-script-url
+      await expect(assertBrowserNavigationAllowed({ url: 'javascript:alert(1)' })).rejects.toThrow(
+        'unsupported protocol',
+      );
+    });
+
+    it('should reject data: protocol', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'data:text/html,<h1>Hi</h1>' })).rejects.toThrow(
+        'unsupported protocol',
+      );
+    });
+
+    it('should reject ftp: protocol', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'ftp://ftp.example.com' })).rejects.toThrow(
+        'unsupported protocol',
+      );
+    });
+
+    it('should allow about:blank', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'about:blank' })).resolves.toBeUndefined();
+    });
+
+    it('should allow public URL with mock DNS', async () => {
+      await expect(
+        assertBrowserNavigationAllowed({
+          url: 'https://example.com',
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should block private IP with strict policy', async () => {
+      await expect(
+        assertBrowserNavigationAllowed({
+          url: 'http://192.168.1.1',
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should block when DNS resolves to loopback with strict policy', async () => {
+      await expect(
+        assertBrowserNavigationAllowed({
+          url: 'https://evil.com',
+          lookupFn: mockLoopbackLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should block when DNS fails with strict policy', async () => {
+      await expect(
+        assertBrowserNavigationAllowed({
+          url: 'https://nonexistent.invalid',
+          lookupFn: mockFailingLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should allow private IP with permissive policy', async () => {
+      await expect(
+        assertBrowserNavigationAllowed({
+          url: 'http://192.168.1.1',
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: PERMISSIVE_POLICY,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // resolvePinnedHostnameWithPolicy — DNS pinning
+  // ────────────────────────────────────────────────
+
+  describe('resolvePinnedHostnameWithPolicy', () => {
+    it('should resolve a public hostname and return pinned lookup', async () => {
+      const result = await resolvePinnedHostnameWithPolicy('example.com', {
+        lookupFn: mockPublicLookup(),
+        policy: STRICT_POLICY,
+      });
+      expect(result.hostname).toBe('example.com');
+      expect(result.addresses).toContain('93.184.216.34');
+      expect(typeof result.lookup).toBe('function');
+    });
+
+    it('should reject empty hostname', async () => {
+      await expect(resolvePinnedHostnameWithPolicy('', { lookupFn: mockPublicLookup() })).rejects.toThrow(
+        InvalidBrowserNavigationUrlError,
+      );
+    });
+
+    it('should block hostname resolving to private IP with strict policy', async () => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('evil.com', {
+          lookupFn: mockLoopbackLookup(),
+          policy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should allow localhost with permissive policy', async () => {
+      const result = await resolvePinnedHostnameWithPolicy('localhost', {
+        lookupFn: mockLoopbackLookup(),
+        policy: PERMISSIVE_POLICY,
+      });
+      expect(result.hostname).toBe('localhost');
+      expect(result.addresses).toContain('127.0.0.1');
+    });
+
+    it('should block when DNS returns empty results', async () => {
+      const emptyLookup: any = async () => [];
+      await expect(
+        resolvePinnedHostnameWithPolicy('empty.com', {
+          lookupFn: emptyLookup,
+          policy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should block when DNS lookup throws', async () => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('fail.com', {
+          lookupFn: mockFailingLookup(),
+          policy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should prefer IPv4 addresses over IPv6 in deduplication', async () => {
+      const multiLookup: any = async () => [
+        { address: '2607:f8b0:4004:800::200e', family: 6 },
+        { address: '93.184.216.34', family: 4 },
+        { address: '2607:f8b0:4004:800::200f', family: 6 },
+      ];
+      const result = await resolvePinnedHostnameWithPolicy('multi.com', {
+        lookupFn: multiLookup,
+        policy: STRICT_POLICY,
+      });
+      // IPv4 should come first
+      expect(result.addresses[0]).toBe('93.184.216.34');
+    });
+
+    it('should deduplicate addresses', async () => {
+      const dupLookup: any = async () => [
+        { address: '93.184.216.34', family: 4 },
+        { address: '93.184.216.34', family: 4 },
+      ];
+      const result = await resolvePinnedHostnameWithPolicy('dup.com', {
+        lookupFn: dupLookup,
+        policy: STRICT_POLICY,
+      });
+      expect(result.addresses).toHaveLength(1);
+    });
+
+    it('should honor hostnameAllowlist restriction', async () => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('evil.com', {
+          lookupFn: mockPublicLookup(),
+          policy: { ...STRICT_POLICY, hostnameAllowlist: ['allowed.com'] },
+        }),
+      ).rejects.toThrow('not in the allowlist');
+    });
+
+    it('should allow hostname matching allowlist wildcard pattern', async () => {
+      const result = await resolvePinnedHostnameWithPolicy('api.allowed.com', {
+        lookupFn: mockPublicLookup(),
+        policy: { ...STRICT_POLICY, hostnameAllowlist: ['*.allowed.com'] },
+      });
+      expect(result.hostname).toBe('api.allowed.com');
+    });
+
+    it('should NOT match wildcard pattern against the base domain itself', async () => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('allowed.com', {
+          lookupFn: mockPublicLookup(),
+          policy: { ...STRICT_POLICY, hostnameAllowlist: ['*.allowed.com'] },
+        }),
+      ).rejects.toThrow('not in the allowlist');
+    });
+
+    it('should allow explicitly allowedHostnames even with private IPs', async () => {
+      const result = await resolvePinnedHostnameWithPolicy('internal.myapp.com', {
+        lookupFn: mockLoopbackLookup(),
+        policy: { ...STRICT_POLICY, allowedHostnames: ['internal.myapp.com'] },
+      });
+      expect(result.hostname).toBe('internal.myapp.com');
+    });
+
+    it('should normalize hostname (case, trailing dot) before checking', async () => {
+      const result = await resolvePinnedHostnameWithPolicy('EXAMPLE.COM.', {
+        lookupFn: mockPublicLookup(),
+        policy: STRICT_POLICY,
+      });
+      expect(result.hostname).toBe('example.com');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // createPinnedLookup — DNS pinning callback
+  // ────────────────────────────────────────────────
+
+  describe('createPinnedLookup', () => {
+    it('should throw if addresses array is empty', () => {
+      expect(() => createPinnedLookup({ hostname: 'test.com', addresses: [] })).toThrow('at least one address');
+    });
+
+    it('should return pinned address for matching hostname', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.2.3.4'],
+      });
+      const result = await new Promise<{ err: any; address: string; family: number }>((resolve) => {
+        (lookup as any)('test.com', (err: any, address: string, family: number) => {
+          resolve({ err, address, family });
+        });
+      });
+      expect(result.err).toBeNull();
+      expect(result.address).toBe('1.2.3.4');
+      expect(result.family).toBe(4);
+    });
+
+    it('should return all addresses when opts.all is true', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.2.3.4', '2001:db8::1'],
+      });
+      const results = await new Promise<any[]>((resolve) => {
+        (lookup as any)('test.com', { all: true }, (err: any, records: any[]) => {
+          resolve(records);
+        });
+      });
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({ address: '1.2.3.4', family: 4 });
+      expect(results[1]).toEqual({ address: '2001:db8::1', family: 6 });
+    });
+
+    it('should filter by requested family', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.2.3.4', '2001:db8::1'],
+      });
+      const results = await new Promise<any[]>((resolve) => {
+        (lookup as any)('test.com', { all: true, family: 4 }, (err: any, records: any[]) => {
+          resolve(records);
+        });
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].address).toBe('1.2.3.4');
+    });
+
+    it('should fall back to all records when requested family has no matches', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.2.3.4'], // only IPv4
+      });
+      const results = await new Promise<any[]>((resolve) => {
+        (lookup as any)('test.com', { all: true, family: 6 }, (err: any, records: any[]) => {
+          resolve(records);
+        });
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].address).toBe('1.2.3.4');
+    });
+
+    it('should round-robin through addresses', () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.1.1.1', '2.2.2.2'],
+      });
+      const addresses: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        (lookup as any)('test.com', (_err: any, addr: string) => {
+          addresses.push(addr);
+        });
+      }
+      expect(addresses[0]).toBe('1.1.1.1');
+      expect(addresses[1]).toBe('2.2.2.2');
+      expect(addresses[2]).toBe('1.1.1.1');
+    });
+
+    it('should use fallback for non-matching hostnames', async () => {
+      const fallback = ((_host: string, cb: any) => {
+        cb(null, '9.9.9.9', 4);
+      }) as any;
+      const lookup = createPinnedLookup({
+        hostname: 'pinned.com',
+        addresses: ['1.2.3.4'],
+        fallback,
+      });
+      const result = await new Promise<{ err: any; address: string }>((resolve) => {
+        (lookup as any)('other.com', (err: any, address: string) => {
+          resolve({ err, address });
+        });
+      });
+      expect(result.err).toBeNull();
+      expect(result.address).toBe('9.9.9.9');
+    });
+
+    it('should normalize hostname for matching (case-insensitive, trailing dot)', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'Test.Com',
+        addresses: ['1.2.3.4'],
+      });
+      const result = await new Promise<{ err: any; address: string }>((resolve) => {
+        (lookup as any)('test.com', (err: any, address: string) => {
+          resolve({ err, address });
+        });
+      });
+      expect(result.err).toBeNull();
+      expect(result.address).toBe('1.2.3.4');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // requiresInspectableBrowserNavigationRedirects
+  // ────────────────────────────────────────────────
+
+  describe('requiresInspectableBrowserNavigationRedirects', () => {
+    it('should return true when no policy is provided', () => {
+      expect(requiresInspectableBrowserNavigationRedirects()).toBe(true);
+    });
+
+    it('should return true with strict policy', () => {
+      expect(requiresInspectableBrowserNavigationRedirects(STRICT_POLICY)).toBe(true);
+    });
+
+    it('should return false with permissive policy', () => {
+      expect(requiresInspectableBrowserNavigationRedirects(PERMISSIVE_POLICY)).toBe(false);
+    });
+
+    it('should return false with deprecated allowPrivateNetwork', () => {
+      expect(requiresInspectableBrowserNavigationRedirects({ allowPrivateNetwork: true })).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // assertBrowserNavigationResultAllowed
+  // ────────────────────────────────────────────────
+
+  describe('assertBrowserNavigationResultAllowed', () => {
+    it('should accept empty url gracefully', async () => {
+      await expect(assertBrowserNavigationResultAllowed({ url: '' })).resolves.toBeUndefined();
+    });
+
+    it('should accept invalid url gracefully', async () => {
+      await expect(assertBrowserNavigationResultAllowed({ url: 'not-a-url' })).resolves.toBeUndefined();
+    });
+
+    it('should block private IP result url with strict policy', async () => {
+      await expect(
+        assertBrowserNavigationResultAllowed({
+          url: 'http://127.0.0.1',
+          lookupFn: mockLoopbackLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('should allow public IP result url with strict policy', async () => {
+      await expect(
+        assertBrowserNavigationResultAllowed({
+          url: 'https://example.com',
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // assertBrowserNavigationRedirectChainAllowed
+  // ────────────────────────────────────────────────
+
+  describe('assertBrowserNavigationRedirectChainAllowed', () => {
+    it('should accept null request', async () => {
+      await expect(
+        assertBrowserNavigationRedirectChainAllowed({
+          request: null,
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should accept undefined request', async () => {
+      await expect(
+        assertBrowserNavigationRedirectChainAllowed({
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should validate all URLs in a redirect chain', async () => {
+      const chain = {
+        url: () => 'https://final.com',
+        redirectedFrom: () => ({
+          url: () => 'https://middle.com',
+          redirectedFrom: () => ({
+            url: () => 'https://start.com',
+            redirectedFrom: () => null,
+          }),
+        }),
+      };
+      await expect(
+        assertBrowserNavigationRedirectChainAllowed({
+          request: chain,
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should block if any URL in redirect chain is private', async () => {
+      const chain = {
+        url: () => 'http://127.0.0.1',
+        redirectedFrom: () => ({
+          url: () => 'https://start.com',
+          redirectedFrom: () => null,
+        }),
+      };
+      await expect(
+        assertBrowserNavigationRedirectChainAllowed({
+          request: chain,
+          lookupFn: mockPublicLookup(),
+          ssrfPolicy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // sanitizeUntrustedFileName
+  // ────────────────────────────────────────────────
+
+  describe('sanitizeUntrustedFileName', () => {
+    it('should return fallback for empty string', () => {
+      expect(sanitizeUntrustedFileName('', 'fallback.txt')).toBe('fallback.txt');
+    });
+
+    it('should return fallback for whitespace-only string', () => {
+      expect(sanitizeUntrustedFileName('   ', 'fallback.txt')).toBe('fallback.txt');
+    });
+
+    it('should return fallback for "."', () => {
+      expect(sanitizeUntrustedFileName('.', 'fallback.txt')).toBe('fallback.txt');
+    });
+
+    it('should return fallback for ".."', () => {
+      expect(sanitizeUntrustedFileName('..', 'fallback.txt')).toBe('fallback.txt');
+    });
+
+    it('should strip directory traversal', () => {
+      expect(sanitizeUntrustedFileName('../../../etc/passwd', 'fallback.txt')).toBe('passwd');
+    });
+
+    it('should strip Windows-style paths', () => {
+      expect(sanitizeUntrustedFileName('C:\\Users\\evil\\file.exe', 'fallback.txt')).toBe('file.exe');
+    });
+
+    it('should strip control characters', () => {
+      const name = 'file\x00\x01\x1f.txt';
+      const result = sanitizeUntrustedFileName(name, 'fallback.txt');
+      expect(result).toBe('file.txt');
+      expect(result).not.toContain('\x00');
+    });
+
+    it('should strip DEL character (0x7F)', () => {
+      const name = 'file\x7f.txt';
+      expect(sanitizeUntrustedFileName(name, 'fallback.txt')).toBe('file.txt');
+    });
+
+    it('should truncate to 200 characters', () => {
+      const longName = 'a'.repeat(300) + '.txt';
+      const result = sanitizeUntrustedFileName(longName, 'fallback.txt');
+      expect(result.length).toBeLessThanOrEqual(200);
+    });
+
+    it('should handle normal filenames unchanged', () => {
+      expect(sanitizeUntrustedFileName('report.pdf', 'fallback.txt')).toBe('report.pdf');
+    });
+
+    it('should strip posix path prefix', () => {
+      expect(sanitizeUntrustedFileName('/tmp/evil/file.txt', 'fallback.txt')).toBe('file.txt');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // resolvePathWithinRoot — lexical confinement
+  // ────────────────────────────────────────────────
+
+  describe('resolvePathWithinRoot', () => {
+    const root = '/safe/root';
+
+    it('should resolve a simple file within root', () => {
+      const result = resolvePathWithinRoot({ rootDir: root, requestedPath: 'file.txt', scopeLabel: 'test' });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.path).toBe(resolve(root, 'file.txt'));
+    });
+
+    it('should resolve a nested file within root', () => {
+      const result = resolvePathWithinRoot({ rootDir: root, requestedPath: 'sub/dir/file.txt', scopeLabel: 'test' });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.path).toBe(resolve(root, 'sub/dir/file.txt'));
+    });
+
+    it('should reject path that escapes root via ..', () => {
+      const result = resolvePathWithinRoot({ rootDir: root, requestedPath: '../../../etc/passwd', scopeLabel: 'test' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('escapes');
+    });
+
+    it('should reject empty path', () => {
+      const result = resolvePathWithinRoot({ rootDir: root, requestedPath: '', scopeLabel: 'test' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('Empty path');
+    });
+
+    it('should use defaultFileName for empty path when provided', () => {
+      const result = resolvePathWithinRoot({
+        rootDir: root,
+        requestedPath: '',
+        scopeLabel: 'test',
+        defaultFileName: 'default.txt',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.path).toBe(resolve(root, 'default.txt'));
+    });
+
+    it('should reject absolute path outside root', () => {
+      const result = resolvePathWithinRoot({ rootDir: root, requestedPath: '/etc/passwd', scopeLabel: 'test' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should reject whitespace-only path', () => {
+      const result = resolvePathWithinRoot({ rootDir: root, requestedPath: '   ', scopeLabel: 'test' });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // assertSafeOutputPath — filesystem checks
+  // ────────────────────────────────────────────────
+
+  describe('assertSafeOutputPath', () => {
+    it('should reject empty path', async () => {
+      await expect(assertSafeOutputPath('')).rejects.toThrow('Output path is required');
+    });
+
+    it('should reject null-ish path', async () => {
+      await expect(assertSafeOutputPath(null as any)).rejects.toThrow('Output path is required');
+    });
+
+    it('should reject path with directory traversal', async () => {
+      // normalize() resolves /safe/../../../etc/passwd to a path containing ..
+      await expect(assertSafeOutputPath('foo/../../../etc/passwd')).rejects.toThrow('directory traversal');
+    });
+
+    it('should accept simple absolute path without allowedRoots', async () => {
+      // Without allowedRoots, only the traversal check applies
+      await expect(assertSafeOutputPath('/tmp/test.txt')).resolves.toBeUndefined();
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // assertSafeOutputPath — with real filesystem
+  // ────────────────────────────────────────────────
+
+  describe('assertSafeOutputPath with allowedRoots', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should accept a file within allowedRoots', async () => {
+      const filePath = join(tempRoot, 'file.txt');
+      await writeFile(filePath, 'data');
+      await expect(assertSafeOutputPath(filePath, [tempRoot])).resolves.toBeUndefined();
+    });
+
+    it('should reject a file outside allowedRoots', async () => {
+      const outsideDir = await createTempRoot();
+      try {
+        const outsidePath = join(outsideDir, 'file.txt');
+        await writeFile(outsidePath, 'data');
+        await expect(assertSafeOutputPath(outsidePath, [tempRoot])).rejects.toThrow('outside allowed directories');
+      } finally {
+        await rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should reject a symlink target', async () => {
+      const realFile = join(tempRoot, 'real.txt');
+      const linkPath = join(tempRoot, 'link.txt');
+      await writeFile(realFile, 'data');
+      await symlink(realFile, linkPath);
+      await expect(assertSafeOutputPath(linkPath, [tempRoot])).rejects.toThrow('symbolic link');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // assertSafeUploadPaths
+  // ────────────────────────────────────────────────
+
+  describe('assertSafeUploadPaths', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should accept existing regular files', async () => {
+      const filePath = join(tempRoot, 'upload.txt');
+      await writeFile(filePath, 'content');
+      await expect(assertSafeUploadPaths([filePath])).resolves.toBeUndefined();
+    });
+
+    it('should reject nonexistent file', async () => {
+      await expect(assertSafeUploadPaths([join(tempRoot, 'nonexistent.txt')])).rejects.toThrow(
+        'does not exist or is inaccessible',
+      );
+    });
+
+    it('should reject symlinks', async () => {
+      const realFile = join(tempRoot, 'real.txt');
+      const linkPath = join(tempRoot, 'link.txt');
+      await writeFile(realFile, 'data');
+      await symlink(realFile, linkPath);
+      await expect(assertSafeUploadPaths([linkPath])).rejects.toThrow('symbolic link');
+    });
+
+    it('should reject directories', async () => {
+      const dirPath = join(tempRoot, 'subdir');
+      await mkdir(dirPath);
+      await expect(assertSafeUploadPaths([dirPath])).rejects.toThrow('not a regular file');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // resolveStrictExistingUploadPaths
+  // ────────────────────────────────────────────────
+
+  describe('resolveStrictExistingUploadPaths', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should return ok:true for valid files', async () => {
+      const filePath = join(tempRoot, 'file.txt');
+      await writeFile(filePath, 'data');
+      const result = await resolveStrictExistingUploadPaths({ requestedPaths: [filePath] });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.paths).toEqual([filePath]);
+    });
+
+    it('should return ok:false for nonexistent files', async () => {
+      const result = await resolveStrictExistingUploadPaths({
+        requestedPaths: [join(tempRoot, 'missing.txt')],
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // resolveWritablePathWithinRoot — async filesystem checks
+  // ────────────────────────────────────────────────
+
+  describe('resolveWritablePathWithinRoot', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should accept a writable file within root', async () => {
+      const filePath = join(tempRoot, 'output.txt');
+      await writeFile(filePath, 'data');
+      const result = await resolveWritablePathWithinRoot({
+        rootDir: tempRoot,
+        requestedPath: 'output.txt',
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should accept a new file (not yet created) within root', async () => {
+      const result = await resolveWritablePathWithinRoot({
+        rootDir: tempRoot,
+        requestedPath: 'new-file.txt',
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should reject symlink target', async () => {
+      const realFile = join(tempRoot, 'real.txt');
+      const linkPath = join(tempRoot, 'link.txt');
+      await writeFile(realFile, 'data');
+      await symlink(realFile, linkPath);
+      const result = await resolveWritablePathWithinRoot({
+        rootDir: tempRoot,
+        requestedPath: 'link.txt',
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/symlink|symbolic link/);
+    });
+
+    it('should reject path that escapes root lexically', async () => {
+      const result = await resolveWritablePathWithinRoot({
+        rootDir: tempRoot,
+        requestedPath: '../../etc/passwd',
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('escapes');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // resolveExistingPathsWithinRoot
+  // ────────────────────────────────────────────────
+
+  describe('resolveExistingPathsWithinRoot', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should resolve existing files within root', async () => {
+      const filePath = join(tempRoot, 'file.txt');
+      await writeFile(filePath, 'data');
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['file.txt'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should allow missing files (returns fallback resolved path)', async () => {
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['missing.txt'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should reject path that escapes root', async () => {
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['../../../etc/passwd'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // resolveStrictExistingPathsWithinRoot
+  // ────────────────────────────────────────────────
+
+  describe('resolveStrictExistingPathsWithinRoot', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should resolve existing files', async () => {
+      const filePath = join(tempRoot, 'file.txt');
+      await writeFile(filePath, 'data');
+      const result = await resolveStrictExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['file.txt'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.paths[0]).toBe(filePath);
+    });
+
+    it('should reject missing files', async () => {
+      const result = await resolveStrictExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['missing.txt'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('does not exist');
+    });
+
+    it('should reject symlinks pointing outside root', async () => {
+      const outsideDir = await createTempRoot();
+      try {
+        const outsideFile = join(outsideDir, 'secret.txt');
+        await writeFile(outsideFile, 'secret');
+        const linkPath = join(tempRoot, 'link.txt');
+        await symlink(outsideFile, linkPath);
+        const result = await resolveStrictExistingPathsWithinRoot({
+          rootDir: tempRoot,
+          requestedPaths: ['link.txt'],
+          scopeLabel: 'test',
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toMatch(/symlink|escapes/);
+      } finally {
+        await rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should reject directories', async () => {
+      const dirPath = join(tempRoot, 'subdir');
+      await mkdir(dirPath);
+      const result = await resolveStrictExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['subdir'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/not a regular file|symlink/);
+    });
+
+    it('should reject path escaping root', async () => {
+      const result = await resolveStrictExistingPathsWithinRoot({
+        rootDir: tempRoot,
+        requestedPaths: ['../../etc/passwd'],
+        scopeLabel: 'test',
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // writeViaSiblingTempPath — atomic writes
+  // ────────────────────────────────────────────────
+
+  describe('writeViaSiblingTempPath', () => {
+    let tempRoot: string;
+
+    beforeEach(async () => {
+      tempRoot = await createTempRoot();
+    });
+
+    afterEach(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('should write file atomically', async () => {
+      const targetPath = join(tempRoot, 'output.txt');
+      await writeViaSiblingTempPath({
+        rootDir: tempRoot,
+        targetPath,
+        writeTemp: async (tempPath) => {
+          await writeFile(tempPath, 'atomic content');
+        },
+      });
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(targetPath, 'utf-8');
+      expect(content).toBe('atomic content');
+    });
+
+    it('should reject target path outside root', async () => {
+      const outsidePath = join(tmpdir(), `outside-${randomUUID()}`, 'file.txt');
+      await expect(
+        writeViaSiblingTempPath({
+          rootDir: tempRoot,
+          targetPath: outsidePath,
+          writeTemp: async (tempPath) => {
+            await writeFile(tempPath, 'data');
+          },
+        }),
+      ).rejects.toThrow('outside the allowed root');
+    });
+
+    it('should clean up temp file on write failure', async () => {
+      const targetPath = join(tempRoot, 'output.txt');
+      await expect(
+        writeViaSiblingTempPath({
+          rootDir: tempRoot,
+          targetPath,
+          writeTemp: async () => {
+            throw new Error('Write failed');
+          },
+        }),
+      ).rejects.toThrow('Write failed');
+      // Verify temp file is cleaned up
+      const { readdir } = await import('node:fs/promises');
+      const files = await readdir(tempRoot);
+      const partFiles = files.filter((f) => f.includes('.part'));
+      expect(partFiles).toHaveLength(0);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // isInternalUrl — SSRF policy interaction
+  // ────────────────────────────────────────────────
+
+  describe('isInternalUrl with policy', () => {
+    it('should still block private IP even when policy has no relevant flags', () => {
+      expect(isInternalUrl('http://127.0.0.1', {})).toBe(true);
+    });
+
+    it('should respect allowRfc2544BenchmarkRange in policy', () => {
+      expect(isInternalUrl('http://198.18.0.1', { allowRfc2544BenchmarkRange: true })).toBe(false);
+      expect(isInternalUrl('http://198.18.0.1', { allowRfc2544BenchmarkRange: false })).toBe(true);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // IPv4 boundary addresses
+  // ────────────────────────────────────────────────
+
+  describe('IPv4 boundary addresses', () => {
+    it('should block 10.0.0.0 (start of /8)', () => {
+      expect(isInternalUrl('http://10.0.0.0')).toBe(true);
+    });
+
+    it('should NOT block 11.0.0.0 (just outside 10/8)', () => {
+      expect(isInternalUrl('http://11.0.0.0')).toBe(false);
+    });
+
+    it('should block 172.16.0.0 (start of /12)', () => {
+      expect(isInternalUrl('http://172.16.0.0')).toBe(true);
+    });
+
+    it('should NOT block 172.15.255.255 (just below /12)', () => {
+      expect(isInternalUrl('http://172.15.255.255')).toBe(false);
+    });
+
+    it('should block 192.168.0.0 (start of /16)', () => {
+      expect(isInternalUrl('http://192.168.0.0')).toBe(true);
+    });
+
+    it('should NOT block 192.167.255.255 (just below /16)', () => {
+      expect(isInternalUrl('http://192.167.255.255')).toBe(false);
+    });
+
+    it('should block 169.254.0.0 (start of link-local)', () => {
+      expect(isInternalUrl('http://169.254.0.0')).toBe(true);
+    });
+
+    it('should NOT block 169.253.255.255 (just below link-local)', () => {
+      expect(isInternalUrl('http://169.253.255.255')).toBe(false);
+    });
+  });
+});

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -594,6 +594,40 @@ describe('security.ts', () => {
         }),
       ).resolves.toBeUndefined();
     });
+
+    it('should block when proxy env vars are set with strict policy (fail closed)', async () => {
+      const original = process.env.HTTP_PROXY;
+      process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+      try {
+        await expect(
+          assertBrowserNavigationAllowed({
+            url: 'https://example.com',
+            lookupFn: mockPublicLookup(),
+            ssrfPolicy: STRICT_POLICY,
+          }),
+        ).rejects.toThrow('proxy variables are set');
+      } finally {
+        if (original !== undefined) process.env.HTTP_PROXY = original;
+        else delete process.env.HTTP_PROXY;
+      }
+    });
+
+    it('should allow navigation when proxy env vars are set with permissive policy', async () => {
+      const original = process.env.HTTP_PROXY;
+      process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+      try {
+        await expect(
+          assertBrowserNavigationAllowed({
+            url: 'https://example.com',
+            lookupFn: mockPublicLookup(),
+            ssrfPolicy: PERMISSIVE_POLICY,
+          }),
+        ).resolves.toBeUndefined();
+      } finally {
+        if (original !== undefined) process.env.HTTP_PROXY = original;
+        else delete process.env.HTTP_PROXY;
+      }
+    });
   });
 
   // ────────────────────────────────────────────────
@@ -1066,6 +1100,10 @@ describe('security.ts', () => {
       // Without allowedRoots, only the traversal check applies
       await expect(assertSafeOutputPath('/tmp/test.txt')).resolves.toBeUndefined();
     });
+
+    it('should accept /etc/passwd without allowedRoots (lexical check only)', async () => {
+      await expect(assertSafeOutputPath('/etc/passwd')).resolves.toBeUndefined();
+    });
   });
 
   // ────────────────────────────────────────────────
@@ -1240,6 +1278,26 @@ describe('security.ts', () => {
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toContain('escapes');
     });
+
+    it('should return error when stat fails with non-ENOENT error', async () => {
+      // Create a file inside an inaccessible directory to trigger EACCES on lstat
+      const subdir = join(tempRoot, 'noaccess');
+      await mkdir(subdir);
+      await writeFile(join(subdir, 'file.txt'), 'data');
+      const { chmod } = await import('node:fs/promises');
+      await chmod(subdir, 0o000);
+      try {
+        const result = await resolveWritablePathWithinRoot({
+          rootDir: tempRoot,
+          requestedPath: 'noaccess/file.txt',
+          scopeLabel: 'test',
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toContain('Cannot stat');
+      } finally {
+        await chmod(subdir, 0o755);
+      }
+    });
   });
 
   // ────────────────────────────────────────────────
@@ -1362,6 +1420,25 @@ describe('security.ts', () => {
         scopeLabel: 'test',
       });
       expect(result.ok).toBe(false);
+    });
+
+    it('should return error when realpath fails with non-ENOENT error', async () => {
+      const subdir = join(tempRoot, 'noaccess');
+      await mkdir(subdir);
+      await writeFile(join(subdir, 'file.txt'), 'data');
+      const { chmod } = await import('node:fs/promises');
+      await chmod(subdir, 0o000);
+      try {
+        const result = await resolveStrictExistingPathsWithinRoot({
+          rootDir: tempRoot,
+          requestedPaths: ['noaccess/file.txt'],
+          scopeLabel: 'test',
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toContain('Cannot resolve');
+      } finally {
+        await chmod(subdir, 0o755);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Add vitest as test runner and update the `test` script in package.json
- Add comprehensive test suite for `src/security.ts` with 172 tests covering:
  - IPv4 private/reserved range blocking: loopback (127.0.0.0/8), link-local (169.254.0.0/16), RFC1918 (10/8, 172.16/12, 192.168/16), broadcast, unspecified, carrier-grade NAT, multicast, RFC2544 benchmark
  - IPv6 range blocking: loopback, unspecified, link-local, unique-local, multicast, deprecated site-local
  - IPv6 embedded IPv4 formats: IPv4-mapped (::ffff:x.x.x.x), 6to4 (2002::/16), Teredo (2001:0000::/32), NAT64 (64:ff9b::/96), ISATAP
  - Hostname blocking: localhost, *.localhost, *.local, *.internal, metadata.google.internal, case-insensitive, trailing dot
  - DNS pinning / TOCTOU protection: createPinnedLookup round-robin, family filtering, fallback, resolvePinnedHostnameWithPolicy
  - SSRF policy configuration: strict vs permissive, allowedHostnames, hostnameAllowlist wildcards, allowRfc2544BenchmarkRange
  - Browser navigation guards: protocol blocking, redirect chain validation, result URL validation
  - Path safety: resolvePathWithinRoot, resolveWritablePathWithinRoot, resolveExistingPathsWithinRoot, resolveStrictExistingPathsWithinRoot, assertSafeOutputPath, assertSafeUploadPaths, symlink detection
  - File sanitization: sanitizeUntrustedFileName, writeViaSiblingTempPath atomic writes
  - Edge cases: empty strings, malformed URLs, legacy IPv4 literals (octal/hex), boundary addresses

## Test plan
- [x] All 172 tests pass via `npm test`
- [x] `npm run format:check` passes
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)