### PR TITLE
Updates from OpenClaw 2026.4.10

### DIFF
--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -215,6 +215,7 @@ export async function executeSingleAction(
         fn: action.fn,
         ref: action.ref,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case 'close':

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -6,6 +6,9 @@ import {
   forceDisconnectPlaywrightConnection,
   tryTerminateExecutionViaCdp,
 } from '../connection.js';
+import type { SsrfPolicy } from '../types.js';
+
+import { assertInteractionNavigationCompletedSafely } from './navigation.js';
 
 export interface FrameEvalResult {
   frameUrl: string;
@@ -22,11 +25,16 @@ export async function evaluateInAllFramesViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   fn: string;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<FrameEvalResult[]> {
   const fnText = opts.fn.trim();
   if (!fnText) throw new Error('function is required');
 
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   const frames = page.frames();
   const results: FrameEvalResult[] = [];
 
@@ -144,11 +152,16 @@ export async function evaluateViaPlaywright(opts: {
   ref?: string;
   timeoutMs?: number;
   signal?: AbortSignal;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<unknown> {
   const fnText = opts.fn.trim();
   if (!fnText) throw new Error('function is required');
 
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   const outerTimeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
@@ -206,25 +219,42 @@ export async function evaluateViaPlaywright(opts: {
     }
   }
 
+  const previousUrl = page.url();
   try {
     if (opts.ref !== undefined && opts.ref !== '') {
       const locator = refLocator(page, opts.ref);
-      return await awaitEvalWithAbort(
-        locator.evaluate(ELEMENT_EVALUATOR as (...args: unknown[]) => unknown, {
-          fnBody: fnText,
-          timeoutMs: evaluateTimeout,
-        }),
-        abortPromise,
-      );
+      return await assertInteractionNavigationCompletedSafely({
+        action: () =>
+          awaitEvalWithAbort(
+            locator.evaluate(ELEMENT_EVALUATOR as (...args: unknown[]) => unknown, {
+              fnBody: fnText,
+              timeoutMs: evaluateTimeout,
+            }),
+            abortPromise,
+          ),
+        cdpUrl: opts.cdpUrl,
+        page,
+        previousUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
     }
 
-    return await awaitEvalWithAbort(
-      page.evaluate(BROWSER_EVALUATOR as (...args: unknown[]) => unknown, {
-        fnBody: fnText,
-        timeoutMs: evaluateTimeout,
-      }),
-      abortPromise,
-    );
+    return await assertInteractionNavigationCompletedSafely({
+      action: () =>
+        awaitEvalWithAbort(
+          page.evaluate(BROWSER_EVALUATOR as (...args: unknown[]) => unknown, {
+            fnBody: fnText,
+            timeoutMs: evaluateTimeout,
+          }),
+          abortPromise,
+        ),
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } finally {
     if (signal && abortListener) signal.removeEventListener('abort', abortListener);
     // Release closure references to prevent memory leaks in long-lived signals

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -19,7 +19,7 @@ import {
 import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
 import type { FormField, SsrfPolicy } from '../types.js';
 
-import { assertPostInteractionNavigationSafe } from './navigation.js';
+import { assertInteractionNavigationCompletedSafely } from './navigation.js';
 
 type MouseButton = 'left' | 'right' | 'middle';
 type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
@@ -60,14 +60,18 @@ export async function mouseClickViaPlaywright(opts: {
   ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
-  await page.mouse.click(opts.x, opts.y, {
-    button: opts.button,
-    clickCount: opts.clickCount,
-    delay: opts.delayMs,
-  });
-  await assertPostInteractionNavigationSafe({
+  const previousUrl = page.url();
+  await assertInteractionNavigationCompletedSafely({
+    action: async () => {
+      await page.mouse.click(opts.x, opts.y, {
+        button: opts.button,
+        clickCount: opts.clickCount,
+        delay: opts.delayMs,
+      });
+    },
     cdpUrl: opts.cdpUrl,
     page,
+    previousUrl,
     ssrfPolicy: opts.ssrfPolicy,
     targetId: opts.targetId,
   });
@@ -85,26 +89,34 @@ export async function pressAndHoldViaCdp(opts: {
   holdMs?: number;
   ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   const { x, y } = opts;
+  const previousUrl = page.url();
 
-  await withPageScopedCdpClient({
-    cdpUrl: opts.cdpUrl,
-    page,
-    targetId: opts.targetId,
-    fn: async (send) => {
-      await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-      if (opts.delay !== undefined && opts.delay !== 0) await new Promise((r) => setTimeout(r, opts.delay));
-      await send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1 });
-      if (opts.holdMs !== undefined && opts.holdMs !== 0) await new Promise((r) => setTimeout(r, opts.holdMs));
-      await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 });
+  await assertInteractionNavigationCompletedSafely({
+    action: async () => {
+      await withPageScopedCdpClient({
+        cdpUrl: opts.cdpUrl,
+        page,
+        targetId: opts.targetId,
+        fn: async (send) => {
+          await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+          if (opts.delay !== undefined && opts.delay !== 0) await new Promise((r) => setTimeout(r, opts.delay));
+          await send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1 });
+          if (opts.holdMs !== undefined && opts.holdMs !== 0) await new Promise((r) => setTimeout(r, opts.holdMs));
+          await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 });
+        },
+      });
     },
-  });
-  await assertPostInteractionNavigationSafe({
     cdpUrl: opts.cdpUrl,
     page,
+    previousUrl,
     ssrfPolicy: opts.ssrfPolicy,
     targetId: opts.targetId,
   });
@@ -127,11 +139,15 @@ export async function clickByTextViaPlaywright(opts: {
     .or(page.getByTitle(opts.text, { exact: opts.exact }))
     .and(page.locator(':visible'))
     .first();
+  const previousUrl = page.url();
   try {
-    await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
-    await assertPostInteractionNavigationSafe({
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
+      },
       cdpUrl: opts.cdpUrl,
       page,
+      previousUrl,
       ssrfPolicy: opts.ssrfPolicy,
       targetId: opts.targetId,
     });
@@ -157,11 +173,15 @@ export async function clickByRoleViaPlaywright(opts: {
   const locator = page
     .getByRole(opts.role as Parameters<typeof page.getByRole>[0], { name: opts.name })
     .nth(opts.index ?? 0);
+  const previousUrl = page.url();
   try {
-    await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
-    await assertPostInteractionNavigationSafe({
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers });
+      },
       cdpUrl: opts.cdpUrl,
       page,
+      previousUrl,
       ssrfPolicy: opts.ssrfPolicy,
       targetId: opts.targetId,
     });
@@ -188,6 +208,7 @@ export async function clickViaPlaywright(opts: {
   const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  const previousUrl = page.url();
 
   // Determine if this is a checkable role element so we can verify the click worked.
   let checkableRole = false;
@@ -201,53 +222,58 @@ export async function clickViaPlaywright(opts: {
   }
 
   try {
-    const delayMs = resolveBoundedDelayMs(opts.delayMs, 'click delayMs', MAX_CLICK_DELAY_MS);
-    if (delayMs > 0) {
-      await locator.hover({ timeout, force: opts.force });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-
-    // For checkable roles, capture aria-checked before the click.
-    let ariaCheckedBefore: string | null | undefined;
-    if (checkableRole && opts.doubleClick !== true) {
-      ariaCheckedBefore = await locator.getAttribute('aria-checked', { timeout }).catch(() => undefined);
-    }
-
-    if (opts.doubleClick === true) {
-      await locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
-    } else {
-      await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
-    }
-
-    // If this is a checkable role and aria-checked didn't change, fall back to JS click.
-    // Poll briefly to give async frameworks time to update the DOM before concluding
-    // the click didn't work — otherwise we'd fire a second click that un-toggles it.
-    if (checkableRole && opts.doubleClick !== true && ariaCheckedBefore !== undefined) {
-      const POLL_INTERVAL_MS = 50;
-      const POLL_TIMEOUT_MS = 500;
-      const ATTR_TIMEOUT_MS = Math.min(timeout, POLL_TIMEOUT_MS);
-      let changed = false;
-      for (let elapsed = 0; elapsed < POLL_TIMEOUT_MS; elapsed += POLL_INTERVAL_MS) {
-        const current = await locator.getAttribute('aria-checked', { timeout: ATTR_TIMEOUT_MS }).catch(() => undefined);
-        if (current === undefined || current !== ariaCheckedBefore) {
-          changed = true;
-          break;
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        const delayMs = resolveBoundedDelayMs(opts.delayMs, 'click delayMs', MAX_CLICK_DELAY_MS);
+        if (delayMs > 0) {
+          await locator.hover({ timeout, force: opts.force });
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
         }
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-      }
-      if (!changed) {
-        await locator
-          .evaluate((el: Element) => {
-            (el as HTMLElement).click();
-          })
-          .catch(() => {
-            /* intentional no-op */
-          });
-      }
-    }
-    await assertPostInteractionNavigationSafe({
+
+        // For checkable roles, capture aria-checked before the click.
+        let ariaCheckedBefore: string | null | undefined;
+        if (checkableRole && opts.doubleClick !== true) {
+          ariaCheckedBefore = await locator.getAttribute('aria-checked', { timeout }).catch(() => undefined);
+        }
+
+        if (opts.doubleClick === true) {
+          await locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
+        } else {
+          await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
+        }
+
+        // If this is a checkable role and aria-checked didn't change, fall back to JS click.
+        // Poll briefly to give async frameworks time to update the DOM before concluding
+        // the click didn't work — otherwise we'd fire a second click that un-toggles it.
+        if (checkableRole && opts.doubleClick !== true && ariaCheckedBefore !== undefined) {
+          const POLL_INTERVAL_MS = 50;
+          const POLL_TIMEOUT_MS = 500;
+          const ATTR_TIMEOUT_MS = Math.min(timeout, POLL_TIMEOUT_MS);
+          let changed = false;
+          for (let elapsed = 0; elapsed < POLL_TIMEOUT_MS; elapsed += POLL_INTERVAL_MS) {
+            const current = await locator
+              .getAttribute('aria-checked', { timeout: ATTR_TIMEOUT_MS })
+              .catch(() => undefined);
+            if (current === undefined || current !== ariaCheckedBefore) {
+              changed = true;
+              break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+          }
+          if (!changed) {
+            await locator
+              .evaluate((el: Element) => {
+                (el as HTMLElement).click();
+              })
+              .catch(() => {
+                /* intentional no-op */
+              });
+          }
+        }
+      },
       cdpUrl: opts.cdpUrl,
       page,
+      previousUrl,
       ssrfPolicy: opts.ssrfPolicy,
       targetId: opts.targetId,
     });
@@ -301,10 +327,14 @@ export async function typeViaPlaywright(opts: {
       await locator.fill(text, { timeout });
     }
     if (opts.submit === true) {
-      await locator.press('Enter', { timeout });
-      await assertPostInteractionNavigationSafe({
+      const previousUrl = page.url();
+      await assertInteractionNavigationCompletedSafely({
+        action: async () => {
+          await locator.press('Enter', { timeout });
+        },
         cdpUrl: opts.cdpUrl,
         page,
+        previousUrl,
         ssrfPolicy: opts.ssrfPolicy,
         targetId: opts.targetId,
       });
@@ -328,12 +358,16 @@ export async function selectOptionViaPlaywright(opts: {
   const page = await getRestoredPageForTarget(opts);
   const label = resolved.ref ?? resolved.selector ?? '';
   const locator = resolveLocator(page, resolved);
+  const previousUrl = page.url();
 
   try {
-    await locator.selectOption(opts.values, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
-    await assertPostInteractionNavigationSafe({
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        await locator.selectOption(opts.values, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
+      },
       cdpUrl: opts.cdpUrl,
       page,
+      previousUrl,
       ssrfPolicy: opts.ssrfPolicy,
       targetId: opts.targetId,
     });
@@ -359,12 +393,16 @@ export async function dragViaPlaywright(opts: {
   const endLocator = resolveLocator(page, resolvedEnd);
   const startLabel = resolvedStart.ref ?? resolvedStart.selector ?? '';
   const endLabel = resolvedEnd.ref ?? resolvedEnd.selector ?? '';
+  const previousUrl = page.url();
 
   try {
-    await startLocator.dragTo(endLocator, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
-    await assertPostInteractionNavigationSafe({
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        await startLocator.dragTo(endLocator, { timeout: resolveInteractionTimeoutMs(opts.timeoutMs) });
+      },
       cdpUrl: opts.cdpUrl,
       page,
+      previousUrl,
       ssrfPolicy: opts.ssrfPolicy,
       targetId: opts.targetId,
     });
@@ -517,8 +555,13 @@ export async function armDialogViaPlaywright(opts: {
   accept: boolean;
   promptText?: string;
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   const state = ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
@@ -554,8 +597,13 @@ export async function armFileUploadViaPlaywright(opts: {
   targetId?: string;
   paths?: string[];
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   const state = ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);

--- a/src/actions/keyboard.ts
+++ b/src/actions/keyboard.ts
@@ -1,7 +1,7 @@
 import { getPageForTargetId, ensurePageState } from '../connection.js';
 import type { SsrfPolicy } from '../types.js';
 
-import { assertPostInteractionNavigationSafe } from './navigation.js';
+import { assertInteractionNavigationCompletedSafely } from './navigation.js';
 
 export async function pressKeyViaPlaywright(opts: {
   cdpUrl: string;
@@ -12,12 +12,20 @@ export async function pressKeyViaPlaywright(opts: {
 }): Promise<void> {
   const key = opts.key.trim();
   if (!key) throw new Error('key is required');
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
-  await page.keyboard.press(key, { delay: Math.max(0, Math.floor(opts.delayMs ?? 0)) });
-  await assertPostInteractionNavigationSafe({
+  const previousUrl = page.url();
+  await assertInteractionNavigationCompletedSafely({
+    action: async () => {
+      await page.keyboard.press(key, { delay: Math.max(0, Math.floor(opts.delayMs ?? 0)) });
+    },
     cdpUrl: opts.cdpUrl,
     page,
+    previousUrl,
     ssrfPolicy: opts.ssrfPolicy,
     targetId: opts.targetId,
   });

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,4 +1,4 @@
-import type { Browser, BrowserContext, Page, Route, Request } from 'playwright-core';
+import type { Browser, BrowserContext, Page, Route, Request, Frame } from 'playwright-core';
 
 import {
   BrowserTabNotFoundError,
@@ -76,6 +76,26 @@ function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
   }
 }
 
+function isSubframeDocumentNavigationRequest(page: Page, request: Request): boolean {
+  let sameMainFrame = false;
+  try {
+    sameMainFrame = request.frame() === page.mainFrame();
+  } catch {
+    return true;
+  }
+  if (sameMainFrame) return false;
+  try {
+    if (request.isNavigationRequest()) return true;
+  } catch {
+    /* fall through to resourceType check */
+  }
+  try {
+    return request.resourceType() === 'document';
+  } catch {
+    return false;
+  }
+}
+
 async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page; targetId?: string }): Promise<void> {
   markPageRefBlocked(opts.cdpUrl, opts.page);
   const resolvedTargetId = await pageTargetId(opts.page).catch(() => null);
@@ -105,27 +125,272 @@ export async function assertPageNavigationCompletedSafely(opts: {
   }
 }
 
-/**
- * Post-interaction navigation safety check. Call after any interaction that
- * could trigger navigation (click, type-submit, press) — validates the final
- * page URL against the SSRF policy and closes the tab if blocked.
- *
- * No-op if no policy is provided.
- */
-export async function assertPostInteractionNavigationSafe(opts: {
+// ── Interaction-time navigation guard ──────────────────────────────
+
+const INTERACTION_NAVIGATION_GRACE_MS = 250;
+const pendingInteractionNavigationGuardCleanup = new WeakMap<Page, () => void>();
+
+function didCrossDocumentUrlChange(page: Page, previousUrl: string): boolean {
+  const currentUrl = page.url();
+  if (currentUrl === previousUrl) return false;
+  try {
+    const prev = new URL(previousUrl);
+    const curr = new URL(currentUrl);
+    if (prev.origin === curr.origin && prev.pathname === curr.pathname && prev.search === curr.search) return false;
+  } catch {
+    /* invalid URLs — treat as cross-document */
+  }
+  return true;
+}
+
+function isHashOnlyNavigation(currentUrl: string, previousUrl: string): boolean {
+  if (currentUrl === previousUrl) return false;
+  try {
+    const prev = new URL(previousUrl);
+    const curr = new URL(currentUrl);
+    return prev.origin === curr.origin && prev.pathname === curr.pathname && prev.search === curr.search;
+  } catch {
+    return false;
+  }
+}
+
+function isMainFrameNavigation(page: Page, frame: Frame): boolean {
+  if (typeof page.mainFrame !== 'function') return true;
+  return frame === page.mainFrame();
+}
+
+async function assertSubframeNavigationAllowed(frameUrl: string, ssrfPolicy?: SsrfPolicy): Promise<void> {
+  if (!ssrfPolicy) return;
+  if (!frameUrl.startsWith('http://') && !frameUrl.startsWith('https://')) return;
+  await assertBrowserNavigationResultAllowed({ url: frameUrl, ...withBrowserNavigationPolicy(ssrfPolicy) });
+}
+
+function snapshotNetworkFrameUrl(frame: Frame): string | null {
+  try {
+    const frameUrl = frame.url();
+    return frameUrl.startsWith('http://') || frameUrl.startsWith('https://') ? frameUrl : null;
+  } catch {
+    return null;
+  }
+}
+
+interface ObservedNavigations {
+  mainFrameNavigated: boolean;
+  subframes: string[];
+}
+
+function formatThrown(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return 'unknown error';
+}
+
+async function assertObservedDelayedNavigations(opts: {
   cdpUrl: string;
   page: Page;
   ssrfPolicy?: SsrfPolicy;
   targetId?: string;
+  observed: ObservedNavigations;
 }): Promise<void> {
-  if (!opts.ssrfPolicy) return;
-  await assertPageNavigationCompletedSafely({
-    cdpUrl: opts.cdpUrl,
-    page: opts.page,
-    response: null,
-    ssrfPolicy: opts.ssrfPolicy,
-    targetId: opts.targetId,
+  let subframeError: Error | undefined;
+  try {
+    for (const frameUrl of opts.observed.subframes) await assertSubframeNavigationAllowed(frameUrl, opts.ssrfPolicy);
+  } catch (err) {
+    subframeError = err instanceof Error ? err : new Error(formatThrown(err));
+  }
+  if (opts.observed.mainFrameNavigated) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
+  if (subframeError !== undefined) throw subframeError;
+}
+
+function observeDelayedInteractionNavigation(page: Page, previousUrl: string): Promise<ObservedNavigations> {
+  if (didCrossDocumentUrlChange(page, previousUrl)) {
+    return Promise.resolve({ mainFrameNavigated: true, subframes: [] });
+  }
+  if (typeof page.on !== 'function' || typeof page.off !== 'function') {
+    return Promise.resolve({ mainFrameNavigated: false, subframes: [] });
+  }
+  return new Promise((resolve) => {
+    const subframes: string[] = [];
+    const timer: { id: ReturnType<typeof setTimeout> | undefined } = { id: undefined };
+    const cleanup = (): void => {
+      if (timer.id !== undefined) clearTimeout(timer.id);
+      page.off('framenavigated', onFrameNavigated);
+    };
+    const onFrameNavigated = (frame: Frame): void => {
+      if (!isMainFrameNavigation(page, frame)) {
+        const frameUrl = snapshotNetworkFrameUrl(frame);
+        if (frameUrl !== null) subframes.push(frameUrl);
+        return;
+      }
+      if (isHashOnlyNavigation(page.url(), previousUrl)) return;
+      cleanup();
+      resolve({ mainFrameNavigated: true, subframes });
+    };
+    timer.id = setTimeout(() => {
+      cleanup();
+      resolve({ mainFrameNavigated: didCrossDocumentUrlChange(page, previousUrl), subframes });
+    }, INTERACTION_NAVIGATION_GRACE_MS);
+    page.on('framenavigated', onFrameNavigated);
   });
+}
+
+function scheduleDelayedInteractionNavigationGuard(opts: {
+  cdpUrl: string;
+  page: Page;
+  previousUrl: string;
+  ssrfPolicy?: SsrfPolicy;
+  targetId?: string;
+}): Promise<void> {
+  if (!opts.ssrfPolicy) return Promise.resolve();
+  const page = opts.page;
+  if (didCrossDocumentUrlChange(page, opts.previousUrl)) {
+    return assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
+  if (typeof page.on !== 'function' || typeof page.off !== 'function') return Promise.resolve();
+  // Cancels overlap when two interactions race on the same page (Promise.all).
+  pendingInteractionNavigationGuardCleanup.get(opts.page)?.();
+  return new Promise<void>((resolve, reject) => {
+    const subframes: string[] = [];
+    const timer: { id: ReturnType<typeof setTimeout> | undefined } = { id: undefined };
+    const settle = (err?: unknown): void => {
+      cleanup();
+      if (err !== undefined) {
+        reject(err instanceof Error ? err : new Error(formatThrown(err)));
+        return;
+      }
+      resolve();
+    };
+    const cleanup = (): void => {
+      if (timer.id !== undefined) clearTimeout(timer.id);
+      page.off('framenavigated', onFrameNavigated);
+      if (pendingInteractionNavigationGuardCleanup.get(opts.page) === settle) {
+        pendingInteractionNavigationGuardCleanup.delete(opts.page);
+      }
+    };
+    const onFrameNavigated = (frame: Frame): void => {
+      if (!isMainFrameNavigation(page, frame)) {
+        const frameUrl = snapshotNetworkFrameUrl(frame);
+        if (frameUrl !== null) subframes.push(frameUrl);
+        return;
+      }
+      if (isHashOnlyNavigation(page.url(), opts.previousUrl)) return;
+      cleanup();
+      assertObservedDelayedNavigations({
+        cdpUrl: opts.cdpUrl,
+        page: opts.page,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+        observed: { mainFrameNavigated: true, subframes },
+      }).then(() => {
+        settle();
+      }, settle);
+    };
+    timer.id = setTimeout(() => {
+      cleanup();
+      assertObservedDelayedNavigations({
+        cdpUrl: opts.cdpUrl,
+        page: opts.page,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+        observed: {
+          mainFrameNavigated: didCrossDocumentUrlChange(page, opts.previousUrl),
+          subframes,
+        },
+      }).then(() => {
+        settle();
+      }, settle);
+    }, INTERACTION_NAVIGATION_GRACE_MS);
+    pendingInteractionNavigationGuardCleanup.set(opts.page, settle);
+    page.on('framenavigated', onFrameNavigated);
+  });
+}
+
+export async function assertInteractionNavigationCompletedSafely<T>(opts: {
+  action: () => Promise<T>;
+  cdpUrl: string;
+  page: Page;
+  previousUrl: string;
+  ssrfPolicy?: SsrfPolicy;
+  targetId?: string;
+}): Promise<T> {
+  if (!opts.ssrfPolicy) return await opts.action();
+  const navPage = opts.page;
+  const navState: { observed: boolean } = { observed: false };
+  const subframeNavigationsDuringAction: string[] = [];
+  const onFrameNavigated = (frame: Frame): void => {
+    if (!isMainFrameNavigation(navPage, frame)) {
+      const frameUrl = snapshotNetworkFrameUrl(frame);
+      if (frameUrl !== null) subframeNavigationsDuringAction.push(frameUrl);
+      return;
+    }
+    if (!isHashOnlyNavigation(opts.page.url(), opts.previousUrl)) navState.observed = true;
+  };
+  if (typeof navPage.on === 'function') navPage.on('framenavigated', onFrameNavigated);
+  let result: T | undefined;
+  let actionError: Error | undefined;
+  try {
+    result = await opts.action();
+  } catch (err) {
+    actionError = err instanceof Error ? err : new Error(formatThrown(err));
+  } finally {
+    if (typeof navPage.off === 'function') navPage.off('framenavigated', onFrameNavigated);
+  }
+  const navigationObserved = navState.observed || didCrossDocumentUrlChange(opts.page, opts.previousUrl);
+  let subframeError: Error | undefined;
+  try {
+    for (const frameUrl of subframeNavigationsDuringAction) {
+      await assertSubframeNavigationAllowed(frameUrl, opts.ssrfPolicy);
+    }
+  } catch (err) {
+    subframeError = err instanceof Error ? err : new Error(formatThrown(err));
+  }
+  if (navigationObserved) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  } else if (actionError !== undefined) {
+    const observed = await observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
+    if (observed.mainFrameNavigated || observed.subframes.length > 0) {
+      await assertObservedDelayedNavigations({
+        cdpUrl: opts.cdpUrl,
+        page: opts.page,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+        observed,
+      });
+    }
+  } else {
+    await scheduleDelayedInteractionNavigationGuard({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      previousUrl: opts.previousUrl,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
+  // Precedence: SSRF block > action error. The security signal wins.
+  if (subframeError !== undefined) throw subframeError;
+  if (actionError !== undefined) throw actionError;
+  return result as T;
 }
 
 async function gotoPageWithNavigationGuard(opts: {
@@ -145,23 +410,33 @@ async function gotoPageWithNavigationGuard(opts: {
       });
       return;
     }
-    if (!isTopLevelNavigationRequest(opts.page, request)) {
+    const isTopLevel = isTopLevelNavigationRequest(opts.page, request);
+    const isSubframeDocument = !isTopLevel && isSubframeDocumentNavigationRequest(opts.page, request);
+    if (!isTopLevel && !isSubframeDocument) {
       await route.continue();
       return;
     }
-    // Only guard navigations initiated by this call:
-    // - initial request must match our target URL
-    // - redirects (redirectedFrom !== null) are always checked since they may be part of our chain
-    const isRedirect = request.redirectedFrom() !== null;
-    if (!isRedirect && request.url() !== opts.url) {
-      await route.continue();
-      return;
+    if (isTopLevel) {
+      // Only guard top-level navigations initiated by this call:
+      // - initial request must match our target URL
+      // - redirects (redirectedFrom !== null) are always checked since they may be part of our chain
+      const isRedirect = request.redirectedFrom() !== null;
+      if (!isRedirect && request.url() !== opts.url) {
+        await route.continue();
+        return;
+      }
     }
     try {
       await assertBrowserNavigationAllowed({ url: request.url(), ...navigationPolicy });
     } catch (err) {
       if (isPolicyDenyNavigationError(err)) {
-        state.blocked = err as Error;
+        if (isTopLevel) {
+          state.blocked = err as Error;
+        } else {
+          console.warn(
+            `[browserclaw] blocked subframe navigation to ${request.url()}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
         await route.abort().catch((e: unknown) => {
           console.warn('[browserclaw] route abort failed', e);
         });

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -65,6 +65,7 @@ import {
   setDialogHandler,
   getRestoredPageForTarget,
 } from './connection.js';
+import { assertCdpEndpointAllowed } from './security.js';
 import { snapshotAi } from './snapshot/ai-snapshot.js';
 import { snapshotRole, snapshotAria } from './snapshot/aria-snapshot.js';
 import {
@@ -606,6 +607,7 @@ export class CrawlPage {
       accept: opts.accept,
       promptText: opts.promptText,
       timeoutMs: opts.timeoutMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -673,6 +675,7 @@ export class CrawlPage {
       targetId: this._targetId,
       paths,
       timeoutMs: opts?.timeoutMs,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -844,6 +847,7 @@ export class CrawlPage {
       ref: opts?.ref,
       timeoutMs: opts?.timeoutMs,
       signal: opts?.signal,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -869,6 +873,7 @@ export class CrawlPage {
       cdpUrl: this.cdpUrl,
       targetId: this._targetId,
       fn,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -1474,6 +1479,7 @@ export class CrawlPage {
           cdpUrl: this.cdpUrl,
           targetId: this._targetId,
           fn: '() => { const b = document.body; return b ? b.innerText : ""; }',
+          ssrfPolicy: this.ssrfPolicy,
         });
         bodyText = typeof raw === 'string' ? raw : null;
       } catch (err) {
@@ -1551,6 +1557,7 @@ export class CrawlPage {
             cdpUrl: this.cdpUrl,
             targetId: this._targetId,
             fn: rule.fn,
+            ssrfPolicy: this.ssrfPolicy,
           });
           const passed = result !== null && result !== undefined && result !== false && result !== 0 && result !== '';
           checks.push({
@@ -1705,13 +1712,14 @@ export class BrowserClaw {
       const ssrfPolicy =
         opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
       /* eslint-enable @typescript-eslint/no-deprecated */
+      // Bootstrap connect to our own freshly-spawned loopback Chrome — no policy check.
+      await connectBrowser(cdpUrl, undefined);
       const telemetry: RunTelemetry = {
         launchMs: chrome.launchMs,
         timestamps: { startedAt, launchedAt: new Date().toISOString() },
       };
       const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo);
       if (opts.url !== undefined && opts.url !== '') {
-        // connectBrowser is called lazily inside currentPage → connectBrowser; connectMs is recorded there
         const page = await browser.currentPage();
         const navT0 = Date.now();
         await page.goto(opts.url);
@@ -1754,14 +1762,17 @@ export class BrowserClaw {
       }
       resolvedUrl = discovered;
     }
-    if (!(await isChromeReachable(resolvedUrl, 3000, opts?.authToken))) {
-      throw new Error(`Cannot connect to Chrome at ${resolvedUrl}. Is Chrome running with --remote-debugging-port?`);
-    }
-    await connectBrowser(resolvedUrl, opts?.authToken);
     /* eslint-disable @typescript-eslint/no-deprecated -- backward-compat bridge for allowInternal */
     const ssrfPolicy =
       opts?.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts?.ssrfPolicy;
     /* eslint-enable @typescript-eslint/no-deprecated */
+    // Surface SSRF policy errors with the right error type rather than letting
+    // isChromeReachable swallow them and report the generic "Cannot connect".
+    await assertCdpEndpointAllowed(resolvedUrl, ssrfPolicy);
+    if (!(await isChromeReachable(resolvedUrl, 3000, opts?.authToken, ssrfPolicy))) {
+      throw new Error(`Cannot connect to Chrome at ${resolvedUrl}. Is Chrome running with --remote-debugging-port?`);
+    }
+    await connectBrowser(resolvedUrl, opts?.authToken, ssrfPolicy);
     const telemetry: RunTelemetry = {
       connectMs: Date.now() - connectT0,
       timestamps: { startedAt, connectedAt: new Date().toISOString() },

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -4,7 +4,8 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
-import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome } from './types.js';
+import { assertCdpEndpointAllowed } from './security.js';
+import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome, SsrfPolicy } from './types.js';
 
 // ── Process Tree Kill ──
 
@@ -661,7 +662,13 @@ async function fetchChromeVersion(
   cdpUrl: string,
   timeoutMs = 500,
   authToken?: string,
+  ssrfPolicy?: SsrfPolicy,
 ): Promise<Record<string, unknown> | null> {
+  try {
+    await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
+  } catch {
+    return null;
+  }
   const ctrl = new AbortController();
   const t = setTimeout(() => {
     ctrl.abort();
@@ -694,9 +701,19 @@ export async function discoverChromeCdpUrl(timeoutMs = 500): Promise<string | nu
   return results.find((url) => url !== null) ?? null;
 }
 
-export async function isChromeReachable(cdpUrl: string, timeoutMs = 500, authToken?: string): Promise<boolean> {
+export async function isChromeReachable(
+  cdpUrl: string,
+  timeoutMs = 500,
+  authToken?: string,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<boolean> {
+  try {
+    await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
+  } catch {
+    return false;
+  }
   if (isWebSocketUrl(cdpUrl)) return await canOpenWebSocket(cdpUrl, timeoutMs);
-  const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken);
+  const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken, ssrfPolicy);
   return version !== null;
 }
 
@@ -704,17 +721,26 @@ export async function getChromeWebSocketUrl(
   cdpUrl: string,
   timeoutMs = 500,
   authToken?: string,
+  ssrfPolicy?: SsrfPolicy,
 ): Promise<string | null> {
+  await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
   if (isWebSocketUrl(cdpUrl)) return cdpUrl;
-  const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken);
+  const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken, ssrfPolicy);
   const rawWsUrl = version?.webSocketDebuggerUrl;
   const wsUrl = typeof rawWsUrl === 'string' ? rawWsUrl.trim() : '';
   if (wsUrl === '') return null;
-  return normalizeCdpWsUrl(wsUrl, cdpUrl);
+  const normalized = normalizeCdpWsUrl(wsUrl, cdpUrl);
+  await assertCdpEndpointAllowed(normalized, ssrfPolicy);
+  return normalized;
 }
 
-export async function isChromeCdpReady(cdpUrl: string, timeoutMs = 500, handshakeTimeoutMs = 800): Promise<boolean> {
-  const wsUrl = await getChromeWebSocketUrl(cdpUrl, timeoutMs);
+export async function isChromeCdpReady(
+  cdpUrl: string,
+  timeoutMs = 500,
+  handshakeTimeoutMs = 800,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<boolean> {
+  const wsUrl = await getChromeWebSocketUrl(cdpUrl, timeoutMs, undefined, ssrfPolicy).catch(() => null);
   if (wsUrl === null) return false;
   return await canRunCdpHealthCommand(wsUrl, handshakeTimeoutMs);
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -13,7 +13,8 @@ import {
 } from './chrome-launcher.js';
 import { ensurePageState, observeBrowser, setDialogHandlerOnPage } from './page-utils.js';
 import { clearRoleRefsForCdpUrl, normalizeCdpUrl } from './ref-resolver.js';
-import type { DialogHandler } from './types.js';
+import { assertCdpEndpointAllowed } from './security.js';
+import type { DialogHandler, SsrfPolicy } from './types.js';
 
 // Re-export everything from sub-modules so existing `import … from './connection.js'`
 // paths keep working. When adding a public function to page-utils or ref-resolver,
@@ -260,6 +261,10 @@ interface CachedConnection {
 
 const cachedByCdpUrl = new Map<string, CachedConnection>();
 const connectingByCdpUrl = new Map<string, Promise<CachedConnection>>();
+// Remembered per-URL so reconnects re-run assertCdpEndpointAllowed even when
+// the action function chain doesn't thread a policy through. Closes the
+// DNS-rebinding window between connect attempts.
+const lastPolicyByCdpUrl = new Map<string, SsrfPolicy>();
 
 // ── Connection Mutex ──
 // Serializes connect/disconnect operations to prevent races where a disconnect
@@ -388,11 +393,19 @@ export async function setDialogHandler(opts: {
 
 // ── Connect to Browser ──
 
-export async function connectBrowser(cdpUrl: string, authToken?: string): Promise<CachedConnection> {
+export async function connectBrowser(
+  cdpUrl: string,
+  authToken?: string,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<CachedConnection> {
   const normalized = normalizeCdpUrl(cdpUrl);
   // Lock-free fast path: return cached connection
   const existing_cached = cachedByCdpUrl.get(normalized);
   if (existing_cached) return existing_cached;
+
+  if (ssrfPolicy !== undefined) lastPolicyByCdpUrl.set(normalized, ssrfPolicy);
+  const effectivePolicy = ssrfPolicy ?? lastPolicyByCdpUrl.get(normalized);
+  await assertCdpEndpointAllowed(normalized, effectivePolicy);
 
   const existing = connectingByCdpUrl.get(normalized);
   if (existing) return await existing;
@@ -411,7 +424,8 @@ export async function connectBrowser(cdpUrl: string, authToken?: string): Promis
         try {
           const timeout = 5000 + attempt * 2000;
           const endpoint =
-            (await getChromeWebSocketUrl(normalized, timeout, authToken).catch(() => null)) ?? normalized;
+            (await getChromeWebSocketUrl(normalized, timeout, authToken, effectivePolicy).catch(() => null)) ??
+            normalized;
           const headers: Record<string, string> = getHeadersWithAuth(endpoint);
           if (authToken !== undefined && authToken !== '' && !headers.Authorization)
             headers.Authorization = `Bearer ${authToken}`;
@@ -472,6 +486,7 @@ export async function disconnectBrowser(): Promise<void> {
       });
     }
     cachedByCdpUrl.clear();
+    lastPolicyByCdpUrl.clear();
     clearBlockedTargetsForCdpUrl();
     clearBlockedPageRefsForCdpUrl();
   });
@@ -491,6 +506,7 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
       const cur = cachedByCdpUrl.get(normalized);
       cachedByCdpUrl.delete(normalized);
       connectingByCdpUrl.delete(normalized);
+      lastPolicyByCdpUrl.delete(normalized);
       if (!cur) return;
       if (cur.onDisconnected && typeof cur.browser.off === 'function')
         cur.browser.off('disconnected', cur.onDisconnected);
@@ -699,7 +715,13 @@ function matchPageByTargetList(pages: Page[], targets: CdpTarget[], targetId: st
   return null;
 }
 
-async function findPageByTargetIdViaTargetList(pages: Page[], targetId: string, cdpUrl: string): Promise<Page | null> {
+async function findPageByTargetIdViaTargetList(
+  pages: Page[],
+  targetId: string,
+  cdpUrl: string,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<Page | null> {
+  await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
   const targets = await fetchJsonForCdp(
     appendCdpPath(normalizeCdpHttpBaseForJsonEndpoints(cdpUrl), '/json/list'),
     2000,
@@ -708,7 +730,7 @@ async function findPageByTargetIdViaTargetList(pages: Page[], targetId: string, 
   return matchPageByTargetList(pages, targets as CdpTarget[], targetId);
 }
 
-export async function findPageByTargetId(browser: Browser, targetId: string, cdpUrl?: string) {
+export async function findPageByTargetId(browser: Browser, targetId: string, cdpUrl?: string, ssrfPolicy?: SsrfPolicy) {
   const pages = getAllPages(browser);
 
   const results = await Promise.all(
@@ -727,7 +749,7 @@ export async function findPageByTargetId(browser: Browser, targetId: string, cdp
 
   if (cdpUrl !== undefined && cdpUrl !== '') {
     try {
-      return await findPageByTargetIdViaTargetList(pages, targetId, cdpUrl);
+      return await findPageByTargetIdViaTargetList(pages, targetId, cdpUrl, ssrfPolicy);
     } catch {}
   }
 
@@ -763,10 +785,10 @@ async function partitionAccessiblePages(opts: {
   return { accessible, blockedCount };
 }
 
-export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string }) {
+export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
   if (opts.targetId !== undefined && opts.targetId !== '' && isBlockedTarget(opts.cdpUrl, opts.targetId))
     throw new BlockedBrowserTargetError();
-  const { browser } = await connectBrowser(opts.cdpUrl);
+  const { browser } = await connectBrowser(opts.cdpUrl, undefined, opts.ssrfPolicy);
   const pages = getAllPages(browser);
   if (!pages.length) throw new Error('No pages available in the connected browser.');
   const { accessible, blockedCount } = await partitionAccessiblePages({ cdpUrl: opts.cdpUrl, pages });
@@ -776,7 +798,7 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
   }
   const first = accessible[0];
   if (opts.targetId === undefined || opts.targetId === '') return first;
-  const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
+  const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl, opts.ssrfPolicy);
   if (!found) {
     throw new BrowserTabNotFoundError(
       `Tab not found (targetId: ${opts.targetId}). Call browser.tabs() to list open tabs.`,
@@ -792,9 +814,13 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
 /**
  * Resolve a page by targetId or throw BrowserTabNotFoundError.
  */
-export async function resolvePageByTargetIdOrThrow(opts: { cdpUrl: string; targetId: string }): Promise<Page> {
-  const { browser } = await connectBrowser(opts.cdpUrl);
-  const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
+export async function resolvePageByTargetIdOrThrow(opts: {
+  cdpUrl: string;
+  targetId: string;
+  ssrfPolicy?: SsrfPolicy;
+}): Promise<Page> {
+  const { browser } = await connectBrowser(opts.cdpUrl, undefined, opts.ssrfPolicy);
+  const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl, opts.ssrfPolicy);
   if (!page) throw new BrowserTabNotFoundError();
   return page;
 }
@@ -802,7 +828,11 @@ export async function resolvePageByTargetIdOrThrow(opts: { cdpUrl: string; targe
 /**
  * Get a page for a target, ensuring page state is initialized.
  */
-export async function getRestoredPageForTarget(opts: { cdpUrl: string; targetId?: string }): Promise<Page> {
+export async function getRestoredPageForTarget(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  ssrfPolicy?: SsrfPolicy;
+}): Promise<Page> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   return page;

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -10,6 +10,8 @@ import {
   createPinnedLookup,
   resolvePinnedHostnameWithPolicy,
   assertBrowserNavigationAllowed,
+  assertCdpEndpointAllowed,
+  BrowserCdpEndpointBlockedError,
   assertSafeOutputPath,
   assertSafeUploadPaths,
   resolveStrictExistingUploadPaths,
@@ -1664,6 +1666,71 @@ describe('security.ts', () => {
           },
         }),
       ).rejects.toThrow('outside the allowed root');
+    });
+  });
+
+  describe('assertCdpEndpointAllowed', () => {
+    it('is a no-op when no policy is provided', async () => {
+      await expect(assertCdpEndpointAllowed('http://localhost:9222')).resolves.toBeUndefined();
+      await expect(assertCdpEndpointAllowed('http://169.254.169.254/')).resolves.toBeUndefined();
+    });
+
+    it('is a no-op when policy is undefined explicitly', async () => {
+      await expect(assertCdpEndpointAllowed('http://localhost:9222', undefined)).resolves.toBeUndefined();
+    });
+
+    it('blocks loopback hostnames under a strict policy', async () => {
+      await expect(assertCdpEndpointAllowed('http://localhost:9222', {})).rejects.toThrow(
+        BrowserCdpEndpointBlockedError,
+      );
+    });
+
+    it('allows loopback when dangerouslyAllowPrivateNetwork is true', async () => {
+      await expect(
+        assertCdpEndpointAllowed('http://127.0.0.1:9222', { dangerouslyAllowPrivateNetwork: true }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('allows ws:// loopback when dangerouslyAllowPrivateNetwork is true', async () => {
+      await expect(
+        assertCdpEndpointAllowed('ws://127.0.0.1:9222/devtools/browser/abc', {
+          dangerouslyAllowPrivateNetwork: true,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects unsupported protocols even with permissive policy', async () => {
+      await expect(
+        assertCdpEndpointAllowed('file:///tmp/cdp.sock', { dangerouslyAllowPrivateNetwork: true }),
+      ).rejects.toThrow(BrowserCdpEndpointBlockedError);
+      await expect(
+        assertCdpEndpointAllowed('javascript:alert(1)', { dangerouslyAllowPrivateNetwork: true }),
+      ).rejects.toThrow(/protocol/);
+    });
+
+    it('rejects malformed URLs with a clear error', async () => {
+      await expect(assertCdpEndpointAllowed('not a url', {})).rejects.toThrow(BrowserCdpEndpointBlockedError);
+      await expect(assertCdpEndpointAllowed('not a url', {})).rejects.toThrow(/invalid URL/);
+    });
+
+    it('error message points users at the dangerouslyAllowPrivateNetwork fix', async () => {
+      try {
+        await assertCdpEndpointAllowed('http://localhost:9222', {});
+        expect.fail('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BrowserCdpEndpointBlockedError);
+        expect((err as Error).message).toContain('dangerouslyAllowPrivateNetwork');
+      }
+    });
+
+    it('preserves the underlying error as cause', async () => {
+      try {
+        await assertCdpEndpointAllowed('http://localhost:9222', {});
+        expect.fail('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BrowserCdpEndpointBlockedError);
+        expect((err as { cause?: unknown }).cause).toBeDefined();
+      }
     });
   });
 });

--- a/src/security.ts
+++ b/src/security.ts
@@ -52,6 +52,45 @@ export class InvalidBrowserNavigationUrlError extends Error {
   }
 }
 
+/** Thrown when the CDP endpoint URL is blocked by the configured SSRF policy. */
+export class BrowserCdpEndpointBlockedError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = 'BrowserCdpEndpointBlockedError';
+    if (options?.cause !== undefined) (this as { cause?: unknown }).cause = options.cause;
+  }
+}
+
+/**
+ * Validate a CDP endpoint URL against an SSRF policy. No-op without a policy.
+ * Connecting to local Chrome with a strict policy requires `dangerouslyAllowPrivateNetwork: true`.
+ */
+export async function assertCdpEndpointAllowed(cdpUrl: string, ssrfPolicy?: SsrfPolicy): Promise<void> {
+  if (!ssrfPolicy) return;
+  let parsed: URL;
+  try {
+    parsed = new URL(cdpUrl);
+  } catch {
+    throw new BrowserCdpEndpointBlockedError(`CDP endpoint blocked: invalid URL "${cdpUrl}"`);
+  }
+  const allowedProtocols = new Set(['http:', 'https:', 'ws:', 'wss:']);
+  if (!allowedProtocols.has(parsed.protocol)) {
+    throw new BrowserCdpEndpointBlockedError(
+      `CDP endpoint blocked: protocol "${parsed.protocol.replace(':', '')}" is not allowed (use http/https/ws/wss)`,
+    );
+  }
+  try {
+    await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy: ssrfPolicy });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new BrowserCdpEndpointBlockedError(
+      `CDP endpoint "${parsed.hostname}" blocked by SSRF policy: ${reason}. ` +
+        `If connecting to local Chrome, set ssrfPolicy.dangerouslyAllowPrivateNetwork = true.`,
+      { cause: error },
+    );
+  }
+}
+
 /** Options for browser navigation SSRF policy. */
 export interface BrowserNavigationPolicyOptions {
   ssrfPolicy?: SsrfPolicy;


### PR DESCRIPTION
## Summary

Major refactor of the post-interaction SSRF check, ported from OpenClaw 2026.4.10. The simple `assertPostInteractionNavigationSafe` (added in 0.12.5 yesterday) is replaced by a new delayed-navigation-aware system: `assertInteractionNavigationCompletedSafely<T>(opts)` that **wraps** the action call instead of being called after, listens to `framenavigated` events DURING the action, and validates main-frame and subframe navigation after.

Also ports the new CDP-endpoint SSRF check from the same OpenClaw release, and closes a DNS-rebinding gap that exists in OC's threading model.

### Why it matters

The simple post-check from yesterday closed the post-click SSRF window for synchronous navigation. This refactor closes four additional windows:

1. **Delayed JS navigation** — `setTimeout(() => location = '...', 100)` after a click is now caught by a 250ms grace-period guard
2. **Subframe navigation** — iframe loads pointing to internal URLs are now blocked during goto and validated after interactions
3. **Hash-only navigation filtering** — `#anchor` changes are correctly skipped, removing false-positive blocks
4. **DNS rebinding on reconnect** — `connectBrowser` now remembers the SSRF policy used to validate a CDP URL the first time and re-applies it on subsequent connects, even when the calling action function doesn't thread a policy through. Closes a gap where a connection drop could let an attacker swap the resolved IP between connect attempts

It also adds **pending-guard cleanup**: back-to-back interactions on the same page cancel any in-flight grace-period guard so they don't fire stale checks.

## Changes

### New helpers in `src/actions/navigation.ts` (~290 LOC)

`assertInteractionNavigationCompletedSafely<T>` (the main entry point) plus 11 supporting helpers (`didCrossDocumentUrlChange`, `isHashOnlyNavigation`, `isMainFrameNavigation`, `assertSubframeNavigationAllowed`, `snapshotNetworkFrameUrl`, `assertObservedDelayedNavigations`, `observeDelayedInteractionNavigation`, `scheduleDelayedInteractionNavigationGuard`, `isSubframeDocumentNavigationRequest`, `INTERACTION_NAVIGATION_GRACE_MS`, `pendingInteractionNavigationGuardCleanup`).

### Updated `gotoPageWithNavigationGuard`
Now also validates subframe document loads. Top-level blocks fail the goto (existing behavior); subframe blocks are silently aborted (new — matches OC).

### CDP-endpoint SSRF check (`src/security.ts`)

- New `BrowserCdpEndpointBlockedError` class
- New `assertCdpEndpointAllowed(cdpUrl, ssrfPolicy?)` helper
- Error messages explicitly point users at `dangerouslyAllowPrivateNetwork: true` for the local-Chrome case
- 9 unit tests covering: no-policy no-op, loopback blocking, `dangerouslyAllowPrivateNetwork` opt-in, ws:// support, unsupported protocol rejection, malformed URL handling, error message content, and `cause` chaining

### Threading + DNS-rebinding fix (`src/connection.ts`)

- `connectBrowser(cdpUrl, authToken?, ssrfPolicy?)` now calls `assertCdpEndpointAllowed` on cache miss
- New `lastPolicyByCdpUrl` map: when `connectBrowser` is called with a policy, it's remembered. Subsequent calls without an explicit policy fall back to the remembered one
- This means a connection drop + reconnect re-runs the SSRF check with the original policy, even when the calling action function doesn't thread a policy through
- Cleared on `disconnectBrowser()` and `closePlaywrightBrowserConnection({ cdpUrl })`
- `findPageByTargetIdViaTargetList`, `findPageByTargetId`, `getPageForTargetId`, `resolvePageByTargetIdOrThrow`, `getRestoredPageForTarget` all gain optional `ssrfPolicy`

### Chrome launcher (`src/chrome-launcher.ts`)

`isChromeReachable`, `getChromeWebSocketUrl`, `isChromeCdpReady`, `fetchChromeVersion` all gain `ssrfPolicy?` and call `assertCdpEndpointAllowed` before any HTTP/WS request. `getChromeWebSocketUrl` re-validates the resolved WS URL too (defense in depth — the WS URL might point to a different host than the original CDP URL).

### Entry-point validation (`src/browser.ts`)

- `BrowserClaw.launch` calls `connectBrowser(cdpUrl, undefined, ssrfPolicy)` explicitly so the URL is validated at entry
- `BrowserClaw.connect` calls `assertCdpEndpointAllowed` directly before `isChromeReachable` so SSRF errors surface with `BrowserCdpEndpointBlockedError` instead of being swallowed into the misleading "Cannot connect to Chrome" message
- `CrawlPage.evaluate` and the two internal `isAuthenticated` evaluate calls forward `this.ssrfPolicy`

### Replaces 9 call sites of the old simple check

| Function | File | Branch wrapped |
|----------|------|----------------|
| `clickViaPlaywright` | interaction.ts | full click sequence (incl. checkable-role fallback) |
| `mouseClickViaPlaywright` | interaction.ts | mouse.click |
| `pressAndHoldViaCdp` | interaction.ts | full CDP send sequence |
| `clickByTextViaPlaywright` | interaction.ts | locator.click |
| `clickByRoleViaPlaywright` | interaction.ts | locator.click |
| `typeViaPlaywright` (submit) | interaction.ts | press('Enter') |
| `selectOptionViaPlaywright` | interaction.ts | selectOption |
| `dragViaPlaywright` | interaction.ts | dragTo |
| `pressKeyViaPlaywright` | keyboard.ts | keyboard.press |
| `evaluateViaPlaywright` | evaluate.ts | both ref and page eval branches |

### Behavior change to flag

Users who pass an `ssrfPolicy` AND connect to local Chrome (`localhost:9222`) without setting `dangerouslyAllowPrivateNetwork: true` will now get `BrowserCdpEndpointBlockedError` at connect time. Previously browserclaw silently allowed it. This matches the OpenClaw-intended behavior — strict policies should explicitly allow private network for local CDP. The error message points users at the fix.

### Bundle restructuring observed

OpenClaw shuffled bundles again: `client-fetch-*.js` is gone — content split across `chrome-By1kRNZR.js`, `cdp.helpers-WDYKRNDl.js`, `server-context-KfDEoq8U.js`, `pw-ai-CmXkxvEq.js`. The function map will need an update on a follow-up PR.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 1119/1119 passing (9 new `assertCdpEndpointAllowed` tests added)
- [x] `npm run build` — clean
- [x] `npm run check-exports` — 9 exports + 3 methods verified

No version bump (0.12.5 wasn't published yet).