### PR TITLE
Updates from OpenClaw 2026.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   assertBrowserNavigationResultAllowed,
   assertBrowserNavigationRedirectChainAllowed,
   requiresInspectableBrowserNavigationRedirects,
+  requiresInspectableBrowserNavigationRedirectsForUrl,
   sanitizeUntrustedFileName,
   createPinnedLookup,
   resolvePinnedHostnameWithPolicy,

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -24,6 +24,7 @@ import {
   assertBrowserNavigationResultAllowed,
   assertBrowserNavigationRedirectChainAllowed,
   requiresInspectableBrowserNavigationRedirects,
+  requiresInspectableBrowserNavigationRedirectsForUrl,
   withBrowserNavigationPolicy,
   InvalidBrowserNavigationUrlError,
   DEFAULT_BROWSER_TMP_DIR,
@@ -875,8 +876,8 @@ describe('security.ts', () => {
   // ────────────────────────────────────────────────
 
   describe('requiresInspectableBrowserNavigationRedirects', () => {
-    it('should return true when no policy is provided', () => {
-      expect(requiresInspectableBrowserNavigationRedirects()).toBe(true);
+    it('should return false when no policy is provided', () => {
+      expect(requiresInspectableBrowserNavigationRedirects()).toBe(false);
     });
 
     it('should return true with strict policy', () => {
@@ -889,6 +890,40 @@ describe('security.ts', () => {
 
     it('should return false with deprecated allowPrivateNetwork', () => {
       expect(requiresInspectableBrowserNavigationRedirects({ allowPrivateNetwork: true })).toBe(false);
+    });
+
+    it('should return false for policy without explicit dangerouslyAllowPrivateNetwork', () => {
+      expect(requiresInspectableBrowserNavigationRedirects({})).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // requiresInspectableBrowserNavigationRedirectsForUrl
+  // ────────────────────────────────────────────────
+
+  describe('requiresInspectableBrowserNavigationRedirectsForUrl', () => {
+    it('should return true for http URL with strict policy', () => {
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('http://example.com', STRICT_POLICY)).toBe(true);
+    });
+
+    it('should return true for https URL with strict policy', () => {
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('https://example.com', STRICT_POLICY)).toBe(true);
+    });
+
+    it('should return false for non-network protocols with strict policy', () => {
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('file:///etc/passwd', STRICT_POLICY)).toBe(false);
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('about:blank', STRICT_POLICY)).toBe(false);
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('data:text/plain,x', STRICT_POLICY)).toBe(false);
+    });
+
+    it('should return false when policy does not require inspection', () => {
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('http://example.com', PERMISSIVE_POLICY)).toBe(false);
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('http://example.com')).toBe(false);
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('http://example.com', {})).toBe(false);
+    });
+
+    it('should return false for invalid URLs', () => {
+      expect(requiresInspectableBrowserNavigationRedirectsForUrl('not a url', STRICT_POLICY)).toBe(false);
     });
   });
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -1000,7 +1000,22 @@ export async function assertBrowserNavigationRedirectChainAllowed(
 
 /**
  * Returns true if the SSRF policy requires redirect chain inspection.
+ * Strict inspection is required only when `dangerouslyAllowPrivateNetwork: false` is explicitly set.
  */
 export function requiresInspectableBrowserNavigationRedirects(ssrfPolicy?: SsrfPolicy): boolean {
-  return !isPrivateNetworkAllowedByPolicy(ssrfPolicy);
+  return ssrfPolicy?.dangerouslyAllowPrivateNetwork === false;
+}
+
+/**
+ * Like `requiresInspectableBrowserNavigationRedirects`, but also requires the URL's protocol
+ * to be http/https — non-network protocols (file:, about:) never need redirect inspection.
+ */
+export function requiresInspectableBrowserNavigationRedirectsForUrl(url: string, ssrfPolicy?: SsrfPolicy): boolean {
+  if (!requiresInspectableBrowserNavigationRedirects(ssrfPolicy)) return false;
+  try {
+    const parsed = new URL(url);
+    return NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

Sync browserclaw with OpenClaw 2026.4.14.

### Ported
- `requiresInspectableBrowserNavigationRedirects` — narrowed from `!isPrivateNetworkAllowedByPolicy(policy)` to `policy?.dangerouslyAllowPrivateNetwork === false`. Matches OC #66386 ("restore hostname navigation under the default browser SSRF policy"). Undefined / `{}` policies now return `false` — only explicit strict mode requires redirect inspection. DNS pinning still protects any policy passed to `resolvePinnedHostnameWithPolicy`.
- New `requiresInspectableBrowserNavigationRedirectsForUrl(url, policy)` — same predicate, plus requires `url` protocol to be http/https. Exported from `index.ts`.

### Not ported (registered as KD #49)
- OC's `assertCdpEndpointAllowed` now auto-allowlists loopback hostnames for strict SSRF policies so managed Chrome's control plane always reaches. browserclaw keeps explicit opt-in (`dangerouslyAllowPrivateNetwork: true` or `allowedHostnames: [host]`). The existing test that rejects `localhost:9222` under `{}` codifies this intent.

### Not applicable
- `ssrf` bundle refactor (`resolveHostnamePolicyChecks` extraction + `assertHostnameAllowedWithPolicy` wrapper) — browserclaw has its own DNS-pinning path.
- `assertBrowserNavigationAllowed` IP-literal restriction narrowing — browserclaw never had the restriction.
- server-context route-level SSRF additions (tab URL redaction, focus-tab / snapshot / screenshot guards, `resolveCdpReachabilityPolicy`, `redactBlockedTabUrls`) — OC HTTP route handlers, not part of browserclaw's library surface.
- `usesFastLoopbackCdpProbeClass` + `attachOnly` param on `resolveCdpReachabilityTimeouts` — OC-only timeout helper.

### Bundle-level verification
- `pw-ai`, `chrome`, `ssrf-policy`, `ip` bodies byte-identical to 2026.4.12 after stripping import hashes.
- Independent verification agent confirmed the delta.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 747 tests pass (+5 new for `requiresInspectableBrowserNavigationRedirectsForUrl`, +1 for `{}` policy case)