### PR TITLE
Fix snapshot crash on latest Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -52,10 +52,35 @@ export class BrowserTabNotFoundError extends Error {
   }
 }
 
-/** Page extended with Playwright's private `_snapshotForAI` method. */
+/**
+ * Page extended with Playwright's AI-snapshot APIs.
+ *
+ * Playwright <1.59 exposed `_snapshotForAI` on the client Page class; Playwright >=1.59
+ * removed it and promoted the capability to `ariaSnapshot({ mode: 'ai', _track: ... })`.
+ * We keep both shapes here and pick whichever is available at runtime.
+ */
 export type PageWithAI = Page & {
   _snapshotForAI?: (opts: { timeout: number; track: string }) => Promise<{ full?: string }>;
+  ariaSnapshot?: (opts: { timeout?: number; mode?: string; _track?: string }) => Promise<string>;
 };
+
+/**
+ * Take an AI-mode snapshot using whichever API the installed playwright-core exposes.
+ * Returns the raw snapshot text (the `e1`/`e2` ref-style aria tree).
+ */
+export async function takeAiSnapshotText(page: Page, timeoutMs: number): Promise<string> {
+  const maybe = page as PageWithAI;
+  if (typeof maybe._snapshotForAI === 'function') {
+    const result = await maybe._snapshotForAI({ timeout: timeoutMs, track: 'response' });
+    return result.full ?? '';
+  }
+  if (typeof maybe.ariaSnapshot === 'function') {
+    return await maybe.ariaSnapshot({ timeout: timeoutMs, mode: 'ai', _track: 'response' });
+  }
+  throw new Error(
+    'AI snapshot API not available. Install playwright-core >=1.50 (uses _snapshotForAI) or >=1.59 (uses ariaSnapshot with mode: "ai").',
+  );
+}
 
 async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<unknown> {
   const ctrl = new AbortController();

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -1,6 +1,11 @@
 import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
-import { getPageForTargetId, ensurePageState, storeRoleRefsForTarget, normalizeTimeoutMs } from '../connection.js';
-import type { PageWithAI } from '../connection.js';
+import {
+  getPageForTargetId,
+  ensurePageState,
+  storeRoleRefsForTarget,
+  normalizeTimeoutMs,
+  takeAiSnapshotText,
+} from '../connection.js';
 import type { SnapshotResult, SnapshotOptions, SsrfPolicy } from '../types.js';
 
 import { buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
@@ -30,19 +35,9 @@ export async function snapshotAi(opts: {
     });
   }
 
-  const maybe = page as PageWithAI;
-  if (!maybe._snapshotForAI) {
-    throw new Error('Playwright _snapshotForAI is not available. Upgrade playwright-core to >= 1.50.');
-  }
-
   const sourceUrl = page.url();
 
-  const result = await maybe._snapshotForAI({
-    timeout: normalizeTimeoutMs(opts.timeoutMs, 5000, 60000),
-    track: 'response',
-  });
-
-  let snapshot = String(result.full);
+  let snapshot = await takeAiSnapshotText(page, normalizeTimeoutMs(opts.timeoutMs, 5000, 60000));
   const maxChars = opts.maxChars;
   const limit =
     typeof maxChars === 'number' && Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : undefined;

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -5,8 +5,8 @@ import {
   storeRoleRefsForTarget,
   normalizeTimeoutMs,
   withPlaywrightPageCdpSession,
+  takeAiSnapshotText,
 } from '../connection.js';
-import type { PageWithAI } from '../connection.js';
 import type { SnapshotResult, AriaSnapshotResult, AriaNode, SsrfPolicy } from '../types.js';
 
 import { buildRoleSnapshotFromAriaSnapshot, buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
@@ -55,12 +55,8 @@ export async function snapshotRole(opts: {
     ) {
       throw new Error('refs=aria does not support selector/frame snapshots yet.');
     }
-    const maybe = page as PageWithAI;
-    if (!maybe._snapshotForAI) {
-      throw new Error('refs=aria requires Playwright _snapshotForAI support.');
-    }
-    const result = await maybe._snapshotForAI({ timeout: normalizeTimeoutMs(opts.timeoutMs, 5000), track: 'response' });
-    const built = buildRoleSnapshotFromAiSnapshot(String(result.full), opts.options);
+    const snapshotText = await takeAiSnapshotText(page, normalizeTimeoutMs(opts.timeoutMs, 5000));
+    const built = buildRoleSnapshotFromAiSnapshot(snapshotText, opts.options);
 
     storeRoleRefsForTarget({
       page,


### PR DESCRIPTION
## Summary

- Playwright 1.59 removed `_snapshotForAI` from the client `Page` class and promoted the capability to `page.ariaSnapshot({ mode: 'ai', _track: 'response' })`. Any fresh install of `browserclaw` + `playwright-core` since then crashes with `Error: Playwright _snapshotForAI is not available` — reported by @felixmortas in #76.
- Adds a `takeAiSnapshotText(page, timeoutMs)` helper in `connection.ts` that detects which API the installed Playwright exposes and calls whichever is present. Output format is identical (`[ref=e1]`-style), so no downstream parsing changes.
- `snapshotAi` and `snapshotRole` (refs=aria path) now route through the helper instead of inline `_snapshotForAI` checks. Bumps version to 0.12.9 (patch — bug fix, no API change).

## Verification

Probed the customer's exact combo (`playwright-core@1.59.1`) against real Chromium:

```
has _snapshotForAI: undefined
has ariaSnapshot:   function
---
- generic [active] [ref=e1]:
  - button "Click me" [ref=e2]
  - link "Link" [ref=e3] [cursor=pointer]
```

Refs come back in the exact shape `buildRoleSnapshotFromAiSnapshot` already parses.

## Why not cap `playwright-core` to <1.59?

Considered but rejected — a version cap blocks users from security/perf fixes in newer Playwright. Dual-path supports both old and new, which is what proper fwd-compat looks like here.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] End-to-end probe against `playwright-core@1.59.1` — returns correct AI-mode snapshot text
- [ ] After merge + publish, verify customer repro from #76 works on 0.12.9