### PR TITLE
Fix Chrome launch race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -834,11 +834,11 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 
   const readyDeadline = Date.now() + 15000;
   while (Date.now() < readyDeadline) {
-    if (await isChromeReachable(cdpUrl, 500)) break;
+    if (await isChromeCdpReady(cdpUrl, 500)) break;
     await new Promise((r) => setTimeout(r, 200));
   }
 
-  if (!(await isChromeReachable(cdpUrl, 500))) {
+  if (!(await isChromeCdpReady(cdpUrl, 500))) {
     const stderrOutput = Buffer.concat(stderrChunks).toString('utf8').trim();
     const stderrHint = stderrOutput ? `\nChrome stderr:\n${stderrOutput.slice(0, 2000)}` : '';
     const sandboxHint =


### PR DESCRIPTION
## Summary

- `launchChrome()` used `isChromeReachable()` for its readiness polling loop, which only checks that Chrome's HTTP debug endpoint responds (`/json/version`). Replaced with `isChromeCdpReady()` which additionally opens a WebSocket and runs a `Browser.getVersion` CDP command, confirming the CDP protocol is actually operational.
- Fixes a race condition where `launchChrome()` could return before CDP WebSocket connections are ready, causing downstream failures when Playwright tries to connect.

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Format check passes
- [x] All 219 tests pass