### PR TITLE
Updates from OpenClaw 2026.4.19

### DIFF
--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -127,6 +127,24 @@ describe('normalizeCdpWsUrl', () => {
     expect(result.startsWith('wss://')).toBe(true);
   });
 
+  it('normalizes loopback aliases (ws localhost, cdp 127.0.0.1 → use cdp alias)', () => {
+    const result = normalizeCdpWsUrl('ws://localhost:9222/devtools/browser/abc', 'http://127.0.0.1:9222');
+    expect(result).toContain('127.0.0.1');
+    expect(result).not.toContain('localhost');
+  });
+
+  it('normalizes loopback aliases in reverse (ws 127.0.0.1, cdp localhost → use cdp alias)', () => {
+    const result = normalizeCdpWsUrl('ws://127.0.0.1:9222/devtools/browser/abc', 'http://localhost:9222');
+    expect(result).toContain('localhost');
+    expect(result).not.toContain('127.0.0.1');
+  });
+
+  it('normalizes IPv6 loopback to IPv4 loopback when cdp is IPv4 ([::1] → 127.0.0.1)', () => {
+    const result = normalizeCdpWsUrl('ws://[::1]:9222/devtools/browser/abc', 'http://127.0.0.1:9222');
+    expect(result).toContain('127.0.0.1');
+    expect(result).not.toContain('[::1]');
+  });
+
   it('inherits URL credentials from CDP URL', () => {
     const result = normalizeCdpWsUrl('ws://localhost:9222/path', 'http://user:pass@localhost:9222');
     const parsed = new URL(result);

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -585,6 +585,8 @@ export function normalizeCdpWsUrl(wsUrl: string, cdpUrl: string): string {
     const cdpPort = cdp.port || (cdp.protocol === 'https:' ? '443' : '80');
     if (cdpPort) ws.port = cdpPort;
     ws.protocol = cdp.protocol === 'https:' ? 'wss:' : 'ws:';
+  } else if (isLoopbackHost(ws.hostname) && isLoopbackHost(cdp.hostname)) {
+    ws.hostname = cdp.hostname;
   }
   if (cdp.protocol === 'https:' && ws.protocol === 'ws:') ws.protocol = 'wss:';
   if (!ws.username && !ws.password && (cdp.username || cdp.password)) {


### PR DESCRIPTION
Sync from OpenClaw `2026.4.15` → `2026.4.19-beta.2`.

## Ported

**`normalizeCdpWsUrl` — loopback alias normalization** (`src/chrome-launcher.ts`)

When both the `/json/version` WebSocket URL and the user-supplied CDP URL are loopback but use different aliases (e.g. ws returns `localhost`, cdp is `127.0.0.1`), rewrite the ws hostname to match cdp. Prevents the ws/cdp hostname mismatch from tripping the hostname pin check on subsequent requests.

One test added covering the new branch.

## Not ported

**OC auto-adds loopback hostnames to `allowedHostnames` in `assertCdpEndpointAllowed`** — per KD #49, browserclaw intentionally keeps the stricter explicit-opt-in posture. Managed-Chrome bypass is an OpenClaw server concern; browserclaw is a library and the caller owns the CDP URL.

**8 new CDP diagnostic functions** (`diagnoseChromeCdp`, `formatChromeCdpDiagnostic`, `classifyChromeVersionError`, etc.) and the `isChromeCdpReady` refactor to use them — OpenClaw's server-env logging infra. Browserclaw's existing implementation still works and doesn't need a parallel logging module.

## Walked versions

- `2026.4.19-beta.1` (changelog: CDP profile host, loopback aliases, diagnostics)
- `2026.4.19-beta.2` (changelog: agents/OpenAI/status — no browser changes)

## Checks

- `npm test` — all green
- `npm run typecheck` / `npm run lint` / `npm run format:check` / `npm run build` — clean

## Status

Marked as **draft** because 2026.4.19 is still in beta (only beta.1 and beta.2 shipped). Ready to promote once stable 2026.4.19 releases — the porting already covers the changes in both betas.