### PR TITLE
feat: typed ExitReason enum (0.12.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -108,6 +108,7 @@ import type {
   AuthCheckRule,
   AuthCheckResult,
   AuthCheckDetail,
+  ExitReason,
   RunTelemetry,
 } from './types.js';
 
@@ -1843,7 +1844,7 @@ export class BrowserClaw {
    *
    * @param exitReason - Optional structured reason for stopping (e.g. `'success'`, `'auth_failed'`, `'timeout'`)
    */
-  async stop(exitReason?: string): Promise<void> {
+  async stop(exitReason?: ExitReason | (string & {})): Promise<void> {
     this._telemetry.timestamps.stoppedAt = new Date().toISOString();
     if (exitReason !== undefined) this._telemetry.exitReason = exitReason;
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,5 +89,6 @@ export type {
   AuthCheckRuleKind,
   AuthCheckResult,
   AuthCheckDetail,
+  ExitReason,
   RunTelemetry,
 } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -638,6 +638,17 @@ export interface AuthCheckResult {
 
 // ── Run Telemetry ──
 
+/** Standard exit reasons for structured telemetry. */
+export type ExitReason =
+  | 'success'
+  | 'auth_failed'
+  | 'nav_failed'
+  | 'timeout'
+  | 'crash'
+  | 'disconnected'
+  | 'manual'
+  | 'error';
+
 /** Structured telemetry envelope for a browser session lifecycle. */
 export interface RunTelemetry {
   /** Milliseconds to launch Chrome (undefined if connected to existing instance) */
@@ -649,7 +660,7 @@ export interface RunTelemetry {
   /** Whether auth verification passed (undefined if not checked) */
   authOk?: boolean;
   /** Structured exit reason when the session ends */
-  exitReason?: 'success' | 'auth_failed' | 'timeout' | 'error' | 'manual' | (string & {});
+  exitReason?: ExitReason | (string & {});
   /** Whether cleanup (process kill, connection close) succeeded */
   cleanupOk?: boolean;
   /** Key timestamps in ISO 8601 format */


### PR DESCRIPTION
## Summary

- Extracts inline `exitReason` union to a named `ExitReason` type
- Adds 3 missing standard values: `nav_failed`, `crash`, `disconnected`
- Full set: `success | auth_failed | nav_failed | timeout | crash | disconnected | manual | error`
- `stop()` parameter typed as `ExitReason | (string & {})` for autocomplete + extensibility
- Bumps to 0.12.1

## Test plan

- [ ] Typecheck, lint, format, tests, build all pass
- [ ] `ExitReason` exported from package entry point

https://claude.ai/code/session_012d8oH17ES5zA8eE7hnr8X4