### PR TITLE
Harden concurrency and naming

### DIFF
--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -102,7 +102,7 @@ export async function downloadViaPlaywright(opts: {
   const outPath = opts.path.trim();
   if (!outPath) throw new Error('path is required');
 
-  state.armIdDownload = bumpDownloadArmId();
+  state.armIdDownload = bumpDownloadArmId(state);
   const armId = state.armIdDownload;
   const waiter = createPageDownloadWaiter(page, timeout);
 
@@ -132,7 +132,7 @@ export async function waitForDownloadViaPlaywright(opts: {
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
 
-  state.armIdDownload = bumpDownloadArmId();
+  state.armIdDownload = bumpDownloadArmId(state);
   const armId = state.armIdDownload;
 
   const waiter = createPageDownloadWaiter(page, timeout);

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -4,7 +4,7 @@ import {
   restoreRoleRefsForTarget,
   refLocator,
   normalizeTimeoutMs,
-  forceDisconnectPlaywrightForTarget,
+  forceDisconnectPlaywrightConnection,
 } from '../connection.js';
 
 export interface FrameEvalResult {
@@ -170,7 +170,7 @@ export async function evaluateViaPlaywright(opts: {
 
   if (signal !== undefined) {
     const disconnect = () => {
-      forceDisconnectPlaywrightForTarget({
+      forceDisconnectPlaywrightConnection({
         cdpUrl: opts.cdpUrl,
         targetId: opts.targetId,
         reason: 'evaluate aborted',

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -447,7 +447,7 @@ export async function armDialogViaPlaywright(opts: {
   const state = ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
-  state.armIdDialog = bumpDialogArmId();
+  state.armIdDialog = bumpDialogArmId(state);
   const armId = state.armIdDialog;
 
   page
@@ -476,7 +476,7 @@ export async function armFileUploadViaPlaywright(opts: {
   const state = ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
-  state.armIdUpload = bumpUploadArmId();
+  state.armIdUpload = bumpUploadArmId(state);
   const armId = state.armIdUpload;
 
   page

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -10,7 +10,7 @@ import {
   observeContext,
   pageTargetId,
   getAllPages,
-  forceDisconnectPlaywrightForTarget,
+  forceDisconnectPlaywrightConnection,
   resolvePageByTargetIdOrThrow,
   withPageScopedCdpClient,
   isBlockedTarget,
@@ -182,7 +182,7 @@ export async function navigateViaPlaywright(opts: {
     response = await navigate();
   } catch (err) {
     if (!isRetryableNavigateError(err)) throw err;
-    await forceDisconnectPlaywrightForTarget({
+    await forceDisconnectPlaywrightConnection({
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       reason: 'retry navigate after detached frame',

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -1,13 +1,6 @@
-import { getPageForTargetId, ensurePageState, normalizeTimeoutMs } from '../connection.js';
+import { getPageForTargetId, ensurePageState, normalizeTimeoutMs, resolveBoundedDelayMs } from '../connection.js';
 
 const MAX_WAIT_TIME_MS = 30000;
-
-function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
-  const normalized = Math.floor(value ?? 0);
-  if (!Number.isFinite(normalized) || normalized < 0) throw new Error(`${label} must be >= 0`);
-  if (normalized > maxMs) throw new Error(`${label} exceeds maximum of ${String(maxMs)}ms`);
-  return normalized;
-}
 
 export async function waitForViaPlaywright(opts: {
   cdpUrl: string;

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -572,12 +572,10 @@ export function normalizeCdpHttpBaseForJsonEndpoints(cdpUrl: string): string {
     url.pathname = url.pathname.replace(/\/cdp$/, '');
     return url.toString().replace(/\/$/, '');
   } catch {
-    return cdpUrl
-      .replace(/^ws:/, 'http:')
-      .replace(/^wss:/, 'https:')
-      .replace(/\/devtools\/browser\/.*$/, '')
-      .replace(/\/cdp$/, '')
-      .replace(/\/$/, '');
+    let normalized = cdpUrl.replace(/^ws:/, 'http:').replace(/^wss:/, 'https:');
+    const dtIdx = normalized.indexOf('/devtools/browser/');
+    if (dtIdx >= 0) normalized = normalized.slice(0, dtIdx);
+    return normalized.replace(/\/cdp$/, '').replace(/\/$/, '');
   }
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -540,11 +540,13 @@ async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string): Pr
 }
 
 /**
- * Force-disconnect a Playwright browser connection for a given CDP target.
- * Clears the connection cache, sends Runtime.terminateExecution via raw CDP
- * websocket to kill stuck evals (bypassing Playwright), and closes the browser.
+ * Force-disconnect the ENTIRE Playwright browser connection, not just one target.
+ * Clears the connection cache, optionally sends Runtime.terminateExecution to
+ * a specific target via raw CDP websocket to kill stuck evals (bypassing
+ * Playwright), then closes the browser — which disconnects ALL tabs.
+ * The targetId parameter is only used to send Runtime.terminateExecution before closing.
  */
-export async function forceDisconnectPlaywrightForTarget(opts: {
+export async function forceDisconnectPlaywrightConnection(opts: {
   cdpUrl: string;
   targetId?: string;
   reason?: string;
@@ -571,6 +573,9 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
     /* noop */
   });
 }
+
+/** @deprecated Use `forceDisconnectPlaywrightConnection` instead. */
+export const forceDisconnectPlaywrightForTarget = forceDisconnectPlaywrightConnection;
 
 // ── Page Lookup ──
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -138,59 +138,56 @@ function isLoopbackCdpUrl(url: string): boolean {
   }
 }
 
-class NoProxyLeaseManager {
-  private leaseCount = 0;
-  private snapshot: { noProxy?: string; noProxyLower?: string; applied: string } | null = null;
-
-  acquire(url: string): (() => void) | null {
-    if (!isLoopbackCdpUrl(url) || !hasProxyEnvConfigured()) return null;
-    if (this.leaseCount === 0 && !noProxyAlreadyCoversLocalhost()) {
-      const noProxy = process.env.NO_PROXY;
-      const noProxyLower = process.env.no_proxy;
-      const current = noProxy ?? noProxyLower ?? '';
-      const applied = current ? `${current},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
-      process.env.NO_PROXY = applied;
-      process.env.no_proxy = applied;
-      this.snapshot = { noProxy, noProxyLower, applied };
-    }
-    this.leaseCount += 1;
-    let released = false;
-    return () => {
-      if (released) return;
-      released = true;
-      this.release();
-    };
-  }
-
-  release(): void {
-    if (this.leaseCount <= 0) return;
-    this.leaseCount -= 1;
-    if (this.leaseCount > 0 || !this.snapshot) return;
-    const { noProxy, noProxyLower, applied } = this.snapshot;
-    const currentNoProxy = process.env.NO_PROXY;
-    const currentNoProxyLower = process.env.no_proxy;
-    if (currentNoProxy === applied && (currentNoProxyLower === applied || currentNoProxyLower === undefined)) {
-      if (noProxy !== undefined) process.env.NO_PROXY = noProxy;
-      else delete process.env.NO_PROXY;
-      if (noProxyLower !== undefined) process.env.no_proxy = noProxyLower;
-      else delete process.env.no_proxy;
-    }
-    this.snapshot = null;
-  }
-}
-
-const noProxyLeaseManager = new NoProxyLeaseManager();
+/**
+ * Mutex promise chain that serializes concurrent env mutations.
+ *
+ * Playwright reads proxy config from `process.env` at connect time — there is
+ * no API to pass proxy bypass settings per-connection. When the CDP target is
+ * loopback we must temporarily add localhost entries to `NO_PROXY` / `no_proxy`
+ * so Playwright's underlying HTTP stack skips the proxy.
+ *
+ * Because multiple connections may be established concurrently, we serialize
+ * the save → mutate → fn() → restore cycle through a promise chain so that
+ * one caller's restore doesn't clobber another caller's mutation.
+ */
+let envMutexPromise: Promise<void> = Promise.resolve();
 
 /**
  * Scoped NO_PROXY bypass for loopback CDP URLs.
- * This wrapper only mutates env vars for loopback destinations.
+ * Serializes env mutations so concurrent connects don't interleave save/restore.
+ * Only restores if the value hasn't been changed by someone else.
  */
 export async function withNoProxyForCdpUrl<T>(url: string, fn: () => Promise<T>): Promise<T> {
-  const release = noProxyLeaseManager.acquire(url);
+  if (!isLoopbackCdpUrl(url) || !hasProxyEnvConfigured()) return fn();
+  if (noProxyAlreadyCoversLocalhost()) return fn();
+
+  // Serialize env mutations so concurrent connects don't interleave save/restore
+  const prev = envMutexPromise;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let release: () => void = () => {};
+  envMutexPromise = new Promise<void>((r) => {
+    release = r;
+  });
+  await prev;
+
+  const savedNoProxy = process.env.NO_PROXY;
+  const savedNoProxyLower = process.env.no_proxy;
+  const current = savedNoProxy ?? savedNoProxyLower ?? '';
+  const applied = current ? `${current},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
+  process.env.NO_PROXY = applied;
+  process.env.no_proxy = applied;
   try {
     return await fn();
   } finally {
-    release?.();
+    if (process.env.NO_PROXY === applied) {
+      if (savedNoProxy !== undefined) process.env.NO_PROXY = savedNoProxy;
+      else delete process.env.NO_PROXY;
+    }
+    if (process.env.no_proxy === applied) {
+      if (savedNoProxyLower !== undefined) process.env.no_proxy = savedNoProxyLower;
+      else delete process.env.no_proxy;
+    }
+    release();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
 export type { BrowserNavigationPolicyOptions, BrowserNavigationRequestLike, LookupFn } from './security.js';
 export {
   ensureContextState,
+  forceDisconnectPlaywrightConnection,
   forceDisconnectPlaywrightForTarget,
   withPlaywrightPageCdpSession,
   withPageScopedCdpClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type { BrowserNavigationPolicyOptions, BrowserNavigationRequestLike, Look
 export {
   ensureContextState,
   forceDisconnectPlaywrightConnection,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   forceDisconnectPlaywrightForTarget,
   withPlaywrightPageCdpSession,
   withPageScopedCdpClient,

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -14,21 +14,17 @@ const observedPages = new WeakSet<Page>();
 
 // ── Arm ID Counters ──
 
-let nextUploadArmId = 0;
-let nextDialogArmId = 0;
-let nextDownloadArmId = 0;
-
-export function bumpUploadArmId(): number {
-  nextUploadArmId += 1;
-  return nextUploadArmId;
+export function bumpUploadArmId(state: PageState): number {
+  state.nextArmIdUpload += 1;
+  return state.nextArmIdUpload;
 }
-export function bumpDialogArmId(): number {
-  nextDialogArmId += 1;
-  return nextDialogArmId;
+export function bumpDialogArmId(state: PageState): number {
+  state.nextArmIdDialog += 1;
+  return state.nextArmIdDialog;
 }
-export function bumpDownloadArmId(): number {
-  nextDownloadArmId += 1;
-  return nextDownloadArmId;
+export function bumpDownloadArmId(state: PageState): number {
+  state.nextArmIdDownload += 1;
+  return state.nextArmIdDownload;
 }
 
 // ── Context State Management ──
@@ -70,6 +66,9 @@ export function ensurePageState(page: Page): PageState {
     armIdUpload: 0,
     armIdDialog: 0,
     armIdDownload: 0,
+    nextArmIdUpload: 0,
+    nextArmIdDialog: 0,
+    nextArmIdDownload: 0,
   };
   pageStates.set(page, state);
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -18,6 +18,7 @@ import {
 
 import * as ipaddr from 'ipaddr.js';
 
+import { hasProxyEnvConfigured } from './chrome-launcher.js';
 import type { SsrfPolicy, PinnedHostname } from './types.js';
 
 // ── Default temp directories for downloads/uploads ──
@@ -71,8 +72,6 @@ export function withBrowserNavigationPolicy(ssrfPolicy?: SsrfPolicy): BrowserNav
 const NETWORK_NAVIGATION_PROTOCOLS = new Set(['http:', 'https:']);
 const SAFE_NON_NETWORK_URLS = new Set(['about:blank']);
 
-const PROXY_ENV_KEYS = ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy'];
-
 const BLOCKED_HOSTNAMES = new Set(['localhost', 'localhost.localdomain', 'metadata.google.internal']);
 
 function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
@@ -82,14 +81,6 @@ function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
 function isPrivateNetworkAllowedByPolicy(policy?: SsrfPolicy): boolean {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   return policy?.dangerouslyAllowPrivateNetwork === true || policy?.allowPrivateNetwork === true;
-}
-
-function hasProxyEnvConfigured(env: Record<string, string | undefined> = process.env): boolean {
-  for (const key of PROXY_ENV_KEYS) {
-    const value = env[key];
-    if (typeof value === 'string' && value.trim().length > 0) return true;
-  }
-  return false;
 }
 
 // ── Hostname normalization & blocking ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -558,6 +558,9 @@ export interface PageState {
   armIdUpload: number;
   armIdDialog: number;
   armIdDownload: number;
+  nextArmIdUpload: number;
+  nextArmIdDialog: number;
+  nextArmIdDownload: number;
   dialogHandler?: DialogHandler;
 }
 


### PR DESCRIPTION
## Summary
- Scope arm IDs (upload/dialog/download) per page instead of global counters — fixes brittleness under concurrent usage
- Rename `forceDisconnectPlaywrightForTarget` → `forceDisconnectPlaywrightConnection` to reflect it closes all tabs, not just one. Deprecated alias preserved for BC
- Replace `NoProxyLeaseManager` class with a simpler mutex-based `withNoProxyForCdpUrl` that serializes env mutations

## Test plan
- [ ] Concurrent page operations use independent arm IDs
- [ ] `forceDisconnectPlaywrightForTarget` still works (deprecated alias)
- [ ] Loopback CDP connections work with proxy env vars set

🤖 Generated with [Claude Code](https://claude.com/claude-code)