### PR TITLE
Fix dialog sync throw, cache target IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -66,7 +66,9 @@ async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<unknown>
     const res = await fetch(url, { signal: ctrl.signal });
     if (!res.ok) return null;
     return await res.json();
-  } catch {
+  } catch (err) {
+    if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
+      console.warn(`[browserclaw] fetchJsonForCdp ${url} failed: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   } finally {
     clearTimeout(t);
@@ -211,7 +213,9 @@ export function getDirectAgentForCdp(url: string): http.Agent | https.Agent | un
     if (isLoopbackHost(parsed.hostname)) {
       return parsed.protocol === 'https:' || parsed.protocol === 'wss:' ? directHttpsAgent : directHttpAgent;
     }
-  } catch {}
+  } catch {
+    // url is not a valid URL string — return undefined (no direct agent)
+  }
   return undefined;
 }
 
@@ -399,7 +403,11 @@ export async function disconnectBrowser(): Promise<void> {
     for (const p of connectingByCdpUrl.values()) {
       try {
         await p;
-      } catch {}
+      } catch (err) {
+        console.warn(
+          `[browserclaw] disconnectBrowser: pending connect failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
   for (const cur of cachedByCdpUrl.values()) {
@@ -595,12 +603,19 @@ export function getAllPages(browser: Browser) {
   return browser.contexts().flatMap((c) => c.pages());
 }
 
+/** Cache of CDP target IDs — stable for a page's lifetime. */
+const pageTargetIdCache = new WeakMap<Page, string>();
+
 export async function pageTargetId(page: Page): Promise<string | null> {
+  const cached = pageTargetIdCache.get(page);
+  if (cached !== undefined) return cached;
   const session = await page.context().newCDPSession(page);
   try {
     const info = await session.send('Target.getTargetInfo');
     const targetInfo = (info as { targetInfo?: { targetId?: string } }).targetInfo;
-    return (targetInfo?.targetId ?? '').trim() || null;
+    const id = (targetInfo?.targetId ?? '').trim() || null;
+    if (id !== null) pageTargetIdCache.set(page, id);
+    return id;
   } finally {
     await session.detach().catch(() => {
       /* noop */
@@ -635,17 +650,20 @@ async function findPageByTargetIdViaTargetList(pages: Page[], targetId: string, 
 export async function findPageByTargetId(browser: Browser, targetId: string, cdpUrl?: string) {
   const pages = getAllPages(browser);
 
-  let resolvedViaCdp = false;
-  for (const page of pages) {
-    let tid: string | null = null;
-    try {
-      tid = await pageTargetId(page);
-      resolvedViaCdp = true;
-    } catch {
-      tid = null;
-    }
-    if (tid !== null && tid !== '' && tid === targetId) return page;
-  }
+  const results = await Promise.all(
+    pages.map(async (page) => {
+      try {
+        const tid = await pageTargetId(page);
+        return { page, tid };
+      } catch {
+        return { page, tid: null as string | null };
+      }
+    }),
+  );
+
+  const resolvedViaCdp = results.some(({ tid }) => tid !== null);
+  const matched = results.find(({ tid }) => tid !== null && tid !== '' && tid === targetId);
+  if (matched) return matched.page;
 
   if (cdpUrl !== undefined && cdpUrl !== '') {
     try {
@@ -708,9 +726,8 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
     );
   }
   if (isBlockedPageRef(opts.cdpUrl, found)) throw new BlockedBrowserTargetError();
-  const foundTargetId = await pageTargetId(found).catch(() => null);
-  if (foundTargetId !== null && foundTargetId !== '' && isBlockedTarget(opts.cdpUrl, foundTargetId))
-    throw new BlockedBrowserTargetError();
+  // findPageByTargetId matched found against opts.targetId — reuse it directly
+  if (isBlockedTarget(opts.cdpUrl, opts.targetId)) throw new BlockedBrowserTargetError();
   return found;
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -726,7 +726,8 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
     );
   }
   if (isBlockedPageRef(opts.cdpUrl, found)) throw new BlockedBrowserTargetError();
-  // findPageByTargetId matched found against opts.targetId — reuse it directly
+  // Both resolution paths (CDP match and URL-based fallback) locate the page by opts.targetId —
+  // no need to call pageTargetId(found) again.
   if (isBlockedTarget(opts.cdpUrl, opts.targetId)) throw new BlockedBrowserTargetError();
   return found;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   writeViaSiblingTempPath,
   assertSafeUploadPaths,
   resolveStrictExistingUploadPaths,
+  resolveStrictExistingPathsWithinRoot,
 } from './security.js';
 export type { BrowserNavigationPolicyOptions, BrowserNavigationRequestLike, LookupFn } from './security.js';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   setDialogHandler,
   parseRoleRef,
   BrowserTabNotFoundError,
+  BlockedBrowserTargetError,
 } from './connection.js';
 export { pressAndHoldViaCdp } from './actions/interaction.js';
 export type { FrameEvalResult } from './actions/evaluate.js';

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -136,6 +136,7 @@ export function ensurePageState(page: Page): PageState {
 
       // If a persistent onDialog handler is registered, invoke it.
       if (state.dialogHandler) {
+        const handler = state.dialogHandler;
         let handled = false;
         const event = {
           type: dialog.type(),
@@ -150,7 +151,8 @@ export function ensurePageState(page: Page): PageState {
             return dialog.dismiss();
           },
         };
-        Promise.resolve(state.dialogHandler(event))
+        Promise.resolve()
+          .then(() => handler(event))
           .then(() => {
             if (!handled) {
               dialog.dismiss().catch((err: unknown) => {

--- a/src/security.ts
+++ b/src/security.ts
@@ -602,6 +602,12 @@ export async function assertSafeUploadPaths(paths: string[]): Promise<void> {
 /**
  * Resolve and validate upload file paths, returning them if all are safe.
  * Returns `{ ok: true, paths }` or `{ ok: false, error }`.
+ *
+ * **Note:** This function does NOT provide root confinement — it only checks that
+ * each path exists and is a regular file. An attacker-controlled path can still
+ * reference any readable file on the system (e.g. `/etc/passwd`).
+ * For uploads that must stay within a specific directory, use
+ * `resolveStrictExistingPathsWithinRoot` instead.
  */
 export async function resolveStrictExistingUploadPaths(params: {
   requestedPaths: string[];


### PR DESCRIPTION
## Summary

- **Bug fix:** Dialog handler sync throws now caught — `Promise.resolve().then(() => handler(event))` instead of `Promise.resolve(handler(event))` which swallowed sync exceptions
- **Empty catches hardened:** `fetchJsonForCdp` logs debug warn on failure; `getDirectAgentForCdp` has explanatory comment; `disconnectBrowser` warns on pending connect failure
- **API surface:** `BlockedBrowserTargetError` exported from `index.ts`; `resolveStrictExistingUploadPaths` JSDoc clarifies it does NOT provide root confinement and points to `resolveStrictExistingPathsWithinRoot`
- **Performance:** `WeakMap<Page, string>` cache for `pageTargetId` (target IDs are stable); `findPageByTargetId` parallelizes CDP calls with `Promise.all`; `getPageForTargetId` removes redundant second `pageTargetId` call

## Test plan

- [x] `npm run build` — clean compilation, no type errors
- [x] `npm test` — 177 tests pass
- [x] `npm run format:check` — no formatting issues