### PR TITLE
Updates from OpenClaw 2026.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -1,4 +1,5 @@
 import { BrowserTabNotFoundError, BlockedBrowserTargetError } from '../connection.js';
+import type { SsrfPolicy } from '../types.js';
 
 import { evaluateViaPlaywright } from './evaluate.js';
 import {
@@ -90,6 +91,7 @@ export async function executeSingleAction(
   targetId: string | undefined,
   evaluateEnabled: boolean,
   depth = 0,
+  ssrfPolicy?: SsrfPolicy,
 ): Promise<void> {
   if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${String(MAX_BATCH_DEPTH)}`);
   const effectiveTargetId = action.targetId ?? targetId;
@@ -106,6 +108,7 @@ export async function executeSingleAction(
         modifiers: action.modifiers as ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[] | undefined,
         delayMs: action.delayMs,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case 'type':
@@ -118,6 +121,7 @@ export async function executeSingleAction(
         submit: action.submit,
         slowly: action.slowly,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case 'press':
@@ -126,6 +130,7 @@ export async function executeSingleAction(
         targetId: effectiveTargetId,
         key: action.key,
         delayMs: action.delayMs,
+        ssrfPolicy,
       });
       break;
     case 'hover':
@@ -224,6 +229,7 @@ export async function executeSingleAction(
         stopOnError: action.stopOnError,
         evaluateEnabled,
         depth: depth + 1,
+        ssrfPolicy,
       });
       break;
     default:
@@ -246,6 +252,7 @@ export async function batchViaPlaywright(opts: {
   stopOnError?: boolean;
   evaluateEnabled?: boolean;
   depth?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<{ results: BatchActionResult[] }> {
   const depth = opts.depth ?? 0;
   if (depth > MAX_BATCH_DEPTH) throw new Error(`Batch nesting depth exceeds maximum of ${String(MAX_BATCH_DEPTH)}`);
@@ -262,7 +269,7 @@ export async function batchViaPlaywright(opts: {
       break;
     }
     try {
-      await executeSingleAction(action, opts.cdpUrl, opts.targetId, evaluateEnabled, depth);
+      await executeSingleAction(action, opts.cdpUrl, opts.targetId, evaluateEnabled, depth, opts.ssrfPolicy);
       results.push({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -160,6 +160,7 @@ export async function executeSingleAction(
         endRef: action.endRef,
         endSelector: action.endSelector,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case 'select':
@@ -170,6 +171,7 @@ export async function executeSingleAction(
         selector: action.selector,
         values: action.values,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case 'fill':

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -57,12 +57,19 @@ export async function mouseClickViaPlaywright(opts: {
   button?: MouseButton;
   clickCount?: number;
   delayMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   await page.mouse.click(opts.x, opts.y, {
     button: opts.button,
     clickCount: opts.clickCount,
     delay: opts.delayMs,
+  });
+  await assertPostInteractionNavigationSafe({
+    cdpUrl: opts.cdpUrl,
+    page,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
   });
 }
 
@@ -76,6 +83,7 @@ export async function pressAndHoldViaCdp(opts: {
   y: number;
   delay?: number;
   holdMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
@@ -94,6 +102,12 @@ export async function pressAndHoldViaCdp(opts: {
       await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 });
     },
   });
+  await assertPostInteractionNavigationSafe({
+    cdpUrl: opts.cdpUrl,
+    page,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
 }
 
 export async function clickByTextViaPlaywright(opts: {
@@ -104,6 +118,7 @@ export async function clickByTextViaPlaywright(opts: {
   button?: MouseButton;
   modifiers?: KeyModifier[];
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
@@ -114,6 +129,12 @@ export async function clickByTextViaPlaywright(opts: {
     .first();
   try {
     await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
+    await assertPostInteractionNavigationSafe({
+      cdpUrl: opts.cdpUrl,
+      page,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, `text="${opts.text}"`);
   }
@@ -128,6 +149,7 @@ export async function clickByRoleViaPlaywright(opts: {
   button?: MouseButton;
   modifiers?: KeyModifier[];
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
@@ -137,6 +159,12 @@ export async function clickByRoleViaPlaywright(opts: {
     .nth(opts.index ?? 0);
   try {
     await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
+    await assertPostInteractionNavigationSafe({
+      cdpUrl: opts.cdpUrl,
+      page,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -293,6 +321,7 @@ export async function selectOptionViaPlaywright(opts: {
   selector?: string;
   values: string[];
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   if (opts.values.length === 0) throw new Error('values are required');
@@ -302,6 +331,12 @@ export async function selectOptionViaPlaywright(opts: {
 
   try {
     await locator.selectOption(opts.values, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
+    await assertPostInteractionNavigationSafe({
+      cdpUrl: opts.cdpUrl,
+      page,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -315,6 +350,7 @@ export async function dragViaPlaywright(opts: {
   endRef?: string;
   endSelector?: string;
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const resolvedStart = requireRefOrSelector(opts.startRef, opts.startSelector);
   const resolvedEnd = requireRefOrSelector(opts.endRef, opts.endSelector);
@@ -326,6 +362,12 @@ export async function dragViaPlaywright(opts: {
 
   try {
     await startLocator.dragTo(endLocator, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
+    await assertPostInteractionNavigationSafe({
+      cdpUrl: opts.cdpUrl,
+      page,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, `${startLabel} -> ${endLabel}`);
   }

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -17,7 +17,9 @@ import {
   withPageScopedCdpClient,
 } from '../connection.js';
 import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
-import type { FormField } from '../types.js';
+import type { FormField, SsrfPolicy } from '../types.js';
+
+import { assertPostInteractionNavigationSafe } from './navigation.js';
 
 type MouseButton = 'left' | 'right' | 'middle';
 type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
@@ -151,6 +153,7 @@ export async function clickViaPlaywright(opts: {
   delayMs?: number;
   timeoutMs?: number;
   force?: boolean;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -214,6 +217,12 @@ export async function clickViaPlaywright(opts: {
           });
       }
     }
+    await assertPostInteractionNavigationSafe({
+      cdpUrl: opts.cdpUrl,
+      page,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -247,6 +256,7 @@ export async function typeViaPlaywright(opts: {
   submit?: boolean;
   slowly?: boolean;
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const text = opts.text;
@@ -262,7 +272,15 @@ export async function typeViaPlaywright(opts: {
     } else {
       await locator.fill(text, { timeout });
     }
-    if (opts.submit === true) await locator.press('Enter', { timeout });
+    if (opts.submit === true) {
+      await locator.press('Enter', { timeout });
+      await assertPostInteractionNavigationSafe({
+        cdpUrl: opts.cdpUrl,
+        page,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
+    }
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }

--- a/src/actions/keyboard.ts
+++ b/src/actions/keyboard.ts
@@ -1,14 +1,24 @@
 import { getPageForTargetId, ensurePageState } from '../connection.js';
+import type { SsrfPolicy } from '../types.js';
+
+import { assertPostInteractionNavigationSafe } from './navigation.js';
 
 export async function pressKeyViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   key: string;
   delayMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const key = opts.key.trim();
   if (!key) throw new Error('key is required');
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
   await page.keyboard.press(key, { delay: Math.max(0, Math.floor(opts.delayMs ?? 0)) });
+  await assertPostInteractionNavigationSafe({
+    cdpUrl: opts.cdpUrl,
+    page,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
 }

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -57,11 +57,22 @@ function isPolicyDenyNavigationError(err: unknown): boolean {
 }
 
 function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
-  if (!request.isNavigationRequest()) return false;
+  let sameMainFrame = false;
   try {
-    return request.frame() === page.mainFrame();
+    sameMainFrame = request.frame() === page.mainFrame();
   } catch {
-    return true;
+    sameMainFrame = true;
+  }
+  if (!sameMainFrame) return false;
+  try {
+    if (request.isNavigationRequest()) return true;
+  } catch {
+    /* fall through to resourceType check */
+  }
+  try {
+    return request.resourceType() === 'document';
+  } catch {
+    return false;
   }
 }
 
@@ -76,7 +87,7 @@ async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page; 
   });
 }
 
-async function assertPageNavigationCompletedSafely(opts: {
+export async function assertPageNavigationCompletedSafely(opts: {
   cdpUrl: string;
   page: Page;
   response: Awaited<ReturnType<Page['goto']>>;
@@ -92,6 +103,29 @@ async function assertPageNavigationCompletedSafely(opts: {
       await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page: opts.page, targetId: opts.targetId });
     throw err;
   }
+}
+
+/**
+ * Post-interaction navigation safety check. Call after any interaction that
+ * could trigger navigation (click, type-submit, press) — validates the final
+ * page URL against the SSRF policy and closes the tab if blocked.
+ *
+ * No-op if no policy is provided.
+ */
+export async function assertPostInteractionNavigationSafe(opts: {
+  cdpUrl: string;
+  page: Page;
+  ssrfPolicy?: SsrfPolicy;
+  targetId?: string;
+}): Promise<void> {
+  if (!opts.ssrfPolicy) return;
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page: opts.page,
+    response: null,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
 }
 
 async function gotoPageWithNavigationGuard(opts: {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -326,6 +326,7 @@ export class CrawlPage {
       button: opts?.button,
       clickCount: opts?.clickCount,
       delayMs: opts?.delayMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -353,6 +354,7 @@ export class CrawlPage {
       y,
       delay: opts?.delay,
       holdMs: opts?.holdMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -387,6 +389,7 @@ export class CrawlPage {
       button: opts?.button,
       modifiers: opts?.modifiers,
       timeoutMs: opts?.timeoutMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -425,6 +428,7 @@ export class CrawlPage {
       button: opts?.button,
       modifiers: opts?.modifiers,
       timeoutMs: opts?.timeoutMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -491,6 +495,7 @@ export class CrawlPage {
       targetId: this._targetId,
       ref,
       values,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -508,6 +513,7 @@ export class CrawlPage {
       startRef,
       endRef,
       timeoutMs: opts?.timeoutMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -889,6 +895,7 @@ export class CrawlPage {
       ref: opts?.ref,
       element: opts?.element,
       type: opts?.type,
+      ssrfPolicy: this.ssrfPolicy,
     });
     return result.buffer;
   }
@@ -901,7 +908,11 @@ export class CrawlPage {
    * @returns PDF document as a Buffer
    */
   async pdf(): Promise<Buffer> {
-    const result = await pdfViaPlaywright({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const result = await pdfViaPlaywright({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     return result.buffer;
   }
 
@@ -934,6 +945,7 @@ export class CrawlPage {
       refs,
       maxLabels: opts?.maxLabels,
       type: opts?.type,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -195,6 +195,7 @@ export class CrawlPage {
           compact: opts.compact,
           maxDepth: opts.maxDepth,
         },
+        ssrfPolicy: this.ssrfPolicy,
       });
     }
     if (
@@ -214,6 +215,7 @@ export class CrawlPage {
         compact: opts?.compact,
         maxDepth: opts?.maxDepth,
       },
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -227,7 +229,12 @@ export class CrawlPage {
    * @returns Array of accessibility tree nodes
    */
   async ariaSnapshot(opts?: { limit?: number }): Promise<AriaSnapshotResult> {
-    return snapshotAria({ cdpUrl: this.cdpUrl, targetId: this._targetId, limit: opts?.limit });
+    return snapshotAria({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      limit: opts?.limit,
+      ssrfPolicy: this.ssrfPolicy,
+    });
   }
 
   // ── Interactions ─────────────────────────────────────────────
@@ -257,6 +264,7 @@ export class CrawlPage {
       delayMs: opts?.delayMs,
       timeoutMs: opts?.timeoutMs,
       force: opts?.force,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -285,6 +293,7 @@ export class CrawlPage {
       delayMs: opts?.delayMs,
       timeoutMs: opts?.timeoutMs,
       force: opts?.force,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -445,6 +454,7 @@ export class CrawlPage {
       submit: opts?.submit,
       slowly: opts?.slowly,
       timeoutMs: opts?.timeoutMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -677,6 +687,7 @@ export class CrawlPage {
       actions,
       stopOnError: opts?.stopOnError,
       evaluateEnabled: opts?.evaluateEnabled,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -703,6 +714,7 @@ export class CrawlPage {
       targetId: this._targetId,
       key,
       delayMs: opts?.delayMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 

--- a/src/capture/pdf.ts
+++ b/src/capture/pdf.ts
@@ -1,7 +1,24 @@
+import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
 import { getPageForTargetId, ensurePageState } from '../connection.js';
+import type { SsrfPolicy } from '../types.js';
 
-export async function pdfViaPlaywright(opts: { cdpUrl: string; targetId?: string }): Promise<{ buffer: Buffer }> {
+export async function pdfViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  ssrfPolicy?: SsrfPolicy;
+}): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
+
   return { buffer: await page.pdf({ printBackground: true }) };
 }

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -1,4 +1,6 @@
+import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
 import { getPageForTargetId, ensurePageState, refLocator } from '../connection.js';
+import type { SsrfPolicy } from '../types.js';
 
 export async function takeScreenshotViaPlaywright(opts: {
   cdpUrl: string;
@@ -7,9 +9,21 @@ export async function takeScreenshotViaPlaywright(opts: {
   ref?: string;
   element?: string;
   type?: 'png' | 'jpeg';
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
+
   const type = opts.type ?? 'png';
 
   if (opts.ref !== undefined && opts.ref !== '') {
@@ -29,6 +43,7 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   refs: string[];
   maxLabels?: number;
   type?: 'png' | 'jpeg';
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<{
   buffer: Buffer;
   labels: { ref: string; index: number; box: { x: number; y: number; width: number; height: number } }[];
@@ -36,6 +51,16 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
 }> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   const maxLabels =
     typeof opts.maxLabels === 'number' && Number.isFinite(opts.maxLabels)

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -1,6 +1,7 @@
+import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
 import { getPageForTargetId, ensurePageState, storeRoleRefsForTarget, normalizeTimeoutMs } from '../connection.js';
 import type { PageWithAI } from '../connection.js';
-import type { SnapshotResult, SnapshotOptions } from '../types.js';
+import type { SnapshotResult, SnapshotOptions, SsrfPolicy } from '../types.js';
 
 import { buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
 
@@ -14,9 +15,20 @@ export async function snapshotAi(opts: {
   maxChars?: number;
   timeoutMs?: number;
   options?: SnapshotOptions;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<SnapshotResult> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   const maybe = page as PageWithAI;
   if (!maybe._snapshotForAI) {

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -1,3 +1,4 @@
+import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
 import {
   getPageForTargetId,
   ensurePageState,
@@ -6,7 +7,7 @@ import {
   withPlaywrightPageCdpSession,
 } from '../connection.js';
 import type { PageWithAI } from '../connection.js';
-import type { SnapshotResult, AriaSnapshotResult, AriaNode } from '../types.js';
+import type { SnapshotResult, AriaSnapshotResult, AriaNode, SsrfPolicy } from '../types.js';
 
 import { buildRoleSnapshotFromAriaSnapshot, buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
 
@@ -29,9 +30,20 @@ export async function snapshotRole(opts: {
     compact?: boolean;
     maxDepth?: number;
   };
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<SnapshotResult> {
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   const sourceUrl = page.url();
 
@@ -124,10 +136,21 @@ export async function snapshotAria(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<AriaSnapshotResult> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
   const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   const sourceUrl = page.url();
 


### PR DESCRIPTION
## Summary

Ports the **post-interaction SSRF check** added in OpenClaw 2026.4.x. Closes a narrow window where a click/submit/keypress could trigger a redirect to a blocked internal URL and subsequent reads would see the raw page.

Also ports a harder-to-spot refinement to `isTopLevelNavigationRequest` — OpenClaw's version is strictly more defensive (catches `document` resource-type requests even when `isNavigationRequest()` is false, and wraps both checks in try/catch with sensible fallbacks). Browserclaw's previous version could under-block top-level navigation in edge cases, which is a real security gap.

browserclaw already had `assertPageNavigationCompletedSafely` (from the 0.11.1 navigation-guard port) but only invoked it post-navigation — not after interactions or before snapshots. OpenClaw wired a thin wrapper `assertPostInteractionNavigationSafe()` into all the affected call sites.

## Changes

### Post-interaction SSRF check
- `src/actions/navigation.ts` — exported `assertPageNavigationCompletedSafely`; added new `assertPostInteractionNavigationSafe`
- `src/actions/interaction.ts` — `clickViaPlaywright` (always) and `typeViaPlaywright` (on submit) now run the post-interaction guard
- `src/actions/keyboard.ts` — `pressKeyViaPlaywright` runs the guard after key press
- `src/snapshot/ai-snapshot.ts`, `src/snapshot/aria-snapshot.ts` — `snapshotAi` / `snapshotRole` / `snapshotAria` run the guard before capturing (if `ssrfPolicy` set)
- `src/actions/batch.ts` — threaded `ssrfPolicy` through `batchViaPlaywright` and `executeSingleAction`
- `src/browser.ts` — `CrawlPage.click / clickBySelector / type / press / snapshot / ariaSnapshot / batch` now forward `this.ssrfPolicy` to the underlying functions

### isTopLevelNavigationRequest refinement
- `src/actions/navigation.ts` — `isTopLevelNavigationRequest` now matches OpenClaw's defensive pattern: main-frame check (default `true` on error), `isNavigationRequest()` (tolerating exceptions), fallback to `resourceType() === 'document'`. Closes a gap where document-type navigations without `isNavigationRequest === true` could slip through the route-handler SSRF filter.

### Sync artifacts
- `sync/run-log.md` — added 2026.4.10 entry
- `sync/function-map.md` — refreshed bundle names (old 165K thread-bindings monolith is gone, merged into `client-fetch-BqqqnaEO.js`) and added navigation-guard functions

## Sync workstream findings

- **Security (A):** 0 real gaps. Optional undici/agent helpers (`resolvePinnedHostname`, `assertPublicHostname`, suffix-allowlist helpers) skipped — HTTP client plumbing not needed in standalone lib
- **Connection (C):** 0 gaps. All 48 known diffs correctly preserved; all Chrome launcher functions unchanged
- **Browser actions (B):** 1 real gap (the post-interaction check, ported in this PR). Every other diff the workstream flagged was correctly protected by the known-differences registry (pressSequentially, evaluate fallback, waitFor visible-only text matching, setExtraHTTPHeaders page-scoped CDP, consolePriority 'warn' alias, etc.)

Follow-up code review caught the `isTopLevelNavigationRequest` divergence that the workstream agents missed (it's a helper, not a top-level `*ViaPlaywright` function).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 732/732 passing
- [x] `npm run check-exports`