### PR TITLE
Fix 'Route is already handled' crash in navigation guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -403,26 +403,37 @@ async function gotoPageWithNavigationGuard(opts: {
 }): Promise<Awaited<ReturnType<Page['goto']>>> {
   const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
   const state: { blocked: Error | null } = { blocked: null };
+  const safeContinue = async (route: Route): Promise<void> => {
+    try {
+      await route.continue();
+    } catch (e) {
+      if (e instanceof Error && /already handled/i.test(e.message)) return;
+      console.warn('[browserclaw] route continue failed', e);
+    }
+  };
+  const safeAbort = async (route: Route): Promise<void> => {
+    try {
+      await route.abort();
+    } catch (e) {
+      if (e instanceof Error && /already handled/i.test(e.message)) return;
+      console.warn('[browserclaw] route abort failed', e);
+    }
+  };
   const handler = async (route: Route, request: Request) => {
     if (state.blocked !== null) {
-      await route.abort().catch((e: unknown) => {
-        console.warn('[browserclaw] route abort failed', e);
-      });
+      await safeAbort(route);
       return;
     }
     const isTopLevel = isTopLevelNavigationRequest(opts.page, request);
     const isSubframeDocument = !isTopLevel && isSubframeDocumentNavigationRequest(opts.page, request);
     if (!isTopLevel && !isSubframeDocument) {
-      await route.continue();
+      await safeContinue(route);
       return;
     }
     if (isTopLevel) {
-      // Only guard top-level navigations initiated by this call:
-      // - initial request must match our target URL
-      // - redirects (redirectedFrom !== null) are always checked since they may be part of our chain
       const isRedirect = request.redirectedFrom() !== null;
       if (!isRedirect && request.url() !== opts.url) {
-        await route.continue();
+        await safeContinue(route);
         return;
       }
     }
@@ -437,14 +448,12 @@ async function gotoPageWithNavigationGuard(opts: {
             `[browserclaw] blocked subframe navigation to ${request.url()}: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
-        await route.abort().catch((e: unknown) => {
-          console.warn('[browserclaw] route abort failed', e);
-        });
+        await safeAbort(route);
         return;
       }
       throw err;
     }
-    await route.continue();
+    await safeContinue(route);
   };
   await opts.page.route('**', handler);
   try {


### PR DESCRIPTION
## Problem

`gotoPageWithNavigationGuard` in `src/actions/navigation.ts` registers a `page.route('**', handler)` before calling `page.goto()` and unroutes in `finally`. The handler calls `route.continue()` / `route.abort()` to permit or block requests.

**Bug**: `route.continue()` calls on lines 416, 425, and 447 are unprotected. When Playwright dispatches a route that has already been handled (observed on redirect chains and multi-goto timing races where the previous `goto`'s handler races with `unroute`), `route.continue()` throws `"Route is already handled!"`. The throw escapes the async handler as an unhandled rejection, triggers `process.on('uncaughtException')`, and kills the Node process.

## Evidence

Stack trace observed in production (browserclaw-agent):

\`\`\`
route.continue: Route is already handled!
    at handler (/app/node_modules/browserclaw/dist/index.js:3673:25)

Node.js v22.22.2
2026-04-18 23:08:46,419 WARN exited: browserclaw-browser (exit status 1; not expected)
\`\`\`

## Fix

Same file already uses defensive `.catch()` on `route.abort()` calls at lines 408 and 440. The inconsistency is that `route.continue()` calls are not similarly protected.

Wrap all `continue` and `abort` calls in `safeContinue` / `safeAbort` helpers that:

- Swallow the specific "already handled" error (benign race)
- Surface other errors via `console.warn` (matches existing style)

No behavior change on the happy path. Protects against the specific Playwright race that's been killing the service.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 4268 / 4268 passing
- [x] Hot-patched the built dist into a running browserclaw-agent container; the crash is gone under the same workflow that previously crashed every time