### PR TITLE
feat: auth health API and run telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.11.6",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/auth-telemetry.test.ts
+++ b/src/auth-telemetry.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+
+import type { AuthCheckRule, AuthCheckResult, RunTelemetry } from './types.js';
+
+// ── Auth Health Types ──
+
+describe('AuthCheckRule', () => {
+  it('should accept a url rule', () => {
+    const rule: AuthCheckRule = { url: '/dashboard' };
+    expect(rule.url).toBe('/dashboard');
+  });
+
+  it('should accept a cookie rule', () => {
+    const rule: AuthCheckRule = { cookie: 'session_id' };
+    expect(rule.cookie).toBe('session_id');
+  });
+
+  it('should accept a selector rule', () => {
+    const rule: AuthCheckRule = { selector: '[data-user-id]' };
+    expect(rule.selector).toBe('[data-user-id]');
+  });
+
+  it('should accept a text rule', () => {
+    const rule: AuthCheckRule = { text: 'Welcome back' };
+    expect(rule.text).toBe('Welcome back');
+  });
+
+  it('should accept a textGone rule', () => {
+    const rule: AuthCheckRule = { textGone: 'Sign in' };
+    expect(rule.textGone).toBe('Sign in');
+  });
+
+  it('should accept a fn rule', () => {
+    const rule: AuthCheckRule = { fn: '() => !!document.cookie' };
+    expect(rule.fn).toBe('() => !!document.cookie');
+  });
+
+  it('should accept multiple rules combined', () => {
+    const rule: AuthCheckRule = {
+      url: '/dashboard',
+      cookie: 'session_id',
+      textGone: 'Sign in',
+    };
+    expect(rule.url).toBe('/dashboard');
+    expect(rule.cookie).toBe('session_id');
+    expect(rule.textGone).toBe('Sign in');
+  });
+});
+
+describe('AuthCheckResult', () => {
+  it('should represent a fully authenticated result', () => {
+    const result: AuthCheckResult = {
+      authenticated: true,
+      checks: [
+        { rule: 'url', passed: true, detail: 'https://app.example.com/dashboard' },
+        { rule: 'cookie', passed: true, detail: 'cookie "session_id" present' },
+      ],
+    };
+    expect(result.authenticated).toBe(true);
+    expect(result.checks).toHaveLength(2);
+    expect(result.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it('should represent a failed auth result', () => {
+    const result: AuthCheckResult = {
+      authenticated: false,
+      checks: [
+        { rule: 'url', passed: true, detail: 'https://app.example.com/login' },
+        { rule: 'textGone', passed: false, detail: '"Sign in" still present' },
+      ],
+    };
+    expect(result.authenticated).toBe(false);
+    expect(result.checks.some((c) => !c.passed)).toBe(true);
+  });
+
+  it('should represent an empty rules result as authenticated', () => {
+    const result: AuthCheckResult = {
+      authenticated: true,
+      checks: [],
+    };
+    expect(result.authenticated).toBe(true);
+    expect(result.checks).toHaveLength(0);
+  });
+});
+
+// ── Run Telemetry Types ──
+
+describe('RunTelemetry', () => {
+  it('should represent a launch telemetry envelope', () => {
+    const telemetry: RunTelemetry = {
+      launchMs: 1823,
+      connectMs: 45,
+      navMs: 620,
+      authOk: true,
+      exitReason: 'success',
+      cleanupOk: true,
+      timestamps: {
+        startedAt: '2026-04-05T10:00:00.000Z',
+        launchedAt: '2026-04-05T10:00:01.823Z',
+        connectedAt: '2026-04-05T10:00:01.868Z',
+        navigatedAt: '2026-04-05T10:00:02.488Z',
+        stoppedAt: '2026-04-05T10:00:05.000Z',
+      },
+    };
+    expect(telemetry.launchMs).toBe(1823);
+    expect(telemetry.connectMs).toBe(45);
+    expect(telemetry.navMs).toBe(620);
+    expect(telemetry.authOk).toBe(true);
+    expect(telemetry.exitReason).toBe('success');
+    expect(telemetry.cleanupOk).toBe(true);
+    expect(telemetry.timestamps.startedAt).toBeTruthy();
+    expect(telemetry.timestamps.launchedAt).toBeTruthy();
+    expect(telemetry.timestamps.connectedAt).toBeTruthy();
+    expect(telemetry.timestamps.navigatedAt).toBeTruthy();
+    expect(telemetry.timestamps.stoppedAt).toBeTruthy();
+  });
+
+  it('should represent a connect-only telemetry envelope (no launch)', () => {
+    const telemetry: RunTelemetry = {
+      connectMs: 120,
+      timestamps: {
+        startedAt: '2026-04-05T10:00:00.000Z',
+        connectedAt: '2026-04-05T10:00:00.120Z',
+      },
+    };
+    expect(telemetry.launchMs).toBeUndefined();
+    expect(telemetry.connectMs).toBe(120);
+    expect(telemetry.navMs).toBeUndefined();
+    expect(telemetry.timestamps.launchedAt).toBeUndefined();
+  });
+
+  it('should represent a failed session telemetry', () => {
+    const telemetry: RunTelemetry = {
+      launchMs: 15000,
+      authOk: false,
+      exitReason: 'auth_failed',
+      cleanupOk: true,
+      timestamps: {
+        startedAt: '2026-04-05T10:00:00.000Z',
+        launchedAt: '2026-04-05T10:00:15.000Z',
+        stoppedAt: '2026-04-05T10:00:16.000Z',
+      },
+    };
+    expect(telemetry.authOk).toBe(false);
+    expect(telemetry.exitReason).toBe('auth_failed');
+    expect(telemetry.cleanupOk).toBe(true);
+  });
+
+  it('should represent a cleanup failure', () => {
+    const telemetry: RunTelemetry = {
+      launchMs: 2000,
+      exitReason: 'timeout',
+      cleanupOk: false,
+      timestamps: {
+        startedAt: '2026-04-05T10:00:00.000Z',
+        launchedAt: '2026-04-05T10:00:02.000Z',
+        stoppedAt: '2026-04-05T10:00:30.000Z',
+      },
+    };
+    expect(telemetry.cleanupOk).toBe(false);
+    expect(telemetry.exitReason).toBe('timeout');
+  });
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -105,6 +105,10 @@ import type {
   HttpCredentials,
   ChallengeInfo,
   ChallengeWaitResult,
+  AuthCheckRule,
+  AuthCheckResult,
+  AuthCheckDetail,
+  RunTelemetry,
 } from './types.js';
 
 /**
@@ -1388,6 +1392,103 @@ export class CrawlPage {
     });
   }
 
+  // ── Auth Health ──────────────────────────────────────────────
+
+  /**
+   * Check whether the current page session appears authenticated.
+   *
+   * Evaluates one or more rules against the page state. All rules must pass
+   * for `authenticated` to be `true`. Returns per-rule details for debugging.
+   *
+   * @param rules - Array of auth check rules (url, cookie, selector, text, textGone, fn)
+   * @returns Authentication status and per-rule check details
+   *
+   * @example
+   * ```ts
+   * // Check by URL and absence of login text
+   * const result = await page.isAuthenticated([
+   *   { url: '/dashboard' },
+   *   { textGone: 'Sign in' },
+   * ]);
+   * if (!result.authenticated) {
+   *   console.log('Auth failed:', result.checks.filter(c => !c.passed));
+   * }
+   *
+   * // Check by cookie presence
+   * const result = await page.isAuthenticated([{ cookie: 'session_id' }]);
+   *
+   * // Check with custom JS function
+   * const result = await page.isAuthenticated([
+   *   { fn: '() => !!document.querySelector("[data-user-id]")' },
+   * ]);
+   * ```
+   */
+  async isAuthenticated(rules: AuthCheckRule[]): Promise<AuthCheckResult> {
+    if (!rules.length) return { authenticated: true, checks: [] };
+
+    const page = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const checks: AuthCheckDetail[] = [];
+
+    for (const rule of rules) {
+      if (rule.url !== undefined) {
+        const currentUrl = page.url();
+        const passed = currentUrl.includes(rule.url);
+        checks.push({ rule: 'url', passed, detail: passed ? currentUrl : `expected "${rule.url}" in "${currentUrl}"` });
+      }
+
+      if (rule.cookie !== undefined) {
+        const cookies = await page.context().cookies();
+        const found = cookies.some((c) => c.name === rule.cookie && c.value !== '');
+        checks.push({ rule: 'cookie', passed: found, detail: found ? `cookie "${rule.cookie}" present` : `cookie "${rule.cookie}" missing or empty` });
+      }
+
+      if (rule.selector !== undefined) {
+        try {
+          const count = await page.locator(rule.selector).count();
+          const passed = count > 0;
+          checks.push({ rule: 'selector', passed, detail: passed ? `"${rule.selector}" found (${String(count)})` : `"${rule.selector}" not found` });
+        } catch {
+          checks.push({ rule: 'selector', passed: false, detail: `"${rule.selector}" error during evaluation` });
+        }
+      }
+
+      if (rule.text !== undefined) {
+        try {
+          const bodyText = await page.evaluate('() => { const b = document.body; return b ? b.innerText : ""; }');
+          const passed = typeof bodyText === 'string' && bodyText.includes(rule.text);
+          checks.push({ rule: 'text', passed, detail: passed ? `"${rule.text}" found` : `"${rule.text}" not found in page text` });
+        } catch {
+          checks.push({ rule: 'text', passed: false, detail: `"${rule.text}" error during evaluation` });
+        }
+      }
+
+      if (rule.textGone !== undefined) {
+        try {
+          const bodyText = await page.evaluate('() => { const b = document.body; return b ? b.innerText : ""; }');
+          const passed = typeof bodyText === 'string' && !bodyText.includes(rule.textGone);
+          checks.push({ rule: 'textGone', passed, detail: passed ? `"${rule.textGone}" absent (good)` : `"${rule.textGone}" still present` });
+        } catch {
+          checks.push({ rule: 'textGone', passed: false, detail: `"${rule.textGone}" error during evaluation` });
+        }
+      }
+
+      if (rule.fn !== undefined) {
+        try {
+          const result: unknown = await page.evaluate(rule.fn);
+          const passed = result !== null && result !== undefined && result !== false && result !== 0 && result !== '';
+          checks.push({ rule: 'fn', passed, detail: passed ? 'function returned truthy' : `function returned ${JSON.stringify(result)}` });
+        } catch (err) {
+          checks.push({ rule: 'fn', passed: false, detail: `function threw: ${err instanceof Error ? err.message : String(err)}` });
+        }
+      }
+    }
+
+    return {
+      authenticated: checks.length > 0 && checks.every((c) => c.passed),
+      checks,
+    };
+  }
+
   // ── Playwright Escape Hatches ─────────────────────────────────
 
   /**
@@ -1470,15 +1571,18 @@ export class BrowserClaw {
   private readonly ssrfPolicy: SsrfPolicy | undefined;
   private readonly recordVideo: { dir: string; size?: { width: number; height: number } } | undefined;
   private chrome: RunningChrome | null;
+  private readonly _telemetry: RunTelemetry;
 
   private constructor(
     cdpUrl: string,
     chrome: RunningChrome | null,
+    telemetry: RunTelemetry,
     ssrfPolicy?: SsrfPolicy,
     recordVideo?: { dir: string; size?: { width: number; height: number } },
   ) {
     this.cdpUrl = cdpUrl;
     this.chrome = chrome;
+    this._telemetry = telemetry;
     this.ssrfPolicy = ssrfPolicy;
     this.recordVideo = recordVideo;
   }
@@ -1508,16 +1612,28 @@ export class BrowserClaw {
    * ```
    */
   static async launch(opts: LaunchOptions = {}): Promise<BrowserClaw> {
+    const startedAt = new Date().toISOString();
     const chrome = await launchChrome(opts);
     const cdpUrl = `http://127.0.0.1:${String(chrome.cdpPort)}`;
     /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
     const ssrfPolicy =
       opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
     /* eslint-enable @typescript-eslint/no-deprecated */
-    const browser = new BrowserClaw(cdpUrl, chrome, ssrfPolicy, opts.recordVideo);
+    const telemetry: RunTelemetry = {
+      launchMs: chrome.launchMs,
+      timestamps: { startedAt, launchedAt: new Date().toISOString() },
+    };
+    const connectT0 = Date.now();
+    const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo);
     if (opts.url !== undefined && opts.url !== '') {
+      // connectBrowser is called lazily inside currentPage → connectBrowser
       const page = await browser.currentPage();
+      telemetry.connectMs = Date.now() - connectT0;
+      telemetry.timestamps.connectedAt = new Date().toISOString();
+      const navT0 = Date.now();
       await page.goto(opts.url);
+      telemetry.navMs = Date.now() - navT0;
+      telemetry.timestamps.navigatedAt = new Date().toISOString();
     }
     return browser;
   }
@@ -1537,6 +1653,8 @@ export class BrowserClaw {
    * ```
    */
   static async connect(cdpUrl?: string, opts?: ConnectOptions): Promise<BrowserClaw> {
+    const startedAt = new Date().toISOString();
+    const connectT0 = Date.now();
     let resolvedUrl = cdpUrl;
     if (resolvedUrl === undefined || resolvedUrl === '') {
       const discovered = await discoverChromeCdpUrl();
@@ -1555,7 +1673,11 @@ export class BrowserClaw {
     const ssrfPolicy =
       opts?.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts?.ssrfPolicy;
     /* eslint-enable @typescript-eslint/no-deprecated */
-    return new BrowserClaw(resolvedUrl, null, ssrfPolicy, opts?.recordVideo);
+    const telemetry: RunTelemetry = {
+      connectMs: Date.now() - connectT0,
+      timestamps: { startedAt, connectedAt: new Date().toISOString() },
+    };
+    return new BrowserClaw(resolvedUrl, null, telemetry, ssrfPolicy, opts?.recordVideo);
   }
 
   /**
@@ -1670,13 +1792,61 @@ export class BrowserClaw {
    * If the browser was launched by `BrowserClaw.launch()`, the Chrome process
    * will be terminated. If connected via `BrowserClaw.connect()`, only the
    * Playwright connection is closed.
+   *
+   * @param exitReason - Optional structured reason for stopping (e.g. `'success'`, `'auth_failed'`, `'timeout'`)
    */
-  async stop(): Promise<void> {
-    clearRecordingContext(this.cdpUrl);
-    await disconnectBrowser();
-    if (this.chrome) {
-      await stopChrome(this.chrome);
-      this.chrome = null;
+  async stop(exitReason?: string): Promise<void> {
+    this._telemetry.timestamps.stoppedAt = new Date().toISOString();
+    if (exitReason !== undefined) this._telemetry.exitReason = exitReason;
+    try {
+      clearRecordingContext(this.cdpUrl);
+      await disconnectBrowser();
+      if (this.chrome) {
+        await stopChrome(this.chrome);
+        this.chrome = null;
+      }
+      this._telemetry.cleanupOk = true;
+    } catch (err) {
+      this._telemetry.cleanupOk = false;
+      throw err;
     }
+  }
+
+  /**
+   * Get structured telemetry for this browser session.
+   *
+   * Returns timing data, timestamps, and exit information collected
+   * throughout the session lifecycle. Useful for diagnosing startup
+   * latency, auth failures, and cleanup issues in cron/unattended runs.
+   *
+   * @returns Telemetry envelope with launch/connect/nav timings and exit info
+   *
+   * @example
+   * ```ts
+   * const browser = await BrowserClaw.launch({ url: 'https://example.com' });
+   * const page = await browser.currentPage();
+   *
+   * // ... do work ...
+   *
+   * const auth = await page.isAuthenticated([{ cookie: 'session' }]);
+   * browser.recordAuthResult(auth.authenticated);
+   *
+   * await browser.stop(auth.authenticated ? 'success' : 'auth_failed');
+   * console.log(browser.telemetry());
+   * // { launchMs: 1823, connectMs: 45, navMs: 620, authOk: true,
+   * //   exitReason: 'success', cleanupOk: true, timestamps: { ... } }
+   * ```
+   */
+  telemetry(): Readonly<RunTelemetry> {
+    return this._telemetry;
+  }
+
+  /**
+   * Record the result of an authentication check in the telemetry envelope.
+   *
+   * @param ok - Whether authentication was successful
+   */
+  recordAuthResult(ok: boolean): void {
+    this._telemetry.authOk = ok;
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1464,7 +1464,11 @@ export class CrawlPage {
       if (rule.text !== undefined || rule.textGone !== undefined) {
         let bodyText: string | null = null;
         try {
-          const raw = await page.evaluate('() => { const b = document.body; return b ? b.innerText : ""; }');
+          const raw = await evaluateViaPlaywright({
+            cdpUrl: this.cdpUrl,
+            targetId: this.targetId,
+            fn: '() => { const b = document.body; return b ? b.innerText : ""; }',
+          });
           bodyText = typeof raw === 'string' ? raw : null;
         } catch {
           // bodyText stays null — individual checks below will report the error
@@ -1499,7 +1503,11 @@ export class CrawlPage {
 
       if (rule.fn !== undefined) {
         try {
-          const result: unknown = await page.evaluate(rule.fn);
+          const result: unknown = await evaluateViaPlaywright({
+            cdpUrl: this.cdpUrl,
+            targetId: this.targetId,
+            fn: rule.fn,
+          });
           const passed = result !== null && result !== undefined && result !== false && result !== 0 && result !== '';
           checks.push({
             rule: 'fn',

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1669,13 +1669,10 @@ export class BrowserClaw {
       launchMs: chrome.launchMs,
       timestamps: { startedAt, launchedAt: new Date().toISOString() },
     };
-    const connectT0 = Date.now();
     const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo);
     if (opts.url !== undefined && opts.url !== '') {
-      // connectBrowser is called lazily inside currentPage → connectBrowser
+      // connectBrowser is called lazily inside currentPage → connectBrowser; connectMs is recorded there
       const page = await browser.currentPage();
-      telemetry.connectMs = Date.now() - connectT0;
-      telemetry.timestamps.connectedAt = new Date().toISOString();
       const navT0 = Date.now();
       await page.goto(opts.url);
       telemetry.navMs = Date.now() - navT0;
@@ -1754,7 +1751,12 @@ export class BrowserClaw {
    * @returns CrawlPage for the first/active page
    */
   async currentPage(): Promise<CrawlPage> {
+    const connectT0 = Date.now();
     const { browser } = await connectBrowser(this.cdpUrl);
+    if (this._telemetry.connectMs === undefined) {
+      this._telemetry.connectMs = Date.now() - connectT0;
+      this._telemetry.timestamps.connectedAt = new Date().toISOString();
+    }
     const pages = getAllPages(browser);
     if (!pages.length) throw new Error('No pages available. Use browser.open(url) to create a tab.');
     const tid = await pageTargetId(pages[0]).catch(() => null);

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1455,7 +1455,10 @@ export class CrawlPage {
             passed,
             detail: passed ? `"${rule.selector}" found (${String(count)})` : `"${rule.selector}" not found`,
           });
-        } catch {
+        } catch (err) {
+          console.warn(
+            `[browserclaw] isAuthenticated selector check failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
           checks.push({ rule: 'selector', passed: false, detail: `"${rule.selector}" error during evaluation` });
         }
       }
@@ -1470,8 +1473,10 @@ export class CrawlPage {
             fn: '() => { const b = document.body; return b ? b.innerText : ""; }',
           });
           bodyText = typeof raw === 'string' ? raw : null;
-        } catch {
-          // bodyText stays null — individual checks below will report the error
+        } catch (err) {
+          console.warn(
+            `[browserclaw] isAuthenticated body text fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
 
         if (rule.text !== undefined) {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1439,14 +1439,22 @@ export class CrawlPage {
       if (rule.cookie !== undefined) {
         const cookies = await page.context().cookies();
         const found = cookies.some((c) => c.name === rule.cookie && c.value !== '');
-        checks.push({ rule: 'cookie', passed: found, detail: found ? `cookie "${rule.cookie}" present` : `cookie "${rule.cookie}" missing or empty` });
+        checks.push({
+          rule: 'cookie',
+          passed: found,
+          detail: found ? `cookie "${rule.cookie}" present` : `cookie "${rule.cookie}" missing or empty`,
+        });
       }
 
       if (rule.selector !== undefined) {
         try {
           const count = await page.locator(rule.selector).count();
           const passed = count > 0;
-          checks.push({ rule: 'selector', passed, detail: passed ? `"${rule.selector}" found (${String(count)})` : `"${rule.selector}" not found` });
+          checks.push({
+            rule: 'selector',
+            passed,
+            detail: passed ? `"${rule.selector}" found (${String(count)})` : `"${rule.selector}" not found`,
+          });
         } catch {
           checks.push({ rule: 'selector', passed: false, detail: `"${rule.selector}" error during evaluation` });
         }
@@ -1467,7 +1475,11 @@ export class CrawlPage {
             checks.push({ rule: 'text', passed: false, detail: `"${rule.text}" error during evaluation` });
           } else {
             const passed = bodyText.includes(rule.text);
-            checks.push({ rule: 'text', passed, detail: passed ? `"${rule.text}" found` : `"${rule.text}" not found in page text` });
+            checks.push({
+              rule: 'text',
+              passed,
+              detail: passed ? `"${rule.text}" found` : `"${rule.text}" not found in page text`,
+            });
           }
         }
 
@@ -1476,7 +1488,11 @@ export class CrawlPage {
             checks.push({ rule: 'textGone', passed: false, detail: `"${rule.textGone}" error during evaluation` });
           } else {
             const passed = !bodyText.includes(rule.textGone);
-            checks.push({ rule: 'textGone', passed, detail: passed ? `"${rule.textGone}" absent (good)` : `"${rule.textGone}" still present` });
+            checks.push({
+              rule: 'textGone',
+              passed,
+              detail: passed ? `"${rule.textGone}" absent (good)` : `"${rule.textGone}" still present`,
+            });
           }
         }
       }
@@ -1485,9 +1501,17 @@ export class CrawlPage {
         try {
           const result: unknown = await page.evaluate(rule.fn);
           const passed = result !== null && result !== undefined && result !== false && result !== 0 && result !== '';
-          checks.push({ rule: 'fn', passed, detail: passed ? 'function returned truthy' : `function returned ${JSON.stringify(result)}` });
+          checks.push({
+            rule: 'fn',
+            passed,
+            detail: passed ? 'function returned truthy' : `function returned ${JSON.stringify(result)}`,
+          });
         } catch (err) {
-          checks.push({ rule: 'fn', passed: false, detail: `function threw: ${err instanceof Error ? err.message : String(err)}` });
+          checks.push({
+            rule: 'fn',
+            passed: false,
+            detail: `function threw: ${err instanceof Error ? err.message : String(err)}`,
+          });
         }
       }
     }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1452,23 +1452,32 @@ export class CrawlPage {
         }
       }
 
-      if (rule.text !== undefined) {
+      // Fetch body text once if either text or textGone rule is present
+      if (rule.text !== undefined || rule.textGone !== undefined) {
+        let bodyText: string | null = null;
         try {
-          const bodyText = await page.evaluate('() => { const b = document.body; return b ? b.innerText : ""; }');
-          const passed = typeof bodyText === 'string' && bodyText.includes(rule.text);
-          checks.push({ rule: 'text', passed, detail: passed ? `"${rule.text}" found` : `"${rule.text}" not found in page text` });
+          const raw = await page.evaluate('() => { const b = document.body; return b ? b.innerText : ""; }');
+          bodyText = typeof raw === 'string' ? raw : null;
         } catch {
-          checks.push({ rule: 'text', passed: false, detail: `"${rule.text}" error during evaluation` });
+          // bodyText stays null — individual checks below will report the error
         }
-      }
 
-      if (rule.textGone !== undefined) {
-        try {
-          const bodyText = await page.evaluate('() => { const b = document.body; return b ? b.innerText : ""; }');
-          const passed = typeof bodyText === 'string' && !bodyText.includes(rule.textGone);
-          checks.push({ rule: 'textGone', passed, detail: passed ? `"${rule.textGone}" absent (good)` : `"${rule.textGone}" still present` });
-        } catch {
-          checks.push({ rule: 'textGone', passed: false, detail: `"${rule.textGone}" error during evaluation` });
+        if (rule.text !== undefined) {
+          if (bodyText === null) {
+            checks.push({ rule: 'text', passed: false, detail: `"${rule.text}" error during evaluation` });
+          } else {
+            const passed = bodyText.includes(rule.text);
+            checks.push({ rule: 'text', passed, detail: passed ? `"${rule.text}" found` : `"${rule.text}" not found in page text` });
+          }
+        }
+
+        if (rule.textGone !== undefined) {
+          if (bodyText === null) {
+            checks.push({ rule: 'textGone', passed: false, detail: `"${rule.textGone}" error during evaluation` });
+          } else {
+            const passed = !bodyText.includes(rule.textGone);
+            checks.push({ rule: 'textGone', passed, detail: passed ? `"${rule.textGone}" absent (good)` : `"${rule.textGone}" still present` });
+          }
         }
       }
 

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -861,6 +861,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     userDataDir,
     cdpPort,
     startedAt,
+    launchMs: Date.now() - startedAt,
     proc,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,4 +85,8 @@ export type {
   ChallengeKind,
   ChallengeInfo,
   ChallengeWaitResult,
+  AuthCheckRule,
+  AuthCheckResult,
+  AuthCheckDetail,
+  RunTelemetry,
 } from './types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export type {
   ChallengeInfo,
   ChallengeWaitResult,
   AuthCheckRule,
+  AuthCheckRuleKind,
   AuthCheckResult,
   AuthCheckDetail,
   RunTelemetry,

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,8 @@ export interface RunningChrome {
   cdpPort: number;
   /** Unix timestamp (ms) when the browser was started */
   startedAt: number;
+  /** Milliseconds from spawn to CDP-ready */
+  launchMs: number;
   /** The child process handle */
   proc: ChildProcess;
 }
@@ -590,6 +592,76 @@ export interface ChallengeWaitResult {
   resolved: boolean;
   /** The challenge still present (null if resolved) */
   challenge: ChallengeInfo | null;
+}
+
+// ── Auth Health ──
+
+/**
+ * A single rule for checking whether the browser session is authenticated.
+ * Multiple rules can be combined — all must pass for `authenticated: true`.
+ */
+export interface AuthCheckRule {
+  /** URL must match this substring or regex pattern (checked against page URL) */
+  url?: string;
+  /** A cookie with this name must exist (non-empty value) */
+  cookie?: string;
+  /** A CSS selector that must match a visible element on the page */
+  selector?: string;
+  /** Text that must be present on the page */
+  text?: string;
+  /** Text that must NOT be present on the page (e.g. "Sign in", "Log in") */
+  textGone?: string;
+  /** JavaScript function (as string) that must return a truthy value in the browser context */
+  fn?: string;
+}
+
+/** Result of a single auth check rule evaluation. */
+export interface AuthCheckDetail {
+  /** Which rule type was checked */
+  rule: string;
+  /** Whether this individual check passed */
+  passed: boolean;
+  /** Human-readable detail (e.g. the actual URL, cookie value presence, etc.) */
+  detail?: string;
+}
+
+/** Result of an `isAuthenticated()` call. */
+export interface AuthCheckResult {
+  /** `true` only if ALL rules passed */
+  authenticated: boolean;
+  /** Per-rule results for debugging */
+  checks: AuthCheckDetail[];
+}
+
+// ── Run Telemetry ──
+
+/** Structured telemetry envelope for a browser session lifecycle. */
+export interface RunTelemetry {
+  /** Milliseconds to launch Chrome (undefined if connected to existing instance) */
+  launchMs?: number;
+  /** Milliseconds to establish CDP connection */
+  connectMs?: number;
+  /** Milliseconds for initial navigation (if a URL was provided at launch) */
+  navMs?: number;
+  /** Whether auth verification passed (undefined if not checked) */
+  authOk?: boolean;
+  /** Structured exit reason when the session ends */
+  exitReason?: string;
+  /** Whether cleanup (process kill, connection close) succeeded */
+  cleanupOk?: boolean;
+  /** Key timestamps in ISO 8601 format */
+  timestamps: {
+    /** When the launch/connect sequence started */
+    startedAt: string;
+    /** When Chrome process became reachable */
+    launchedAt?: string;
+    /** When Playwright CDP connection was established */
+    connectedAt?: string;
+    /** When initial navigation completed */
+    navigatedAt?: string;
+    /** When stop() was called */
+    stoppedAt?: string;
+  };
 }
 
 // ── DNS Pinning ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -605,7 +605,7 @@ export interface AuthCheckRule {
   url?: string;
   /** A cookie with this name must exist (non-empty value) */
   cookie?: string;
-  /** A CSS selector that must match a visible element on the page */
+  /** A CSS selector that must match at least one element on the page (includes hidden elements) */
   selector?: string;
   /** Text that must be present on the page */
   text?: string;
@@ -615,10 +615,13 @@ export interface AuthCheckRule {
   fn?: string;
 }
 
+/** The kind of auth check rule that was evaluated. */
+export type AuthCheckRuleKind = 'url' | 'cookie' | 'selector' | 'text' | 'textGone' | 'fn';
+
 /** Result of a single auth check rule evaluation. */
 export interface AuthCheckDetail {
   /** Which rule type was checked */
-  rule: string;
+  rule: AuthCheckRuleKind;
   /** Whether this individual check passed */
   passed: boolean;
   /** Human-readable detail (e.g. the actual URL, cookie value presence, etc.) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -649,7 +649,7 @@ export interface RunTelemetry {
   /** Whether auth verification passed (undefined if not checked) */
   authOk?: boolean;
   /** Structured exit reason when the session ends */
-  exitReason?: string;
+  exitReason?: 'success' | 'auth_failed' | 'timeout' | 'error' | 'manual' | (string & {});
   /** Whether cleanup (process kill, connection close) succeeded */
   cleanupOk?: boolean;
   /** Key timestamps in ISO 8601 format */

--- a/src/types.ts
+++ b/src/types.ts
@@ -601,7 +601,7 @@ export interface ChallengeWaitResult {
  * Multiple rules can be combined — all must pass for `authenticated: true`.
  */
 export interface AuthCheckRule {
-  /** URL must match this substring or regex pattern (checked against page URL) */
+  /** URL must contain this substring (checked against page URL) */
   url?: string;
   /** A cookie with this name must exist (non-empty value) */
   cookie?: string;


### PR DESCRIPTION
Add isAuthenticated() to CrawlPage with configurable rules (url, cookie,
selector, text, textGone, fn) for verifying web app auth state. Add
RunTelemetry tracking to BrowserClaw lifecycle (launch/connect/nav timing,
auth status, exit reason, cleanup result). Both features address the
reclassified "bugs" that were actually observability/productization gaps.

https://claude.ai/code/session_012d8oH17ES5zA8eE7hnr8X4