### PR TITLE
Updates from OpenClaw 2026.4.5

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -783,6 +783,9 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
     );
   }
   if (isBlockedPageRef(opts.cdpUrl, found)) throw new BlockedBrowserTargetError();
+  const foundTargetId = await pageTargetId(found).catch(() => null);
+  if (foundTargetId !== null && foundTargetId !== '' && isBlockedTarget(opts.cdpUrl, foundTargetId))
+    throw new BlockedBrowserTargetError();
   return found;
 }
 


### PR DESCRIPTION
## Summary
- **`getPageForTargetId`**: Add `foundTargetId` blocked-target re-check after `findPageByTargetId` returns. OC re-resolves the found page's target ID via CDP and checks if it became blocked between the partition and find steps. Closes a narrow SSRF race window where a target becomes blocked mid-lookup.

## Registry updates (gitignored sync/ files)
- Known diff #46: `restoreRoleRefsForTarget` removed from browserclaw (intentional simplification)
- Known diff #47: `setExtraHTTPHeadersViaPlaywright` uses page-scoped CDP (browserclaw ahead)
- Known diff #48: No single-page fallback in `getPageForTargetId`/`findPageByTargetId` (stricter error reporting)
- Function map: updated bundle filenames, moved `restoreRoleRefsForTarget` to "not ported"

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 732 tests pass
- [x] `npm run format:check` — clean