### PR TITLE
Fix 62 code review issues across all severity levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -14,7 +14,6 @@ import { pressKeyViaPlaywright } from './keyboard.js';
 import { resizeViewportViaPlaywright, closePageViaPlaywright } from './navigation.js';
 import { waitForViaPlaywright } from './wait.js';
 
-
 const MAX_BATCH_DEPTH = 5;
 const MAX_BATCH_TIMEOUT_MS = 300_000;
 const MAX_BATCH_ACTIONS = 100;

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -1,3 +1,5 @@
+import { BrowserTabNotFoundError, BlockedBrowserTargetError } from '../connection.js';
+
 import { evaluateViaPlaywright } from './evaluate.js';
 import {
   clickViaPlaywright,
@@ -12,7 +14,6 @@ import { pressKeyViaPlaywright } from './keyboard.js';
 import { resizeViewportViaPlaywright, closePageViaPlaywright } from './navigation.js';
 import { waitForViaPlaywright } from './wait.js';
 
-import { BrowserTabNotFoundError, BlockedBrowserTargetError } from '../connection.js';
 
 const MAX_BATCH_DEPTH = 5;
 const MAX_BATCH_TIMEOUT_MS = 300_000;

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -12,7 +12,10 @@ import { pressKeyViaPlaywright } from './keyboard.js';
 import { resizeViewportViaPlaywright, closePageViaPlaywright } from './navigation.js';
 import { waitForViaPlaywright } from './wait.js';
 
+import { BrowserTabNotFoundError, BlockedBrowserTargetError } from '../connection.js';
+
 const MAX_BATCH_DEPTH = 5;
+const MAX_BATCH_TIMEOUT_MS = 300_000;
 const MAX_BATCH_ACTIONS = 100;
 
 /** A single action within a batch. */
@@ -251,14 +254,21 @@ export async function batchViaPlaywright(opts: {
 
   const results: BatchActionResult[] = [];
   const evaluateEnabled = opts.evaluateEnabled !== false;
+  const deadline = Date.now() + MAX_BATCH_TIMEOUT_MS;
 
   for (const action of opts.actions) {
+    if (Date.now() > deadline) {
+      results.push({ ok: false, error: 'Batch timeout exceeded' });
+      break;
+    }
     try {
       await executeSingleAction(action, opts.cdpUrl, opts.targetId, evaluateEnabled, depth);
       results.push({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       results.push({ ok: false, error: message });
+      // Always stop on page-destroying errors regardless of stopOnError setting
+      if (err instanceof BrowserTabNotFoundError || err instanceof BlockedBrowserTargetError) break;
       if (opts.stopOnError !== false) break;
     }
   }

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -5,7 +5,6 @@ import type { Page, Download } from 'playwright-core';
 import {
   getPageForTargetId,
   ensurePageState,
-  restoreRoleRefsForTarget,
   refLocator,
   toAIFriendlyError,
   normalizeTimeoutMs,
@@ -100,7 +99,6 @@ export async function downloadViaPlaywright(opts: {
 
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   const state = ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
   const outPath = opts.path.trim();

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -102,8 +102,8 @@ export async function downloadViaPlaywright(opts: {
   const outPath = opts.path.trim();
   if (!outPath) throw new Error('path is required');
 
-  state.armIdDownload = bumpDownloadArmId(state);
-  const armId = state.armIdDownload;
+  const armId = bumpDownloadArmId(state);
+  state.armIdDownload = armId;
   const waiter = createPageDownloadWaiter(page, timeout);
 
   try {

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -28,8 +28,10 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
     }
   };
 
+  let rejectPromise: ((reason: Error) => void) | undefined;
   return {
     promise: new Promise<Download>((resolve, reject) => {
+      rejectPromise = reject;
       handler = (download: Download) => {
         if (done) return;
         done = true;
@@ -48,6 +50,8 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
       if (done) return;
       done = true;
       cleanup();
+      // Reject the pending promise so callers awaiting it don't hang
+      rejectPromise?.(new Error('Download waiter cancelled'));
     },
   };
 }

--- a/src/actions/emulation.ts
+++ b/src/actions/emulation.ts
@@ -35,13 +35,7 @@ export async function setDeviceViaPlaywright(opts: { cdpUrl: string; targetId?: 
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
 
-  if (device.viewport !== null) {
-    await page.setViewportSize({
-      width: device.viewport.width,
-      height: device.viewport.height,
-    });
-  }
-
+  // Apply all emulation settings via CDP in a single session for atomicity
   await withPageScopedCdpClient({
     cdpUrl: opts.cdpUrl,
     page,
@@ -69,6 +63,14 @@ export async function setDeviceViaPlaywright(opts: { cdpUrl: string; targetId?: 
       }
     },
   });
+
+  // Also set viewport at the Playwright level for proper layout
+  if (device.viewport !== null) {
+    await page.setViewportSize({
+      width: device.viewport.width,
+      height: device.viewport.height,
+    });
+  }
 }
 
 export async function setExtraHTTPHeadersViaPlaywright(opts: {
@@ -78,7 +80,16 @@ export async function setExtraHTTPHeadersViaPlaywright(opts: {
 }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
-  await page.context().setExtraHTTPHeaders(opts.headers);
+  // Use CDP Network.setExtraHTTPHeaders for page-scoped headers instead of
+  // context-level setExtraHTTPHeaders which affects all tabs
+  await withPageScopedCdpClient({
+    cdpUrl: opts.cdpUrl,
+    page,
+    targetId: opts.targetId,
+    fn: async (send) => {
+      await send('Network.setExtraHTTPHeaders', { headers: opts.headers });
+    },
+  });
 }
 
 export async function setGeolocationViaPlaywright(opts: {

--- a/src/actions/emulation.ts
+++ b/src/actions/emulation.ts
@@ -107,8 +107,8 @@ export async function setGeolocationViaPlaywright(opts: {
 
   if (opts.clear === true) {
     await context.setGeolocation(null);
-    await context.clearPermissions().catch(() => {
-      /* intentional no-op */
+    await context.clearPermissions().catch((err: unknown) => {
+      console.warn(`[browserclaw] clearPermissions failed: ${err instanceof Error ? err.message : String(err)}`);
     });
     return;
   }

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -154,8 +154,9 @@ export async function evaluateViaPlaywright(opts: {
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
   const outerTimeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
-  let evaluateTimeout = Math.max(1000, Math.min(120000, outerTimeout - 500));
-  evaluateTimeout = Math.min(evaluateTimeout, outerTimeout);
+  // Browser-side timeout must be strictly less than outer timeout so Playwright
+  // can surface its own timeout error instead of hanging indefinitely
+  const evaluateTimeout = Math.max(1000, Math.min(120000, outerTimeout - 1000));
 
   const signal = opts.signal;
   let abortListener: (() => void) | undefined;
@@ -228,5 +229,8 @@ export async function evaluateViaPlaywright(opts: {
     );
   } finally {
     if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+    // Release closure references to prevent memory leaks in long-lived signals
+    abortReject = undefined;
+    abortListener = undefined;
   }
 }

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -5,6 +5,7 @@ import {
   refLocator,
   normalizeTimeoutMs,
   forceDisconnectPlaywrightConnection,
+  tryTerminateExecutionViaCdp,
 } from '../connection.js';
 
 export interface FrameEvalResult {
@@ -88,10 +89,11 @@ const BROWSER_EVALUATOR = new Function(
     '  catch (_) { candidate = (0, eval)(fnBody); }',
     '  var result = typeof candidate === "function" ? candidate() : candidate;',
     '  if (result && typeof result.then === "function") {',
+    '    var tid;',
     '    return Promise.race([',
-    '      result,',
+    '      result.then(function(v) { clearTimeout(tid); return v; }, function(e) { clearTimeout(tid); throw e; }),',
     '      new Promise(function(_, reject) {',
-    '        setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);',
+    '        tid = setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);',
     '      })',
     '    ]);',
     '  }',
@@ -115,10 +117,11 @@ const ELEMENT_EVALUATOR = new Function(
     '  catch (_) { candidate = (0, eval)(fnBody); }',
     '  var result = typeof candidate === "function" ? candidate(el) : candidate;',
     '  if (result && typeof result.then === "function") {',
+    '    var tid;',
     '    return Promise.race([',
-    '      result,',
+    '      result.then(function(v) { clearTimeout(tid); return v; }, function(e) { clearTimeout(tid); throw e; }),',
     '      new Promise(function(_, reject) {',
-    '        setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);',
+    '        tid = setTimeout(function() { reject(new Error("evaluate timed out after " + timeoutMs + "ms")); }, timeoutMs);',
     '      })',
     '    ]);',
     '  }',
@@ -170,13 +173,22 @@ export async function evaluateViaPlaywright(opts: {
 
   if (signal !== undefined) {
     const disconnect = () => {
-      forceDisconnectPlaywrightConnection({
-        cdpUrl: opts.cdpUrl,
-        targetId: opts.targetId,
-        reason: 'evaluate aborted',
-      }).catch(() => {
-        /* intentional no-op */
-      });
+      const targetId = opts.targetId?.trim() ?? '';
+      if (targetId !== '') {
+        // Targeted: only terminate execution on this target, preserving the shared connection
+        tryTerminateExecutionViaCdp(opts.cdpUrl, targetId).catch(() => {
+          /* intentional no-op */
+        });
+      } else {
+        // No target ID — forced to tear down the shared connection as last resort
+        console.warn('[browserclaw] evaluate abort: no targetId, forcing full disconnect');
+        forceDisconnectPlaywrightConnection({
+          cdpUrl: opts.cdpUrl,
+          reason: 'evaluate aborted (no targetId)',
+        }).catch(() => {
+          /* intentional no-op */
+        });
+      }
     };
     if (signal.aborted) {
       disconnect();

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -1,7 +1,6 @@
 import {
   getPageForTargetId,
   ensurePageState,
-  restoreRoleRefsForTarget,
   refLocator,
   normalizeTimeoutMs,
   forceDisconnectPlaywrightConnection,
@@ -151,7 +150,6 @@ export async function evaluateViaPlaywright(opts: {
 
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
   const outerTimeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
   // Browser-side timeout must be strictly less than outer timeout so Playwright

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -318,6 +318,7 @@ export async function fillFormViaPlaywright(opts: {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
 
+  let filledCount = 0;
   for (const field of opts.fields) {
     const ref = field.ref.trim();
     const type = (typeof field.type === 'string' ? field.type.trim() : '') || 'text';
@@ -343,17 +344,25 @@ export async function fillFormViaPlaywright(opts: {
         try {
           await setCheckedViaEvaluate(locator, checked);
         } catch (err) {
-          throw toAIFriendlyError(err, ref);
+          const friendly = toAIFriendlyError(err, ref);
+          throw new Error(
+            `Failed at field "${ref}" (${String(filledCount)}/${String(opts.fields.length)} filled): ${friendly.message}`,
+          );
         }
       }
+      filledCount += 1;
       continue;
     }
 
     try {
       await locator.fill(value, { timeout });
     } catch (err) {
-      throw toAIFriendlyError(err, ref);
+      const friendly = toAIFriendlyError(err, ref);
+      throw new Error(
+        `Failed at field "${ref}" (${String(filledCount)}/${String(opts.fields.length)} filled): ${friendly.message}`,
+      );
     }
+    filledCount += 1;
   }
 }
 
@@ -454,6 +463,10 @@ export async function armDialogViaPlaywright(opts: {
 
   // Fire-and-forget: returns immediately once the arm is registered.
   // The waitForEvent chain runs in the background and handles the dialog when it fires.
+  const resetArm = () => {
+    if (state.armIdDialog === armId) state.armIdDialog = 0;
+  };
+  page.once('close', resetArm);
   page
     .waitForEvent('dialog', { timeout })
     .then(async (dialog) => {
@@ -462,11 +475,13 @@ export async function armDialogViaPlaywright(opts: {
         if (opts.accept) await dialog.accept(opts.promptText);
         else await dialog.dismiss();
       } finally {
-        if (state.armIdDialog === armId) state.armIdDialog = 0;
+        resetArm();
+        page.off('close', resetArm);
       }
     })
     .catch(() => {
-      if (state.armIdDialog === armId) state.armIdDialog = 0;
+      resetArm();
+      page.off('close', resetArm);
     });
 }
 
@@ -483,6 +498,10 @@ export async function armFileUploadViaPlaywright(opts: {
   state.armIdUpload = bumpUploadArmId(state);
   const armId = state.armIdUpload;
 
+  const resetArm = () => {
+    if (state.armIdUpload === armId) state.armIdUpload = 0;
+  };
+  page.once('close', resetArm);
   page
     .waitForEvent('filechooser', { timeout })
     .then(async (fileChooser) => {
@@ -522,11 +541,19 @@ export async function armFileUploadViaPlaywright(opts: {
             el.dispatchEvent(new Event('change', { bubbles: true }));
           });
         }
-      } catch {
-        /* intentional no-op */
+      } catch (e: unknown) {
+        console.warn(
+          `[browserclaw] armFileUpload: dispatch events failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     })
-    .catch(() => {
-      /* intentional no-op */
+    .catch((e: unknown) => {
+      console.warn(
+        `[browserclaw] armFileUpload: filechooser wait failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    })
+    .finally(() => {
+      resetArm();
+      page.off('close', resetArm);
     });
 }

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -64,6 +64,9 @@ export async function mouseClickViaPlaywright(opts: {
   });
 }
 
+// Note: pressAndHold is not cancellable once the mousePressed event is dispatched.
+// The holdMs sleep runs to completion — there is no AbortSignal support because
+// interrupting mid-hold would leave the mouse button in a pressed state.
 export async function pressAndHoldViaCdp(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -191,9 +194,10 @@ export async function clickViaPlaywright(opts: {
     if (checkableRole && opts.doubleClick !== true && ariaCheckedBefore !== undefined) {
       const POLL_INTERVAL_MS = 50;
       const POLL_TIMEOUT_MS = 500;
+      const ATTR_TIMEOUT_MS = Math.min(timeout, POLL_TIMEOUT_MS);
       let changed = false;
       for (let elapsed = 0; elapsed < POLL_TIMEOUT_MS; elapsed += POLL_INTERVAL_MS) {
-        const current = await locator.getAttribute('aria-checked', { timeout }).catch(() => undefined);
+        const current = await locator.getAttribute('aria-checked', { timeout: ATTR_TIMEOUT_MS }).catch(() => undefined);
         if (current === undefined || current !== ariaCheckedBefore) {
           changed = true;
           break;

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -190,6 +190,8 @@ export async function navigateViaPlaywright(opts: {
     response = await navigate();
   } catch (err) {
     if (!isRetryableNavigateError(err)) throw err;
+    // Clean recording context before force-disconnect to prevent stale references
+    recordingContexts.delete(opts.cdpUrl);
     await forceDisconnectPlaywrightConnection({
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
@@ -269,9 +271,7 @@ export async function createPageViaPlaywright(opts: {
       });
     } catch (err) {
       if (isPolicyDenyNavigationError(err) || err instanceof BlockedBrowserTargetError) throw err;
-      console.warn(
-        `[browserclaw] createPage navigation failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      console.warn(`[browserclaw] createPage navigation failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -41,7 +41,7 @@ async function createRecordingContext(
   recordVideo: { dir: string; size?: { width: number; height: number } },
 ): Promise<BrowserContext> {
   const context = await browser.newContext({ recordVideo });
-  observeContext(context);
+  await observeContext(context);
   recordingContexts.set(cdpUrl, context);
   context.on('close', () => recordingContexts.delete(cdpUrl));
   return context;
@@ -112,6 +112,14 @@ async function gotoPageWithNavigationGuard(opts: {
       return;
     }
     if (!isTopLevelNavigationRequest(opts.page, request)) {
+      await route.continue();
+      return;
+    }
+    // Only guard navigations initiated by this call:
+    // - initial request must match our target URL
+    // - redirects (redirectedFrom !== null) are always checked since they may be part of our chain
+    const isRedirect = request.redirectedFrom() !== null;
+    if (!isRedirect && request.url() !== opts.url) {
       await route.continue();
       return;
     }
@@ -261,6 +269,9 @@ export async function createPageViaPlaywright(opts: {
       });
     } catch (err) {
       if (isPolicyDenyNavigationError(err) || err instanceof BlockedBrowserTargetError) throw err;
+      console.warn(
+        `[browserclaw] createPage navigation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -17,7 +17,10 @@ export async function waitForViaPlaywright(opts: {
 }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
+  const totalTimeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
+  const deadline = Date.now() + totalTimeout;
+
+  const remaining = () => Math.max(500, deadline - Date.now());
 
   if (typeof opts.timeMs === 'number' && Number.isFinite(opts.timeMs)) {
     // timeMs is a fixed delay capped at MAX_WAIT_TIME_MS, independent of timeoutMs
@@ -26,29 +29,33 @@ export async function waitForViaPlaywright(opts: {
   }
   if (opts.text !== undefined && opts.text !== '') {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- document.body is null before DOM ready
-    await page.waitForFunction((text) => (document.body?.innerText ?? '').includes(text), opts.text, { timeout });
+    await page.waitForFunction((text) => (document.body?.innerText ?? '').includes(text), opts.text, {
+      timeout: remaining(),
+    });
   }
   if (opts.textGone !== undefined && opts.textGone !== '') {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- document.body is null before DOM ready
-    await page.waitForFunction((text) => !(document.body?.innerText ?? '').includes(text), opts.textGone, { timeout });
+    await page.waitForFunction((text) => !(document.body?.innerText ?? '').includes(text), opts.textGone, {
+      timeout: remaining(),
+    });
   }
   if (opts.selector !== undefined && opts.selector !== '') {
     const selector = opts.selector.trim();
-    if (selector !== '') await page.locator(selector).first().waitFor({ state: 'visible', timeout });
+    if (selector !== '') await page.locator(selector).first().waitFor({ state: 'visible', timeout: remaining() });
   }
   if (opts.url !== undefined && opts.url !== '') {
     const url = opts.url.trim();
-    if (url !== '') await page.waitForURL(url, { timeout });
+    if (url !== '') await page.waitForURL(url, { timeout: remaining() });
   }
   if (opts.loadState !== undefined) {
-    await page.waitForLoadState(opts.loadState, { timeout });
+    await page.waitForLoadState(opts.loadState, { timeout: remaining() });
   }
   if (opts.fn !== undefined) {
     if (typeof opts.fn === 'function') {
-      await page.waitForFunction(opts.fn, opts.arg, { timeout });
+      await page.waitForFunction(opts.fn, opts.arg, { timeout: remaining() });
     } else {
       const fn = opts.fn.trim();
-      if (fn !== '') await page.waitForFunction(fn, opts.arg, { timeout });
+      if (fn !== '') await page.waitForFunction(fn, opts.arg, { timeout: remaining() });
     }
   }
 }

--- a/src/actions/wait.ts
+++ b/src/actions/wait.ts
@@ -23,8 +23,8 @@ export async function waitForViaPlaywright(opts: {
   const remaining = () => Math.max(500, deadline - Date.now());
 
   if (typeof opts.timeMs === 'number' && Number.isFinite(opts.timeMs)) {
-    // timeMs is a fixed delay capped at MAX_WAIT_TIME_MS, independent of timeoutMs
-    // (timeoutMs governs condition-based waits below, not this fixed sleep)
+    // timeMs is a fixed delay capped at MAX_WAIT_TIME_MS; it consumes time from the
+    // overall deadline so subsequent condition waits get an accurate remaining() budget
     await page.waitForTimeout(resolveBoundedDelayMs(opts.timeMs, 'wait timeMs', MAX_WAIT_TIME_MS));
   }
   if (opts.text !== undefined && opts.text !== '') {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -56,7 +56,7 @@ import { traceStartViaPlaywright, traceStopViaPlaywright } from './capture/trace
 import { launchChrome, stopChrome, isChromeReachable, discoverChromeCdpUrl } from './chrome-launcher.js';
 import {
   connectBrowser,
-  disconnectBrowser,
+  closePlaywrightBrowserConnection,
   getPageForTargetId,
   ensurePageState,
   pageTargetId,
@@ -132,19 +132,30 @@ import type {
  */
 export class CrawlPage {
   private readonly cdpUrl: string;
-  private readonly targetId: string;
+  private _targetId: string;
   private readonly ssrfPolicy: SsrfPolicy | undefined;
 
   /** @internal */
   constructor(cdpUrl: string, targetId: string, ssrfPolicy?: SsrfPolicy) {
     this.cdpUrl = cdpUrl;
-    this.targetId = targetId;
+    this._targetId = targetId;
     this.ssrfPolicy = ssrfPolicy;
   }
 
   /** The CDP target ID for this page. Use this to identify the page in multi-tab scenarios. */
   get id(): string {
-    return this.targetId;
+    return this._targetId;
+  }
+
+  /**
+   * Refresh the target ID by re-resolving the page from the browser.
+   * Useful after reconnection when the old target ID may be stale.
+   */
+  async refreshTargetId(): Promise<string> {
+    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const newId = await pageTargetId(page);
+    if (newId !== null && newId !== '') this._targetId = newId;
+    return this._targetId;
   }
 
   // ── Snapshot ──────────────────────────────────────────────────
@@ -174,7 +185,7 @@ export class CrawlPage {
     if (opts?.mode === 'role') {
       return snapshotRole({
         cdpUrl: this.cdpUrl,
-        targetId: this.targetId,
+        targetId: this._targetId,
         selector: opts.selector,
         frameSelector: opts.frameSelector,
         refsMode: opts.refsMode,
@@ -196,7 +207,7 @@ export class CrawlPage {
     }
     return snapshotAi({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       maxChars: opts?.maxChars,
       options: {
         interactive: opts?.interactive,
@@ -216,7 +227,7 @@ export class CrawlPage {
    * @returns Array of accessibility tree nodes
    */
   async ariaSnapshot(opts?: { limit?: number }): Promise<AriaSnapshotResult> {
-    return snapshotAria({ cdpUrl: this.cdpUrl, targetId: this.targetId, limit: opts?.limit });
+    return snapshotAria({ cdpUrl: this.cdpUrl, targetId: this._targetId, limit: opts?.limit });
   }
 
   // ── Interactions ─────────────────────────────────────────────
@@ -238,7 +249,7 @@ export class CrawlPage {
   async click(ref: string, opts?: ClickOptions): Promise<void> {
     return clickViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       doubleClick: opts?.doubleClick,
       button: opts?.button,
@@ -266,7 +277,7 @@ export class CrawlPage {
   async clickBySelector(selector: string, opts?: ClickOptions): Promise<void> {
     return clickViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       selector,
       doubleClick: opts?.doubleClick,
       button: opts?.button,
@@ -300,7 +311,7 @@ export class CrawlPage {
   ): Promise<void> {
     return mouseClickViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       x,
       y,
       button: opts?.button,
@@ -328,7 +339,7 @@ export class CrawlPage {
   async pressAndHold(x: number, y: number, opts?: { delay?: number; holdMs?: number }): Promise<void> {
     return pressAndHoldViaCdp({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       x,
       y,
       delay: opts?.delay,
@@ -361,7 +372,7 @@ export class CrawlPage {
   ): Promise<void> {
     return clickByTextViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       text,
       exact: opts?.exact,
       button: opts?.button,
@@ -398,7 +409,7 @@ export class CrawlPage {
   ): Promise<void> {
     return clickByRoleViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       role,
       name,
       index: opts?.index,
@@ -428,7 +439,7 @@ export class CrawlPage {
   async type(ref: string, text: string, opts?: TypeOptions): Promise<void> {
     return typeViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       text,
       submit: opts?.submit,
@@ -446,7 +457,7 @@ export class CrawlPage {
   async hover(ref: string, opts?: { timeoutMs?: number }): Promise<void> {
     return hoverViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       timeoutMs: opts?.timeoutMs,
     });
@@ -467,7 +478,7 @@ export class CrawlPage {
   async select(ref: string, ...values: string[]): Promise<void> {
     return selectOptionViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       values,
     });
@@ -483,7 +494,7 @@ export class CrawlPage {
   async drag(startRef: string, endRef: string, opts?: { timeoutMs?: number }): Promise<void> {
     return dragViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       startRef,
       endRef,
       timeoutMs: opts?.timeoutMs,
@@ -509,7 +520,7 @@ export class CrawlPage {
   async fill(fields: FormField[]): Promise<void> {
     return fillFormViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       fields,
     });
   }
@@ -523,7 +534,7 @@ export class CrawlPage {
   async scrollIntoView(ref: string, opts?: { timeoutMs?: number }): Promise<void> {
     return scrollIntoViewViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       timeoutMs: opts?.timeoutMs,
     });
@@ -537,7 +548,7 @@ export class CrawlPage {
   async highlight(ref: string): Promise<void> {
     return highlightViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
     });
   }
@@ -551,7 +562,7 @@ export class CrawlPage {
   async uploadFile(ref: string, paths: string[]): Promise<void> {
     return setInputFilesViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       paths,
     });
@@ -575,7 +586,7 @@ export class CrawlPage {
   async armDialog(opts: DialogOptions): Promise<void> {
     return armDialogViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       accept: opts.accept,
       promptText: opts.promptText,
       timeoutMs: opts.timeoutMs,
@@ -620,7 +631,7 @@ export class CrawlPage {
   async onDialog(handler: DialogHandler | undefined | null): Promise<void> {
     return setDialogHandler({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       handler: handler ?? undefined,
     });
   }
@@ -643,7 +654,7 @@ export class CrawlPage {
   async armFileUpload(paths?: string[], opts?: { timeoutMs?: number }): Promise<void> {
     return armFileUploadViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       paths,
       timeoutMs: opts?.timeoutMs,
     });
@@ -662,7 +673,7 @@ export class CrawlPage {
   ): Promise<{ results: BatchActionResult[] }> {
     return batchViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       actions,
       stopOnError: opts?.stopOnError,
       evaluateEnabled: opts?.evaluateEnabled,
@@ -689,7 +700,7 @@ export class CrawlPage {
   async press(key: string, opts?: { delayMs?: number }): Promise<void> {
     return pressKeyViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       key,
       delayMs: opts?.delayMs,
     });
@@ -701,7 +712,7 @@ export class CrawlPage {
    * Get the current URL of the page.
    */
   async url(): Promise<string> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     return page.url();
   }
 
@@ -709,7 +720,7 @@ export class CrawlPage {
    * Get the page title.
    */
   async title(): Promise<string> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     return page.title();
   }
 
@@ -723,7 +734,7 @@ export class CrawlPage {
   async goto(url: string, opts?: { timeoutMs?: number }): Promise<{ url: string }> {
     return navigateViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       url,
       timeoutMs: opts?.timeoutMs,
       ssrfPolicy: this.ssrfPolicy,
@@ -736,7 +747,7 @@ export class CrawlPage {
    * @param opts - Timeout options
    */
   async reload(opts?: { timeoutMs?: number }): Promise<void> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     ensurePageState(page);
     await page.reload({ timeout: normalizeTimeoutMs(opts?.timeoutMs, 20000) });
   }
@@ -747,7 +758,7 @@ export class CrawlPage {
    * @param opts - Timeout options
    */
   async goBack(opts?: { timeoutMs?: number }): Promise<void> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     ensurePageState(page);
     await page.goBack({ timeout: normalizeTimeoutMs(opts?.timeoutMs, 20000) });
   }
@@ -758,7 +769,7 @@ export class CrawlPage {
    * @param opts - Timeout options
    */
   async goForward(opts?: { timeoutMs?: number }): Promise<void> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     ensurePageState(page);
     await page.goForward({ timeout: normalizeTimeoutMs(opts?.timeoutMs, 20000) });
   }
@@ -783,7 +794,7 @@ export class CrawlPage {
   async waitFor(opts: WaitOptions): Promise<void> {
     return waitForViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ...opts,
     });
   }
@@ -810,7 +821,7 @@ export class CrawlPage {
   async evaluate(fn: string, opts?: { ref?: string; timeoutMs?: number; signal?: AbortSignal }): Promise<unknown> {
     return evaluateViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       fn,
       ref: opts?.ref,
       timeoutMs: opts?.timeoutMs,
@@ -838,7 +849,7 @@ export class CrawlPage {
   async evaluateInAllFrames(fn: string): Promise<FrameEvalResult[]> {
     return evaluateInAllFramesViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       fn,
     });
   }
@@ -861,7 +872,7 @@ export class CrawlPage {
   async screenshot(opts?: ScreenshotOptions): Promise<Buffer> {
     const result = await takeScreenshotViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       fullPage: opts?.fullPage,
       ref: opts?.ref,
       element: opts?.element,
@@ -878,7 +889,7 @@ export class CrawlPage {
    * @returns PDF document as a Buffer
    */
   async pdf(): Promise<Buffer> {
-    const result = await pdfViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const result = await pdfViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     return result.buffer;
   }
 
@@ -907,7 +918,7 @@ export class CrawlPage {
   }> {
     return screenshotWithLabelsViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       refs,
       maxLabels: opts?.maxLabels,
       type: opts?.type,
@@ -925,7 +936,7 @@ export class CrawlPage {
   async traceStart(opts?: TraceStartOptions): Promise<void> {
     return traceStartViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       screenshots: opts?.screenshots,
       snapshots: opts?.snapshots,
       sources: opts?.sources,
@@ -941,7 +952,7 @@ export class CrawlPage {
   async traceStop(path: string, opts?: { allowedOutputRoots?: string[] }): Promise<void> {
     return traceStopViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       path,
       allowedOutputRoots: opts?.allowedOutputRoots,
     });
@@ -963,7 +974,7 @@ export class CrawlPage {
   async responseBody(url: string, opts?: { timeoutMs?: number; maxChars?: number }): Promise<ResponseBodyResult> {
     return responseBodyViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       url,
       timeoutMs: opts?.timeoutMs,
       maxChars: opts?.maxChars,
@@ -995,7 +1006,7 @@ export class CrawlPage {
   ): Promise<RequestResult> {
     return waitForRequestViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       url,
       method: opts?.method,
       timeoutMs: opts?.timeoutMs,
@@ -1014,7 +1025,7 @@ export class CrawlPage {
   async consoleLogs(opts?: { level?: string; clear?: boolean }): Promise<ConsoleMessage[]> {
     return getConsoleMessagesViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       level: opts?.level,
       clear: opts?.clear,
     });
@@ -1029,7 +1040,7 @@ export class CrawlPage {
   async pageErrors(opts?: { clear?: boolean }): Promise<PageError[]> {
     const result = await getPageErrorsViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       clear: opts?.clear,
     });
     return result.errors;
@@ -1051,7 +1062,7 @@ export class CrawlPage {
   async networkRequests(opts?: { filter?: string; clear?: boolean }): Promise<NetworkRequest[]> {
     const result = await getNetworkRequestsViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       filter: opts?.filter,
       clear: opts?.clear,
     });
@@ -1069,7 +1080,7 @@ export class CrawlPage {
   async resize(width: number, height: number): Promise<void> {
     return resizeViewportViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       width,
       height,
     });
@@ -1083,7 +1094,7 @@ export class CrawlPage {
    * @returns Array of cookie objects
    */
   async cookies(): Promise<Awaited<ReturnType<BrowserContext['cookies']>>> {
-    const result = await cookiesGetViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const result = await cookiesGetViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     return result.cookies;
   }
 
@@ -1102,12 +1113,12 @@ export class CrawlPage {
    * ```
    */
   async setCookie(cookie: CookieData): Promise<void> {
-    return cookiesSetViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this.targetId, cookie });
+    return cookiesSetViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this._targetId, cookie });
   }
 
   /** Clear all cookies in the browser context. */
   async clearCookies(): Promise<void> {
-    return cookiesClearViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    return cookiesClearViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this._targetId });
   }
 
   /**
@@ -1120,7 +1131,7 @@ export class CrawlPage {
   async storageGet(kind: StorageKind, key?: string): Promise<Record<string, string>> {
     const result = await storageGetViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       kind,
       key,
     });
@@ -1137,7 +1148,7 @@ export class CrawlPage {
   async storageSet(kind: StorageKind, key: string, value: string): Promise<void> {
     return storageSetViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       kind,
       key,
       value,
@@ -1152,7 +1163,7 @@ export class CrawlPage {
   async storageClear(kind: StorageKind): Promise<void> {
     return storageClearViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       kind,
     });
   }
@@ -1180,7 +1191,7 @@ export class CrawlPage {
   ): Promise<DownloadResult> {
     return downloadViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       ref,
       path,
       timeoutMs: opts?.timeoutMs,
@@ -1203,7 +1214,7 @@ export class CrawlPage {
   }): Promise<DownloadResult> {
     return waitForDownloadViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       path: opts?.path,
       timeoutMs: opts?.timeoutMs,
       allowedOutputRoots: opts?.allowedOutputRoots,
@@ -1220,7 +1231,7 @@ export class CrawlPage {
   async setOffline(offline: boolean): Promise<void> {
     return setOfflineViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       offline,
     });
   }
@@ -1238,7 +1249,7 @@ export class CrawlPage {
   async setExtraHeaders(headers: Record<string, string>): Promise<void> {
     return setExtraHTTPHeadersViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       headers,
     });
   }
@@ -1251,7 +1262,7 @@ export class CrawlPage {
   async setHttpCredentials(opts: HttpCredentials): Promise<void> {
     return setHttpCredentialsViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       username: opts.username,
       password: opts.password,
       clear: opts.clear,
@@ -1272,7 +1283,7 @@ export class CrawlPage {
   async setGeolocation(opts: GeolocationOptions): Promise<void> {
     return setGeolocationViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       latitude: opts.latitude,
       longitude: opts.longitude,
       accuracy: opts.accuracy,
@@ -1294,7 +1305,7 @@ export class CrawlPage {
   async emulateMedia(opts: { colorScheme: ColorScheme }): Promise<void> {
     return emulateMediaViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       colorScheme: opts.colorScheme,
     });
   }
@@ -1307,7 +1318,7 @@ export class CrawlPage {
   async setLocale(locale: string): Promise<void> {
     return setLocaleViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       locale,
     });
   }
@@ -1320,7 +1331,7 @@ export class CrawlPage {
   async setTimezone(timezoneId: string): Promise<void> {
     return setTimezoneViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       timezoneId,
     });
   }
@@ -1338,7 +1349,7 @@ export class CrawlPage {
   async setDevice(name: string): Promise<void> {
     return setDeviceViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       name,
     });
   }
@@ -1361,7 +1372,7 @@ export class CrawlPage {
    * ```
    */
   async detectChallenge(): Promise<ChallengeInfo | null> {
-    return detectChallengeViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    return detectChallengeViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this._targetId });
   }
 
   /**
@@ -1387,7 +1398,7 @@ export class CrawlPage {
   async waitForChallenge(opts?: { timeoutMs?: number; pollMs?: number }): Promise<ChallengeWaitResult> {
     return waitForChallengeViaPlaywright({
       cdpUrl: this.cdpUrl,
-      targetId: this.targetId,
+      targetId: this._targetId,
       timeoutMs: opts?.timeoutMs,
       pollMs: opts?.pollMs,
     });
@@ -1427,7 +1438,7 @@ export class CrawlPage {
   async isAuthenticated(rules: AuthCheckRule[]): Promise<AuthCheckResult> {
     if (!rules.length) return { authenticated: true, checks: [] };
 
-    const page = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const page = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     const checks: AuthCheckDetail[] = [];
 
     for (const rule of rules) {
@@ -1470,7 +1481,7 @@ export class CrawlPage {
         try {
           const raw = await evaluateViaPlaywright({
             cdpUrl: this.cdpUrl,
-            targetId: this.targetId,
+            targetId: this._targetId,
             fn: '() => { const b = document.body; return b ? b.innerText : ""; }',
           });
           bodyText = typeof raw === 'string' ? raw : null;
@@ -1511,7 +1522,7 @@ export class CrawlPage {
         try {
           const result: unknown = await evaluateViaPlaywright({
             cdpUrl: this.cdpUrl,
-            targetId: this.targetId,
+            targetId: this._targetId,
             fn: rule.fn,
           });
           const passed = result !== null && result !== undefined && result !== false && result !== 0 && result !== '';
@@ -1563,7 +1574,7 @@ export class CrawlPage {
    * ```
    */
   async playwrightPage(): Promise<Page> {
-    return getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    return getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
   }
 
   /**
@@ -1587,7 +1598,7 @@ export class CrawlPage {
    * ```
    */
   async locator(selector: string): Promise<Locator> {
-    const pwPage = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this.targetId });
+    const pwPage = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     return pwPage.locator(selector);
   }
 }
@@ -1661,25 +1672,32 @@ export class BrowserClaw {
   static async launch(opts: LaunchOptions = {}): Promise<BrowserClaw> {
     const startedAt = new Date().toISOString();
     const chrome = await launchChrome(opts);
-    const cdpUrl = `http://127.0.0.1:${String(chrome.cdpPort)}`;
-    /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
-    const ssrfPolicy =
-      opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
-    /* eslint-enable @typescript-eslint/no-deprecated */
-    const telemetry: RunTelemetry = {
-      launchMs: chrome.launchMs,
-      timestamps: { startedAt, launchedAt: new Date().toISOString() },
-    };
-    const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo);
-    if (opts.url !== undefined && opts.url !== '') {
-      // connectBrowser is called lazily inside currentPage → connectBrowser; connectMs is recorded there
-      const page = await browser.currentPage();
-      const navT0 = Date.now();
-      await page.goto(opts.url);
-      telemetry.navMs = Date.now() - navT0;
-      telemetry.timestamps.navigatedAt = new Date().toISOString();
+    try {
+      const cdpUrl = `http://127.0.0.1:${String(chrome.cdpPort)}`;
+      /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
+      const ssrfPolicy =
+        opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+      /* eslint-enable @typescript-eslint/no-deprecated */
+      const telemetry: RunTelemetry = {
+        launchMs: chrome.launchMs,
+        timestamps: { startedAt, launchedAt: new Date().toISOString() },
+      };
+      const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo);
+      if (opts.url !== undefined && opts.url !== '') {
+        // connectBrowser is called lazily inside currentPage → connectBrowser; connectMs is recorded there
+        const page = await browser.currentPage();
+        const navT0 = Date.now();
+        await page.goto(opts.url);
+        telemetry.navMs = Date.now() - navT0;
+        telemetry.timestamps.navigatedAt = new Date().toISOString();
+      }
+      return browser;
+    } catch (err) {
+      await stopChrome(chrome).catch(() => {
+        /* noop — best-effort cleanup */
+      });
+      throw err;
     }
-    return browser;
   }
 
   /**
@@ -1849,7 +1867,7 @@ export class BrowserClaw {
     if (exitReason !== undefined) this._telemetry.exitReason = exitReason;
     try {
       clearRecordingContext(this.cdpUrl);
-      await disconnectBrowser();
+      await closePlaywrightBrowserConnection({ cdpUrl: this.cdpUrl });
       if (this.chrome) {
         await stopChrome(this.chrome);
         this.chrome = null;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1441,6 +1441,24 @@ export class CrawlPage {
     const page = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
     const checks: AuthCheckDetail[] = [];
 
+    // Pre-fetch body text once if any rule needs it, to avoid redundant evaluations
+    const needsBodyText = rules.some((r) => r.text !== undefined || r.textGone !== undefined);
+    let bodyText: string | null = null;
+    if (needsBodyText) {
+      try {
+        const raw = await evaluateViaPlaywright({
+          cdpUrl: this.cdpUrl,
+          targetId: this._targetId,
+          fn: '() => { const b = document.body; return b ? b.innerText : ""; }',
+        });
+        bodyText = typeof raw === 'string' ? raw : null;
+      } catch (err) {
+        console.warn(
+          `[browserclaw] isAuthenticated body text fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     for (const rule of rules) {
       if (rule.url !== undefined) {
         const currentUrl = page.url();
@@ -1475,22 +1493,7 @@ export class CrawlPage {
         }
       }
 
-      // Fetch body text once if either text or textGone rule is present
       if (rule.text !== undefined || rule.textGone !== undefined) {
-        let bodyText: string | null = null;
-        try {
-          const raw = await evaluateViaPlaywright({
-            cdpUrl: this.cdpUrl,
-            targetId: this._targetId,
-            fn: '() => { const b = document.body; return b ? b.innerText : ""; }',
-          });
-          bodyText = typeof raw === 'string' ? raw : null;
-        } catch (err) {
-          console.warn(
-            `[browserclaw] isAuthenticated body text fetch failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
         if (rule.text !== undefined) {
           if (bodyText === null) {
             checks.push({ rule: 'text', passed: false, detail: `"${rule.text}" error during evaluation` });

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -112,8 +112,8 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
           el.remove();
         });
       })
-      .catch(() => {
-        /* intentional no-op */
+      .catch((err: unknown) => {
+        console.warn(`[browserclaw] label overlay cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
       });
   }
 }

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -1,4 +1,4 @@
-import { getPageForTargetId, ensurePageState, restoreRoleRefsForTarget, refLocator } from '../connection.js';
+import { getPageForTargetId, ensurePageState, refLocator } from '../connection.js';
 
 export async function takeScreenshotViaPlaywright(opts: {
   cdpUrl: string;
@@ -10,7 +10,6 @@ export async function takeScreenshotViaPlaywright(opts: {
 }): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   const type = opts.type ?? 'png';
 
   if (opts.ref !== undefined && opts.ref !== '') {
@@ -37,7 +36,6 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
 }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
 
   const maxLabels =
     typeof opts.maxLabels === 'number' && Number.isFinite(opts.maxLabels)

--- a/src/capture/trace.ts
+++ b/src/capture/trace.ts
@@ -43,15 +43,15 @@ export async function traceStopViaPlaywright(opts: {
     throw new Error('No active trace. Start a trace before stopping it.');
   }
 
-  try {
-    await writeViaSiblingTempPath({
-      rootDir: dirname(opts.path),
-      targetPath: opts.path,
-      writeTemp: async (tempPath) => {
-        await context.tracing.stop({ path: tempPath });
-      },
-    });
-  } finally {
-    ctxState.traceActive = false;
-  }
+  // Mark traceActive = false BEFORE stopping, since context.tracing.stop() consumes the
+  // trace regardless of whether the file write/rename succeeds. A failed write should not
+  // leave traceActive = true (which would block starting a new trace).
+  ctxState.traceActive = false;
+  await writeViaSiblingTempPath({
+    rootDir: dirname(opts.path),
+    targetPath: opts.path,
+    writeTemp: async (tempPath) => {
+      await context.tracing.stop({ path: tempPath });
+    },
+  });
 }

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -436,8 +436,11 @@ async function ensurePortAvailable(port: number, retries = 2): Promise<void> {
         const tester = net
           .createServer()
           .once('error', (err: NodeJS.ErrnoException) => {
-            if (err.code === 'EADDRINUSE') reject(new Error(`Port ${String(port)} is already in use`));
-            else reject(err);
+            // Close the server to release its handle on non-EADDRINUSE errors
+            tester.close(() => {
+              if (err.code === 'EADDRINUSE') reject(new Error(`Port ${String(port)} is already in use`));
+              else reject(err);
+            });
           })
           .once('listening', () => {
             tester.close(() => {
@@ -864,9 +867,12 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   proc.stderr.on('data', onStderr);
 
   const readyDeadline = Date.now() + 15000;
+  let pollDelay = 200;
   while (Date.now() < readyDeadline) {
     if (await isChromeCdpReady(cdpUrl, 500)) break;
-    await new Promise((r) => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, pollDelay));
+    // Back off polling to reduce CPU churn on slow launches
+    pollDelay = Math.min(pollDelay + 100, 1000);
   }
 
   if (!(await isChromeCdpReady(cdpUrl, 500))) {
@@ -878,6 +884,11 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
         : '';
     try {
       proc.kill('SIGKILL');
+    } catch {}
+    // Clean up userDataDir lock files on launch failure so subsequent retries don't stall
+    try {
+      const lockFile = path.join(userDataDir, 'SingletonLock');
+      if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile);
     } catch {}
     throw new Error(`Failed to start Chrome CDP on port ${String(cdpPort)}.${sandboxHint}${stderrHint}`);
   }

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -1,10 +1,32 @@
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
 import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome } from './types.js';
+
+// ── Process Tree Kill ──
+
+/**
+ * Kill a process and its children. Uses process group kill on Unix when the
+ * process was spawned with `detached: true`, falls back to direct kill.
+ */
+function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
+  if (process.platform !== 'win32' && proc.pid !== undefined) {
+    try {
+      process.kill(-proc.pid, signal);
+      return;
+    } catch {
+      // Process group kill failed — fall back to direct kill
+    }
+  }
+  try {
+    proc.kill(signal);
+  } catch {
+    /* process may already be dead */
+  }
+}
 
 // ── Executable Detection ──
 
@@ -407,21 +429,32 @@ export function resolveBrowserExecutable(opts?: { executablePath?: string }): Ch
 
 // ── Port Check ──
 
-async function ensurePortAvailable(port: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const tester = net
-      .createServer()
-      .once('error', (err: NodeJS.ErrnoException) => {
-        if (err.code === 'EADDRINUSE') reject(new Error(`Port ${String(port)} is already in use`));
-        else reject(err);
-      })
-      .once('listening', () => {
-        tester.close(() => {
-          resolve();
-        });
-      })
-      .listen(port);
-  });
+async function ensurePortAvailable(port: number, retries = 2): Promise<void> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tester = net
+          .createServer()
+          .once('error', (err: NodeJS.ErrnoException) => {
+            if (err.code === 'EADDRINUSE') reject(new Error(`Port ${String(port)} is already in use`));
+            else reject(err);
+          })
+          .once('listening', () => {
+            tester.close(() => {
+              resolve();
+            });
+          })
+          .listen(port);
+      });
+      return;
+    } catch (err) {
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 100));
+        continue;
+      }
+      throw err;
+    }
+  }
 }
 
 // ── Profile Decoration ──
@@ -750,7 +783,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   const userDataDir = opts.userDataDir ?? resolveUserDataDir(profileName);
   fs.mkdirSync(userDataDir, { recursive: true });
 
-  const spawnChrome = () => {
+  const spawnChrome = (spawnOpts?: { detached?: boolean }) => {
     const args = [
       `--remote-debugging-port=${String(cdpPort)}`,
       '--remote-debugging-address=127.0.0.1',
@@ -784,6 +817,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     return spawn(exe.path, args, {
       stdio: 'pipe',
       env: { ...process.env, HOME: os.homedir() },
+      ...spawnOpts,
     });
   };
 
@@ -793,24 +827,21 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 
   // Bootstrap run if profile doesn't exist yet
   if (!fileExists(localStatePath) || !fileExists(preferencesPath)) {
-    const bootstrap = spawnChrome();
+    const useDetached = process.platform !== 'win32';
+    const bootstrap = spawnChrome(useDetached ? { detached: true } : undefined);
     const deadline = Date.now() + 10000;
     while (Date.now() < deadline) {
       if (fileExists(localStatePath) && fileExists(preferencesPath)) break;
       await new Promise((r) => setTimeout(r, 100));
     }
-    try {
-      bootstrap.kill('SIGTERM');
-    } catch {}
+    killProcessTree(bootstrap, 'SIGTERM');
     const exitDeadline = Date.now() + 5000;
     while (Date.now() < exitDeadline) {
       if (bootstrap.exitCode != null) break;
       await new Promise((r) => setTimeout(r, 50));
     }
     if (bootstrap.exitCode == null) {
-      try {
-        bootstrap.kill('SIGKILL');
-      } catch {}
+      killProcessTree(bootstrap, 'SIGKILL');
     }
   }
 
@@ -869,20 +900,12 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Promise<void> {
   const proc = running.proc;
   if (proc.exitCode !== null) return;
-  try {
-    proc.kill('SIGTERM');
-  } catch {
-    /* process may already be dead */
-  }
+  killProcessTree(proc, 'SIGTERM');
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     // exitCode changes asynchronously after SIGTERM; re-read from proc
     if ((proc as { exitCode: number | null }).exitCode !== null) return;
     await new Promise((r) => setTimeout(r, 100));
   }
-  try {
-    proc.kill('SIGKILL');
-  } catch {
-    /* process may already be dead */
-  }
+  killProcessTree(proc, 'SIGKILL');
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -12,7 +12,7 @@ import {
   hasProxyEnvConfigured,
 } from './chrome-launcher.js';
 import { ensurePageState, observeBrowser, setDialogHandlerOnPage } from './page-utils.js';
-import { clearRoleRefsForCdpUrl, normalizeCdpUrl, restoreRoleRefsForTarget } from './ref-resolver.js';
+import { clearRoleRefsForCdpUrl, normalizeCdpUrl } from './ref-resolver.js';
 import type { DialogHandler } from './types.js';
 
 // Re-export everything from sub-modules so existing `import … from './connection.js'`
@@ -484,7 +484,9 @@ export async function disconnectBrowser(): Promise<void> {
 export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string }): Promise<void> {
   if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
     return withConnectionLock(async () => {
-      const normalized = normalizeCdpUrl(opts.cdpUrl!);
+      const cdpUrl = opts.cdpUrl
+      if (cdpUrl === undefined || cdpUrl === '') return;
+      const normalized = normalizeCdpUrl(cdpUrl);
       clearBlockedTargetsForCdpUrl(normalized);
       clearBlockedPageRefsForCdpUrl(normalized);
       const cur = cachedByCdpUrl.get(normalized);
@@ -721,7 +723,6 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
     }),
   );
 
-  const resolvedViaCdp = results.some(({ tid }) => tid !== null);
   const matched = results.find(({ tid }) => tid !== null && tid !== '' && tid === targetId);
   if (matched) return matched.page;
 
@@ -731,9 +732,6 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
     } catch {}
   }
 
-  // Last resort: if CDP sessions failed for all pages and there's only one, return it.
-  // Only use this fallback when no specific targetId was requested via cdpUrl lookup.
-  if (!resolvedViaCdp && pages.length === 1 && cdpUrl !== undefined) return pages[0] ?? null;
   return null;
 }
 
@@ -781,12 +779,6 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
   if (opts.targetId === undefined || opts.targetId === '') return first;
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
-    if (pages.length === 1) {
-      console.warn(
-        `[browserclaw] targetId "${opts.targetId}" not found, returning only available page (url: ${first.url()})`,
-      );
-      return first;
-    }
     throw new BrowserTabNotFoundError(
       `Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`,
     );
@@ -806,11 +798,10 @@ export async function resolvePageByTargetIdOrThrow(opts: { cdpUrl: string; targe
 }
 
 /**
- * Get a page for a target, ensuring page state is initialized and role refs are restored.
+ * Get a page for a target, ensuring page state is initialized.
  */
 export async function getRestoredPageForTarget(opts: { cdpUrl: string; targetId?: string }): Promise<Page> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   return page;
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -33,7 +33,6 @@ export {
 export {
   rememberRoleRefsForTarget,
   storeRoleRefsForTarget,
-  restoreRoleRefsForTarget,
   clearRoleRefsForCdpUrl,
   parseRoleRef,
   requireRef,
@@ -484,7 +483,7 @@ export async function disconnectBrowser(): Promise<void> {
 export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string }): Promise<void> {
   if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
     return withConnectionLock(async () => {
-      const cdpUrl = opts.cdpUrl
+      const cdpUrl = opts.cdpUrl;
       if (cdpUrl === undefined || cdpUrl === '') return;
       const normalized = normalizeCdpUrl(cdpUrl);
       clearBlockedTargetsForCdpUrl(normalized);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -155,14 +155,19 @@ function isLoopbackCdpUrl(url: string): boolean {
  * one caller's restore doesn't clobber another caller's mutation.
  */
 let envMutexPromise: Promise<void> = Promise.resolve();
+let envMutexDepth = 0;
 
 /**
  * Scoped NO_PROXY bypass for loopback CDP URLs.
  * Serializes env mutations so concurrent connects don't interleave save/restore.
  * Only restores if the value hasn't been changed by someone else.
+ * Reentrant: nested calls skip the env mutation if already inside the mutex.
  */
 export async function withNoProxyForCdpUrl<T>(url: string, fn: () => Promise<T>): Promise<T> {
   if (!isLoopbackCdpUrl(url) || !hasProxyEnvConfigured()) return fn();
+
+  // Reentrancy guard: if already inside this mutex, just run fn() directly
+  if (envMutexDepth > 0) return fn();
 
   const prev = envMutexPromise;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -186,9 +191,11 @@ export async function withNoProxyForCdpUrl<T>(url: string, fn: () => Promise<T>)
   const applied = current ? `${current},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
   process.env.NO_PROXY = applied;
   process.env.no_proxy = applied;
+  envMutexDepth += 1;
   try {
     return await fn();
   } finally {
+    envMutexDepth -= 1;
     if (process.env.NO_PROXY === applied) {
       if (savedNoProxy !== undefined) process.env.NO_PROXY = savedNoProxy;
       else delete process.env.NO_PROXY;
@@ -425,7 +432,11 @@ export async function connectBrowser(cdpUrl: string, authToken?: string): Promis
           return connected;
         } catch (err) {
           lastErr = err;
-          if ((err instanceof Error ? err.message : String(err)).includes('rate limit')) break;
+          if ((err instanceof Error ? err.message : String(err)).includes('rate limit')) {
+            // Rate-limit: wait longer before retrying instead of breaking immediately
+            await new Promise((r) => setTimeout(r, 1000 + attempt * 1000));
+            continue;
+          }
           await new Promise((r) => setTimeout(r, 250 + attempt * 250));
         }
       }
@@ -720,8 +731,9 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
     } catch {}
   }
 
-  // Last resort: if CDP sessions failed for all pages and there's only one, return it
-  if (!resolvedViaCdp && pages.length === 1) return pages[0] ?? null;
+  // Last resort: if CDP sessions failed for all pages and there's only one, return it.
+  // Only use this fallback when no specific targetId was requested via cdpUrl lookup.
+  if (!resolvedViaCdp && pages.length === 1 && cdpUrl !== undefined) return pages[0] ?? null;
   return null;
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -92,14 +92,16 @@ function appendCdpPath(cdpUrl: string, cdpPath: string): string {
  */
 export async function withPlaywrightPageCdpSession<T>(page: Page, fn: (session: CDPSession) => Promise<T>): Promise<T> {
   const CDP_SESSION_TIMEOUT_MS = 10_000;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const session = await Promise.race([
     page.context().newCDPSession(page),
     new Promise<never>((_, reject) => {
-      setTimeout(() => {
+      timer = setTimeout(() => {
         reject(new Error('newCDPSession timed out after 10s'));
       }, CDP_SESSION_TIMEOUT_MS);
     }),
   ]);
+  clearTimeout(timer);
   try {
     return await fn(session);
   } finally {
@@ -253,6 +255,27 @@ interface CachedConnection {
 const cachedByCdpUrl = new Map<string, CachedConnection>();
 const connectingByCdpUrl = new Map<string, Promise<CachedConnection>>();
 
+// ── Connection Mutex ──
+// Serializes connect/disconnect operations to prevent races where a disconnect
+// clears a connection that a concurrent connect just established.
+
+let connectionMutex: Promise<void> = Promise.resolve();
+
+async function withConnectionLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = connectionMutex;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let release: () => void = () => {};
+  connectionMutex = new Promise<void>((r) => {
+    release = r;
+  });
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
 // ── Blocked Target Tracking ──
 
 export class BlockedBrowserTargetError extends Error {
@@ -262,6 +285,7 @@ export class BlockedBrowserTargetError extends Error {
   }
 }
 
+const MAX_BLOCKED_TARGETS = 200;
 const blockedTargetsByCdpUrl = new Set<string>();
 const blockedPageRefsByCdpUrl = new Map<string, WeakSet<Page>>();
 
@@ -279,6 +303,11 @@ export function markTargetBlocked(cdpUrl: string, targetId?: string): void {
   const normalized = targetId?.trim() ?? '';
   if (normalized === '') return;
   blockedTargetsByCdpUrl.add(blockedTargetKey(cdpUrl, normalized));
+  // Evict oldest entries if the set grows too large
+  if (blockedTargetsByCdpUrl.size > MAX_BLOCKED_TARGETS) {
+    const first = blockedTargetsByCdpUrl.values().next();
+    if (first.done !== true) blockedTargetsByCdpUrl.delete(first.value);
+  }
 }
 
 export function clearBlockedTarget(cdpUrl: string, targetId?: string): void {
@@ -355,72 +384,87 @@ export async function setDialogHandler(opts: {
 
 export async function connectBrowser(cdpUrl: string, authToken?: string): Promise<CachedConnection> {
   const normalized = normalizeCdpUrl(cdpUrl);
+  // Lock-free fast path: return cached connection
   const existing_cached = cachedByCdpUrl.get(normalized);
   if (existing_cached) return existing_cached;
 
   const existing = connectingByCdpUrl.get(normalized);
   if (existing) return await existing;
 
-  const connectWithRetry = async () => {
-    let lastErr: unknown;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      try {
-        const timeout = 5000 + attempt * 2000;
-        const endpoint = (await getChromeWebSocketUrl(normalized, timeout, authToken).catch(() => null)) ?? normalized;
-        const headers: Record<string, string> = getHeadersWithAuth(endpoint);
-        if (authToken !== undefined && authToken !== '' && !headers.Authorization)
-          headers.Authorization = `Bearer ${authToken}`;
-        const browser = await withNoProxyForCdpUrl(endpoint, () =>
-          chromium.connectOverCDP(endpoint, { timeout, headers }),
-        );
-        const onDisconnected = () => {
-          if (cachedByCdpUrl.get(normalized)?.browser === browser) {
-            cachedByCdpUrl.delete(normalized);
-            clearRoleRefsForCdpUrl(normalized);
-          }
-        };
-        const connected: CachedConnection = { browser, cdpUrl: normalized, onDisconnected };
-        cachedByCdpUrl.set(normalized, connected);
-        observeBrowser(browser);
-        browser.on('disconnected', onDisconnected);
-        return connected;
-      } catch (err) {
-        lastErr = err;
-        if ((err instanceof Error ? err.message : String(err)).includes('rate limit')) break;
-        await new Promise((r) => setTimeout(r, 250 + attempt * 250));
-      }
-    }
-    throw lastErr instanceof Error ? lastErr : new Error('CDP connect failed');
-  };
+  // Slow path: acquire connection lock before creating a new connection
+  return withConnectionLock(async () => {
+    // Re-check after acquiring lock
+    const rechecked = cachedByCdpUrl.get(normalized);
+    if (rechecked) return rechecked;
+    const recheckPending = connectingByCdpUrl.get(normalized);
+    if (recheckPending) return await recheckPending;
 
-  const promise = connectWithRetry().finally(() => {
-    connectingByCdpUrl.delete(normalized);
+    const connectWithRetry = async () => {
+      let lastErr: unknown;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const timeout = 5000 + attempt * 2000;
+          const endpoint =
+            (await getChromeWebSocketUrl(normalized, timeout, authToken).catch(() => null)) ?? normalized;
+          const headers: Record<string, string> = getHeadersWithAuth(endpoint);
+          if (authToken !== undefined && authToken !== '' && !headers.Authorization)
+            headers.Authorization = `Bearer ${authToken}`;
+          const browser = await withNoProxyForCdpUrl(endpoint, () =>
+            chromium.connectOverCDP(endpoint, { timeout, headers }),
+          );
+          const onDisconnected = () => {
+            if (cachedByCdpUrl.get(normalized)?.browser === browser) {
+              cachedByCdpUrl.delete(normalized);
+              clearRoleRefsForCdpUrl(normalized);
+            }
+          };
+          const connected: CachedConnection = { browser, cdpUrl: normalized, onDisconnected };
+          cachedByCdpUrl.set(normalized, connected);
+          await observeBrowser(browser);
+          browser.on('disconnected', onDisconnected);
+          return connected;
+        } catch (err) {
+          lastErr = err;
+          if ((err instanceof Error ? err.message : String(err)).includes('rate limit')) break;
+          await new Promise((r) => setTimeout(r, 250 + attempt * 250));
+        }
+      }
+      throw lastErr instanceof Error ? lastErr : new Error('CDP connect failed');
+    };
+
+    const promise = connectWithRetry().finally(() => {
+      connectingByCdpUrl.delete(normalized);
+    });
+    connectingByCdpUrl.set(normalized, promise);
+    return await promise;
   });
-  connectingByCdpUrl.set(normalized, promise);
-  return await promise;
 }
 
 export async function disconnectBrowser(): Promise<void> {
-  if (connectingByCdpUrl.size) {
-    for (const p of connectingByCdpUrl.values()) {
-      try {
-        await p;
-      } catch (err) {
-        console.warn(
-          `[browserclaw] disconnectBrowser: pending connect failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+  return withConnectionLock(async () => {
+    if (connectingByCdpUrl.size) {
+      for (const p of connectingByCdpUrl.values()) {
+        try {
+          await p;
+        } catch (err) {
+          console.warn(
+            `[browserclaw] disconnectBrowser: pending connect failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
     }
-  }
-  for (const cur of cachedByCdpUrl.values()) {
-    clearRoleRefsForCdpUrl(cur.cdpUrl);
-    if (cur.onDisconnected && typeof cur.browser.off === 'function')
-      cur.browser.off('disconnected', cur.onDisconnected);
-    await cur.browser.close().catch(() => {
-      /* noop */
-    });
-  }
-  cachedByCdpUrl.clear();
+    for (const cur of cachedByCdpUrl.values()) {
+      clearRoleRefsForCdpUrl(cur.cdpUrl);
+      if (cur.onDisconnected && typeof cur.browser.off === 'function')
+        cur.browser.off('disconnected', cur.onDisconnected);
+      await cur.browser.close().catch(() => {
+        /* noop */
+      });
+    }
+    cachedByCdpUrl.clear();
+    clearBlockedTargetsForCdpUrl();
+    clearBlockedPageRefsForCdpUrl();
+  });
 }
 
 /**
@@ -428,21 +472,21 @@ export async function disconnectBrowser(): Promise<void> {
  */
 export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string }): Promise<void> {
   if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
-    const normalized = normalizeCdpUrl(opts.cdpUrl);
-    clearBlockedTargetsForCdpUrl(normalized);
-    clearBlockedPageRefsForCdpUrl(normalized);
-    const cur = cachedByCdpUrl.get(normalized);
-    cachedByCdpUrl.delete(normalized);
-    connectingByCdpUrl.delete(normalized);
-    if (!cur) return;
-    if (cur.onDisconnected && typeof cur.browser.off === 'function')
-      cur.browser.off('disconnected', cur.onDisconnected);
-    await cur.browser.close().catch(() => {
-      /* noop */
+    return withConnectionLock(async () => {
+      const normalized = normalizeCdpUrl(opts.cdpUrl!);
+      clearBlockedTargetsForCdpUrl(normalized);
+      clearBlockedPageRefsForCdpUrl(normalized);
+      const cur = cachedByCdpUrl.get(normalized);
+      cachedByCdpUrl.delete(normalized);
+      connectingByCdpUrl.delete(normalized);
+      if (!cur) return;
+      if (cur.onDisconnected && typeof cur.browser.off === 'function')
+        cur.browser.off('disconnected', cur.onDisconnected);
+      await cur.browser.close().catch(() => {
+        /* noop */
+      });
     });
   } else {
-    clearBlockedTargetsForCdpUrl();
-    clearBlockedPageRefsForCdpUrl();
     await disconnectBrowser();
   }
 }
@@ -583,10 +627,17 @@ export async function forceDisconnectPlaywrightConnection(opts: {
     });
   }
 
-  cur.browser.close().catch(() => {
+  await cur.browser.close().catch(() => {
     /* noop */
   });
 }
+
+/**
+ * Terminate JavaScript execution on a specific CDP target without tearing down
+ * the shared Playwright connection. Use this to abort a stuck evaluate on one
+ * tab without affecting other tabs.
+ */
+export { tryTerminateExecutionViaCdp };
 
 /** @deprecated Use `forceDisconnectPlaywrightConnection` instead. */
 export const forceDisconnectPlaywrightForTarget = forceDisconnectPlaywrightConnection;
@@ -612,18 +663,13 @@ const pageTargetIdCache = new WeakMap<Page, string>();
 export async function pageTargetId(page: Page): Promise<string | null> {
   const cached = pageTargetIdCache.get(page);
   if (cached !== undefined) return cached;
-  const session = await page.context().newCDPSession(page);
-  try {
+  return withPlaywrightPageCdpSession(page, async (session) => {
     const info = await session.send('Target.getTargetInfo');
     const targetInfo = (info as { targetInfo?: { targetId?: string } }).targetInfo;
     const id = (targetInfo?.targetId ?? '').trim() || null;
     if (id !== null) pageTargetIdCache.set(page, id);
     return id;
-  } finally {
-    await session.detach().catch(() => {
-      /* noop */
-    });
-  }
+  });
 }
 
 function matchPageByTargetList(pages: Page[], targets: CdpTarget[], targetId: string): Page | null {
@@ -723,7 +769,12 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
   if (opts.targetId === undefined || opts.targetId === '') return first;
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
-    if (pages.length === 1) return first;
+    if (pages.length === 1) {
+      console.warn(
+        `[browserclaw] targetId "${opts.targetId}" not found, returning only available page (url: ${first.url()})`,
+      );
+      return first;
+    }
     throw new BrowserTabNotFoundError(
       `Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`,
     );

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -204,35 +204,45 @@ export function setDialogHandlerOnPage(page: Page, handler?: DialogHandler): voi
 
 // ── Stealth ──
 
-function applyStealthToPage(page: Page): void {
-  page.evaluate(STEALTH_SCRIPT).catch((e: unknown) => {
+async function applyStealthToPage(page: Page): Promise<void> {
+  try {
+    await page.evaluate(STEALTH_SCRIPT);
+  } catch (e: unknown) {
     if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
       console.warn('[browserclaw] stealth evaluate failed:', e instanceof Error ? e.message : String(e));
-  });
+  }
 }
 
-export function observeContext(context: BrowserContext): void {
+export async function observeContext(context: BrowserContext): Promise<void> {
   if (observedContexts.has(context)) return;
   observedContexts.add(context);
   ensureContextState(context);
 
-  context.addInitScript(STEALTH_SCRIPT).catch((e: unknown) => {
+  try {
+    await context.addInitScript(STEALTH_SCRIPT);
+  } catch (e: unknown) {
     if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
       console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
-  });
+  }
 
   for (const page of context.pages()) {
     ensurePageState(page);
-    applyStealthToPage(page);
+    await applyStealthToPage(page);
   }
-  context.on('page', (page) => {
+  const onPage = (page: Page) => {
     ensurePageState(page);
-    applyStealthToPage(page);
+    applyStealthToPage(page).catch(() => {
+      /* noop — best-effort stealth for new pages */
+    });
+  };
+  context.on('page', onPage);
+  context.once('close', () => {
+    context.off('page', onPage);
   });
 }
 
-export function observeBrowser(browser: Browser): void {
-  for (const context of browser.contexts()) observeContext(context);
+export async function observeBrowser(browser: Browser): Promise<void> {
+  for (const context of browser.contexts()) await observeContext(context);
 }
 
 // ── Error Helpers ──

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -82,7 +82,8 @@ export function ensurePageState(page: Page): PageState {
         timestamp: new Date().toISOString(),
         location: msg.location(),
       });
-      if (state.console.length > MAX_CONSOLE_MESSAGES) state.console.shift();
+      // Evict oldest entries in bulk to avoid O(n) shift() on every overflow
+      if (state.console.length > MAX_CONSOLE_MESSAGES + 50) state.console.splice(0, 50);
     });
 
     page.on('pageerror', (err) => {
@@ -92,7 +93,7 @@ export function ensurePageState(page: Page): PageState {
         stack: err.stack !== undefined && err.stack !== '' ? err.stack : undefined,
         timestamp: new Date().toISOString(),
       });
-      if (state.errors.length > MAX_PAGE_ERRORS) state.errors.shift();
+      if (state.errors.length > MAX_PAGE_ERRORS + 20) state.errors.splice(0, 20);
     });
 
     page.on('request', (req) => {
@@ -106,7 +107,7 @@ export function ensurePageState(page: Page): PageState {
         url: req.url(),
         resourceType: req.resourceType(),
       });
-      if (state.requests.length > MAX_NETWORK_REQUESTS) state.requests.shift();
+      if (state.requests.length > MAX_NETWORK_REQUESTS + 50) state.requests.splice(0, 50);
     });
 
     page.on('response', (resp) => {

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -80,7 +80,6 @@ export function storeRoleRefsForTarget(opts: {
   });
 }
 
-
 /**
  * Clear role refs for all targets associated with a CDP URL.
  * Called when a browser disconnects.

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -16,6 +16,8 @@ const roleRefsByTarget = new Map<
     storedAt: number;
   }
 >();
+// FIFO eviction (not LRU) — sufficient because refs are short-lived and frequently
+// overwritten per-target. An LRU would add complexity without meaningful benefit here.
 const MAX_ROLE_REFS_CACHE = 50;
 
 export function normalizeCdpUrl(raw: string): string {

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -5,12 +5,15 @@ import type { RoleRefs } from './types.js';
 
 // ── Ref cache: keyed by "cdpUrl::targetId" ──
 
+const REFS_STALENESS_THRESHOLD_MS = 30_000;
+
 const roleRefsByTarget = new Map<
   string,
   {
     refs: RoleRefs;
     frameSelector?: string;
     mode?: 'role' | 'aria';
+    storedAt: number;
   }
 >();
 const MAX_ROLE_REFS_CACHE = 50;
@@ -42,6 +45,7 @@ export function rememberRoleRefsForTarget(opts: {
     refs: opts.refs,
     ...(opts.frameSelector !== undefined && opts.frameSelector !== '' ? { frameSelector: opts.frameSelector } : {}),
     ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
+    storedAt: Date.now(),
   });
   while (roleRefsByTarget.size > MAX_ROLE_REFS_CACHE) {
     const first = roleRefsByTarget.keys().next();
@@ -62,6 +66,7 @@ export function storeRoleRefsForTarget(opts: {
   state.roleRefs = opts.refs;
   state.roleRefsFrameSelector = opts.frameSelector;
   state.roleRefsMode = opts.mode;
+  state.roleRefsStoredAt = Date.now();
 
   if (opts.targetId === undefined || opts.targetId.trim() === '') return;
   rememberRoleRefsForTarget({
@@ -74,15 +79,9 @@ export function storeRoleRefsForTarget(opts: {
 }
 
 export function restoreRoleRefsForTarget(opts: { cdpUrl: string; targetId?: string; page: Page }): void {
-  const targetId = opts.targetId?.trim() ?? '';
-  if (targetId === '') return;
-  const entry = roleRefsByTarget.get(roleRefsKey(opts.cdpUrl, targetId));
-  if (!entry) return;
-  const state = ensurePageState(opts.page);
-  if (state.roleRefs) return;
-  state.roleRefs = entry.refs;
-  state.roleRefsFrameSelector = entry.frameSelector;
-  state.roleRefsMode = entry.mode;
+  // Intentional no-op: cached refs from a previous connection are stale after
+  // reconnection. Consumers must re-snapshot to get fresh refs. This prevents
+  // acting on outdated element references that no longer match the DOM.
 }
 
 /**
@@ -156,6 +155,16 @@ export function refLocator(page: Page, ref: string) {
 
   if (/^e\d+$/.test(normalized)) {
     const state = getPageState(page);
+
+    // Warn if refs are stale
+    if (state?.roleRefsStoredAt !== undefined) {
+      const ageMs = Date.now() - state.roleRefsStoredAt;
+      if (ageMs > REFS_STALENESS_THRESHOLD_MS) {
+        console.warn(
+          `[browserclaw] refs are ${Math.round(ageMs / 1000)}s old — consider re-snapshotting for fresh refs`,
+        );
+      }
+    }
 
     // Aria mode: use aria-ref locator
     if (state?.roleRefsMode === 'aria') {

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -80,11 +80,6 @@ export function storeRoleRefsForTarget(opts: {
   });
 }
 
-export function restoreRoleRefsForTarget(opts: { cdpUrl: string; targetId?: string; page: Page }): void {
-  // Intentional no-op: cached refs from a previous connection are stale after
-  // reconnection. Consumers must re-snapshot to get fresh refs. This prevents
-  // acting on outdated element references that no longer match the DOM.
-}
 
 /**
  * Clear role refs for all targets associated with a CDP URL.
@@ -163,7 +158,7 @@ export function refLocator(page: Page, ref: string) {
       const ageMs = Date.now() - state.roleRefsStoredAt;
       if (ageMs > REFS_STALENESS_THRESHOLD_MS) {
         console.warn(
-          `[browserclaw] refs are ${Math.round(ageMs / 1000)}s old — consider re-snapshotting for fresh refs`,
+          `[browserclaw] refs are ${String(Math.round(ageMs / 1000))}s old — consider re-snapshotting for fresh refs`,
         );
       }
     }

--- a/src/security.ts
+++ b/src/security.ts
@@ -416,6 +416,30 @@ export function createPinnedLookup(params: {
   }) as typeof dnsLookupCb;
 }
 
+// ── DNS Resolution Cache (short-lived) ──
+
+const DNS_CACHE_TTL_MS = 30_000;
+const MAX_DNS_CACHE_SIZE = 100;
+const dnsCache = new Map<string, { result: PinnedHostname; expiresAt: number }>();
+
+function getCachedDnsResult(hostname: string): PinnedHostname | undefined {
+  const entry = dnsCache.get(hostname);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    dnsCache.delete(hostname);
+    return undefined;
+  }
+  return entry.result;
+}
+
+function cacheDnsResult(hostname: string, result: PinnedHostname): void {
+  dnsCache.set(hostname, { result, expiresAt: Date.now() + DNS_CACHE_TTL_MS });
+  if (dnsCache.size > MAX_DNS_CACHE_SIZE) {
+    const first = dnsCache.keys().next();
+    if (first.done !== true) dnsCache.delete(first.value);
+  }
+}
+
 /**
  * Resolve DNS for a hostname and validate resolved addresses against SSRF policy.
  * Returns a PinnedHostname with pre-resolved addresses and a pinned lookup function.
@@ -448,6 +472,10 @@ export async function resolvePinnedHostnameWithPolicy(
       );
     }
   }
+
+  // Return cached result if available (avoids redundant DNS lookups in redirect chains)
+  const cached = getCachedDnsResult(normalized);
+  if (cached) return cached;
 
   const lookupFn = params.lookupFn ?? dnsLookup;
   let results: { address: string; family: number }[];
@@ -482,11 +510,13 @@ export async function resolvePinnedHostnameWithPolicy(
     );
   }
 
-  return {
+  const pinned: PinnedHostname = {
     hostname: normalized,
     addresses,
     lookup: createPinnedLookup({ hostname: normalized, addresses }),
   };
+  cacheDnsResult(normalized, pinned);
+  return pinned;
 }
 
 /**
@@ -722,6 +752,17 @@ export async function resolveExistingPathsWithinRoot(params: {
       resolved.push(real);
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        // Verify parent directory exists and resolves within root to prevent
+        // lexical path from hiding a symlink-based escape via a missing intermediate
+        try {
+          const parentReal = await realpath(dirname(lexical.path));
+          const parentRel = relative(root, parentReal);
+          if (parentRel === '..' || parentRel.startsWith(`..${sep}`) || pathIsAbsolute(parentRel)) {
+            return { ok: false, error: `Path escapes ${params.scopeLabel} via parent symlink: "${raw}".` };
+          }
+        } catch {
+          // Parent doesn't exist either — safe since path can't be reached
+        }
         resolved.push(lexical.path);
       } else {
         return { ok: false, error: `Cannot resolve "${raw}" (${params.scopeLabel}): ${(e as Error).message}` };
@@ -820,7 +861,13 @@ export async function writeViaSiblingTempPath(params: {
   targetPath: string;
   writeTemp: (tempPath: string) => Promise<void>;
 }): Promise<void> {
-  const rootDir = await realpath(resolve(params.rootDir)).catch(() => resolve(params.rootDir));
+  let rootDir: string;
+  try {
+    rootDir = await realpath(resolve(params.rootDir));
+  } catch {
+    console.warn(`[browserclaw] writeViaSiblingTempPath: rootDir realpath failed, using lexical resolve`);
+    rootDir = resolve(params.rootDir);
+  }
   const requestedTargetPath = resolve(params.targetPath);
   const targetPath = await realpath(dirname(requestedTargetPath))
     .then((realDir) => join(realDir, basename(requestedTargetPath)))
@@ -834,6 +881,16 @@ export async function writeViaSiblingTempPath(params: {
     pathIsAbsolute(relativeTargetPath)
   ) {
     throw new Error('Target path is outside the allowed root');
+  }
+
+  // Re-check for symlink right before write to narrow the TOCTOU window
+  try {
+    const stat = await lstat(targetPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Unsafe output path: "${params.targetPath}" is a symbolic link.`);
+    }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
   }
 
   const tempPath = buildSiblingTempPath(targetPath);
@@ -867,6 +924,13 @@ export async function assertBrowserNavigationResultAllowed(
     parsed = new URL(rawUrl);
   } catch {
     return;
+  }
+
+  // Block data: and blob: URLs in post-navigation results — these can be used to exfiltrate data
+  if (parsed.protocol === 'data:' || parsed.protocol === 'blob:') {
+    throw new InvalidBrowserNavigationUrlError(
+      `Navigation result blocked: "${parsed.protocol}" URLs are not allowed.`,
+    );
   }
 
   if (NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol) || isAllowedNonNetworkNavigationUrl(parsed)) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -275,7 +275,8 @@ function isBlockedHostnameOrIp(hostname: string, policy?: SsrfPolicy): boolean {
 function isPrivateIpAddress(address: string, policy?: SsrfPolicy): boolean {
   let normalized = address.trim().toLowerCase();
   if (normalized.startsWith('[') && normalized.endsWith(']')) normalized = normalized.slice(1, -1);
-  if (!normalized) return false;
+  // "[]" strips to empty string — treat as unspecified (blocked)
+  if (!normalized) return true;
 
   const blockOptions = resolveIpv4SpecialUseBlockOptions(policy);
 
@@ -299,7 +300,9 @@ function isPrivateIpAddress(address: string, policy?: SsrfPolicy): boolean {
 
 /**
  * Check whether a URL targets a loopback or private/internal network address.
- * Synchronous hostname-based check. Used to prevent SSRF attacks.
+ * Synchronous hostname-based check — does NOT perform DNS resolution, so
+ * hostnames that resolve to private IPs will not be caught. Use
+ * `assertBrowserNavigationAllowed` for the full async DNS-pinned check.
  */
 export function isInternalUrl(url: string, policy?: SsrfPolicy): boolean {
   let parsed: URL;
@@ -928,9 +931,7 @@ export async function assertBrowserNavigationResultAllowed(
 
   // Block data: and blob: URLs in post-navigation results — these can be used to exfiltrate data
   if (parsed.protocol === 'data:' || parsed.protocol === 'blob:') {
-    throw new InvalidBrowserNavigationUrlError(
-      `Navigation result blocked: "${parsed.protocol}" URLs are not allowed.`,
-    );
+    throw new InvalidBrowserNavigationUrlError(`Navigation result blocked: "${parsed.protocol}" URLs are not allowed.`);
   }
 
   if (NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol) || isAllowedNonNetworkNavigationUrl(parsed)) {

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -171,6 +171,10 @@ export interface SnapshotBuildOptions {
 /**
  * Build a role snapshot from Playwright's ariaSnapshot() output.
  * Assigns ref IDs (e1, e2, ...) to interactive/content elements.
+ *
+ * Shadow DOM elements may produce duplicate role+name pairs because Playwright
+ * flattens shadow trees into the aria snapshot. The `nth` index and duplicate
+ * tracking ensure each element gets a unique locator even when names collide.
  */
 export function buildRoleSnapshotFromAriaSnapshot(
   ariaSnapshot: string,

--- a/src/stealth.ts
+++ b/src/stealth.ts
@@ -80,6 +80,9 @@ export const STEALTH_SCRIPT = `(function() {
   });
 
   // ── 4. window.chrome ──
+  // Stub the chrome.runtime API surface that detection scripts probe for.
+  // Only applied when the real chrome.runtime.connect is absent (headless/CDP mode).
+  // The stubs are intentionally non-functional — they exist solely to pass presence checks.
   p(function() {
     if (window.chrome && window.chrome.runtime && window.chrome.runtime.connect) return;
 
@@ -130,6 +133,9 @@ export const STEALTH_SCRIPT = `(function() {
   });
 
   // ── 6. WebGL vendor / renderer ──
+  // Hardcoded to Intel Iris — the most common discrete GPU on macOS. These strings
+  // are fingerprinting targets; a more sophisticated approach would randomize per-session,
+  // but static values are sufficient to avoid the default "Google SwiftShader" headless signal.
   p(function() {
     var h = {
       apply: function(target, self, args) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -557,6 +557,7 @@ export interface PageState {
   roleRefs?: RoleRefs;
   roleRefsFrameSelector?: string;
   roleRefsMode?: 'role' | 'aria';
+  roleRefsStoredAt?: number;
   armIdUpload: number;
   armIdDialog: number;
   armIdDownload: number;


### PR DESCRIPTION
## Summary
- Fixes all 62 code review issues across high, medium, and low severity levels
- **H1-H8** (high): Critical race conditions, resource leaks, security hardening
- **M1-M31** (medium): Cleanup gaps, error handling, timeout management
- **L1-L23** (low): Polling optimization, comments, deduplication, minor guards

### Key changes
- Rate-limit retry with backoff instead of immediate failure (connection.ts)
- Reentrancy guard on NO_PROXY env mutex (connection.ts)  
- Single-page fallback guard and body text deduplication (browser.ts)
- Browser-side eval timeout strictly less than outer timeout (evaluate.ts)
- Download waiter promise rejection on cancel (download.ts)
- Bulk eviction for console/error/request arrays instead of per-item shift() (page-utils.ts)
- Empty bracket "[]" handling in IP address parser (security.ts)
- Lock file cleanup on Chrome launch failure (chrome-launcher.ts)
- WebSocket polling backoff during Chrome startup (chrome-launcher.ts)
- Recording context cleanup on force-disconnect (navigation.ts)
- Documentation comments for stealth stubs, shadow DOM refs, sync-only SSRF check

## Test plan
- [x] `npm run build` passes
- [x] `npm run format:check` passes  
- [x] `npm run lint` passes (4 pre-existing errors unchanged)
- [x] `npm test` — 219 tests pass