### PR TITLE
Add snapshot tests and refresh docs

### DIFF
--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import https from 'node:https';
 
-import type { Browser } from 'playwright-core';
+import type { Browser, Page } from 'playwright-core';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import {
@@ -14,6 +14,7 @@ import {
   clearBlockedTarget,
   withNoProxyForCdpUrl,
   getAllPages,
+  takeAiSnapshotText,
 } from './connection.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -380,5 +381,72 @@ describe('getAllPages', () => {
       contexts: () => [{ pages: () => [] }, { pages: () => [] }],
     } as unknown as Browser;
     expect(getAllPages(browser)).toHaveLength(0);
+  });
+});
+
+// Passing track to Playwright makes it return incremental diffs on repeat snapshots, which our parser can't handle.
+describe('takeAiSnapshotText', () => {
+  it('calls _snapshotForAI without a track option (Playwright <1.59)', async () => {
+    let capturedOpts: Record<string, unknown> | undefined;
+    const mockPage = {
+      _snapshotForAI: (opts: Record<string, unknown>) => {
+        capturedOpts = opts;
+        return Promise.resolve({ full: '- button "OK" [ref=e1]' });
+      },
+    } as unknown as Page;
+
+    await takeAiSnapshotText(mockPage, 5000);
+
+    expect(capturedOpts).toEqual({ timeout: 5000 });
+    expect(capturedOpts).not.toHaveProperty('track');
+    expect(capturedOpts).not.toHaveProperty('_track');
+  });
+
+  it('calls ariaSnapshot without a _track option (Playwright >=1.59)', async () => {
+    let capturedOpts: Record<string, unknown> | undefined;
+    const mockPage = {
+      ariaSnapshot: (opts: Record<string, unknown>) => {
+        capturedOpts = opts;
+        return Promise.resolve('- button "OK" [ref=e1]');
+      },
+    } as unknown as Page;
+
+    await takeAiSnapshotText(mockPage, 5000);
+
+    expect(capturedOpts).toEqual({ timeout: 5000, mode: 'ai' });
+    expect(capturedOpts).not.toHaveProperty('_track');
+    expect(capturedOpts).not.toHaveProperty('track');
+  });
+
+  it('prefers _snapshotForAI when both APIs are available', async () => {
+    let snapshotForAICalled = false;
+    let ariaSnapshotCalled = false;
+    const mockPage = {
+      _snapshotForAI: () => {
+        snapshotForAICalled = true;
+        return Promise.resolve({ full: '' });
+      },
+      ariaSnapshot: () => {
+        ariaSnapshotCalled = true;
+        return Promise.resolve('');
+      },
+    } as unknown as Page;
+
+    await takeAiSnapshotText(mockPage, 5000);
+
+    expect(snapshotForAICalled).toBe(true);
+    expect(ariaSnapshotCalled).toBe(false);
+  });
+
+  it('throws a descriptive error when neither API is available', async () => {
+    const mockPage = {} as unknown as Page;
+    await expect(takeAiSnapshotText(mockPage, 5000)).rejects.toThrow(/playwright-core/i);
+  });
+
+  it('returns empty string when _snapshotForAI resolves without full', async () => {
+    const mockPage = {
+      _snapshotForAI: () => Promise.resolve({}),
+    } as unknown as Page;
+    await expect(takeAiSnapshotText(mockPage, 5000)).resolves.toBe('');
   });
 });

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -11,7 +11,7 @@ import type { SnapshotResult, SnapshotOptions, SsrfPolicy } from '../types.js';
 import { buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
 
 /**
- * Take an AI-readable snapshot using Playwright's _snapshotForAI.
+ * Take an AI-readable snapshot using Playwright's AI-mode snapshot API.
  * This is the primary snapshot method — uses Playwright's built-in AI mode.
  */
 export async function snapshotAi(opts: {

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -15,7 +15,7 @@ import { buildRoleSnapshotFromAriaSnapshot, buildRoleSnapshotFromAiSnapshot, get
  * Take a role-based snapshot using Playwright's ariaSnapshot().
  * This produces a tree with ref IDs that can be targeted by actions.
  *
- * When `refsMode === 'aria'`, uses Playwright's `_snapshotForAI()` instead
+ * When `refsMode === 'aria'`, uses Playwright's AI-mode snapshot API instead
  * and stores refs in aria mode (resolved via aria-ref locators).
  */
 export async function snapshotRole(opts: {
@@ -47,7 +47,7 @@ export async function snapshotRole(opts: {
 
   const sourceUrl = page.url();
 
-  // refs=aria sub-path: use _snapshotForAI instead of ariaSnapshot
+  // refs=aria sub-path: use the AI-mode snapshot instead of role-based ariaSnapshot
   if (opts.refsMode === 'aria') {
     if (
       (opts.selector !== undefined && opts.selector.trim() !== '') ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,7 +212,7 @@ export interface SnapshotOptions {
   frameSelector?: string;
   /**
    * Snapshot strategy:
-   * - `'aria'` (default) — uses Playwright's `_snapshotForAI()`, produces refs like `e1`
+   * - `'aria'` (default) — uses Playwright's AI-mode snapshot, produces refs like `e1`
    * - `'role'` — uses Playwright's `ariaSnapshot()` + `getByRole()` resolution
    */
   mode?: 'role' | 'aria';


### PR DESCRIPTION
## Summary
Follow-up to #79 (0.12.10 fix). Two findings from a second-pass review:

### 1. Regression test for the `track` removal
Nothing in the suite previously asserted that `takeAiSnapshotText` calls Playwright **without** a track option. A future contributor could silently re-add `track: 'response'` thinking it's useful — and all 4268 tests would still pass while browserclaw silently drops refs on same-page repeat snapshots.

Added five tests in `src/connection.test.ts` covering:
- `_snapshotForAI` call must not include `track`
- `ariaSnapshot` call must not include `_track` or `track`
- `_snapshotForAI` takes precedence when both APIs exist (1.50–1.58 path)
- Descriptive error when neither API is available
- `_snapshotForAI` returning no `full` resolves to empty string

### 2. Stale doc comments
Four docstrings/inline comments still named `_snapshotForAI()` as the only snapshot API, which became misleading once we added the `ariaSnapshot({ mode: 'ai' })` fallback on 1.59+ (PR #78, already merged). Replaced with "AI-mode snapshot API" — neutral wording that covers both paths.

Files touched:
- `src/types.ts` — `SnapshotOptions.mode` JSDoc
- `src/snapshot/ai-snapshot.ts` — `snapshotAi` JSDoc
- `src/snapshot/aria-snapshot.ts` — `snapshotRole` JSDoc + `refsMode === 'aria'` inline comment

## No version bump
0.12.10 hasn't been published to npm yet (last publish is 0.12.9). This PR rolls into the same 0.12.10 release — no bump needed.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (4273 tests pass — 5 new)