### PR TITLE
Bump npm to 0.12.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Version bump to 0.12.4

### Changes since 0.12.3
- **Blocked-target race fix** (from OpenClaw 2026.4.5 sync): `getPageForTargetId` now re-checks the found page's target ID against blocked targets after resolution, closing a narrow SSRF race window
- **Unit tests**: 159 new tests across connection.ts, ref-resolver.ts, page-utils.ts, chrome-launcher.ts (732 total)