### PR TITLE
Updates from OpenClaw 2026.4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.14.0",
+  "version": "0.13.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import {
   isLoopbackHost,
+  isDirectCdpWebSocketEndpoint,
   hasProxyEnvConfigured,
   normalizeCdpWsUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
@@ -47,6 +48,41 @@ describe('isLoopbackHost', () => {
   it('is case sensitive (hostnames are typically lowercase)', () => {
     expect(isLoopbackHost('LOCALHOST')).toBe(false);
     expect(isLoopbackHost('Localhost')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isDirectCdpWebSocketEndpoint
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isDirectCdpWebSocketEndpoint', () => {
+  it('recognizes /devtools/browser/<id>', () => {
+    expect(isDirectCdpWebSocketEndpoint('ws://localhost:9222/devtools/browser/abc-123')).toBe(true);
+    expect(isDirectCdpWebSocketEndpoint('wss://remote:443/devtools/browser/abc-123')).toBe(true);
+  });
+
+  it('recognizes /devtools/page/<id>, /devtools/worker/<id>, /devtools/shared_worker/<id>, /devtools/service_worker/<id>', () => {
+    expect(isDirectCdpWebSocketEndpoint('ws://host/devtools/page/abc')).toBe(true);
+    expect(isDirectCdpWebSocketEndpoint('ws://host/devtools/worker/abc')).toBe(true);
+    expect(isDirectCdpWebSocketEndpoint('ws://host/devtools/shared_worker/abc')).toBe(true);
+    expect(isDirectCdpWebSocketEndpoint('ws://host/devtools/service_worker/abc')).toBe(true);
+  });
+
+  it('rejects non-WS protocols', () => {
+    expect(isDirectCdpWebSocketEndpoint('http://localhost:9222/devtools/browser/abc')).toBe(false);
+    expect(isDirectCdpWebSocketEndpoint('https://localhost:9222/devtools/browser/abc')).toBe(false);
+  });
+
+  it('rejects WS URLs without a /devtools/<type>/<id> path', () => {
+    expect(isDirectCdpWebSocketEndpoint('ws://proxy/cdp')).toBe(false);
+    expect(isDirectCdpWebSocketEndpoint('ws://localhost:9222/')).toBe(false);
+    expect(isDirectCdpWebSocketEndpoint('ws://localhost:9222/devtools/browser/')).toBe(false);
+    expect(isDirectCdpWebSocketEndpoint('ws://localhost:9222/devtools/unknown/abc')).toBe(false);
+  });
+
+  it('rejects invalid URLs', () => {
+    expect(isDirectCdpWebSocketEndpoint('')).toBe(false);
+    expect(isDirectCdpWebSocketEndpoint('not a url')).toBe(false);
   });
 });
 

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -556,6 +556,16 @@ function isWebSocketUrl(url: string): boolean {
   }
 }
 
+export function isDirectCdpWebSocketEndpoint(url: string): boolean {
+  if (!isWebSocketUrl(url)) return false;
+  try {
+    const parsed = new URL(url);
+    return /\/devtools\/(?:browser|page|worker|shared_worker|service_worker)\/[^/]/i.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
 export function isLoopbackHost(hostname: string): boolean {
   const h = hostname.replace(/\.+$/, '');
   return h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '[::1]';
@@ -642,7 +652,7 @@ async function canOpenWebSocket(url: string, timeoutMs: number): Promise<boolean
       () => {
         finish(false);
       },
-      Math.max(50, timeoutMs + 25),
+      Math.max(1, timeoutMs + Math.min(25, timeoutMs)),
     );
     let ws: WebSocket;
     try {
@@ -714,9 +724,12 @@ export async function isChromeReachable(
   } catch {
     return false;
   }
+  if (isDirectCdpWebSocketEndpoint(cdpUrl)) return await canOpenWebSocket(cdpUrl, timeoutMs);
+  const discoveryUrl = isWebSocketUrl(cdpUrl) ? normalizeCdpHttpBaseForJsonEndpoints(cdpUrl) : cdpUrl;
+  const version = await fetchChromeVersion(discoveryUrl, timeoutMs, authToken, ssrfPolicy);
+  if (version !== null) return true;
   if (isWebSocketUrl(cdpUrl)) return await canOpenWebSocket(cdpUrl, timeoutMs);
-  const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken, ssrfPolicy);
-  return version !== null;
+  return false;
 }
 
 export async function getChromeWebSocketUrl(
@@ -726,12 +739,16 @@ export async function getChromeWebSocketUrl(
   ssrfPolicy?: SsrfPolicy,
 ): Promise<string | null> {
   await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
-  if (isWebSocketUrl(cdpUrl)) return cdpUrl;
-  const version = await fetchChromeVersion(cdpUrl, timeoutMs, authToken, ssrfPolicy);
+  if (isDirectCdpWebSocketEndpoint(cdpUrl)) return cdpUrl;
+  const discoveryUrl = isWebSocketUrl(cdpUrl) ? normalizeCdpHttpBaseForJsonEndpoints(cdpUrl) : cdpUrl;
+  const version = await fetchChromeVersion(discoveryUrl, timeoutMs, authToken, ssrfPolicy);
   const rawWsUrl = version?.webSocketDebuggerUrl;
   const wsUrl = typeof rawWsUrl === 'string' ? rawWsUrl.trim() : '';
-  if (wsUrl === '') return null;
-  const normalized = normalizeCdpWsUrl(wsUrl, cdpUrl);
+  if (wsUrl === '') {
+    if (isWebSocketUrl(cdpUrl)) return cdpUrl;
+    return null;
+  }
+  const normalized = normalizeCdpWsUrl(wsUrl, discoveryUrl);
   await assertCdpEndpointAllowed(normalized, ssrfPolicy);
   return normalized;
 }
@@ -764,7 +781,7 @@ async function canRunCdpHealthCommand(wsUrl: string, timeoutMs = 800): Promise<b
       () => {
         finish(false);
       },
-      Math.max(50, timeoutMs + 25),
+      Math.max(1, timeoutMs + Math.min(25, timeoutMs)),
     );
 
     let ws: WebSocket;
@@ -944,7 +961,8 @@ export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Prom
   while (Date.now() - start < timeoutMs) {
     // exitCode changes asynchronously after SIGTERM; re-read from proc
     if ((proc as { exitCode: number | null }).exitCode !== null) return;
-    await new Promise((r) => setTimeout(r, 100));
+    const remainingMs = timeoutMs - (Date.now() - start);
+    await new Promise((r) => setTimeout(r, Math.max(1, Math.min(100, remainingMs))));
   }
   killProcessTree(proc, 'SIGKILL');
 }

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -1733,8 +1733,14 @@ describe('security.ts', () => {
       await expect(assertCdpEndpointAllowed('http://localhost:9222', undefined)).resolves.toBeUndefined();
     });
 
-    it('blocks loopback hostnames under a strict policy', async () => {
-      await expect(assertCdpEndpointAllowed('http://localhost:9222', {})).rejects.toThrow(
+    it('allows loopback hostnames even under a strict policy', async () => {
+      await expect(assertCdpEndpointAllowed('http://localhost:9222', {})).resolves.toBeUndefined();
+      await expect(assertCdpEndpointAllowed('http://127.0.0.1:9222', {})).resolves.toBeUndefined();
+      await expect(assertCdpEndpointAllowed('ws://[::1]:9222/devtools/browser/abc', {})).resolves.toBeUndefined();
+    });
+
+    it('blocks non-loopback private IPs under a strict policy', async () => {
+      await expect(assertCdpEndpointAllowed('http://192.168.1.100:9222', {})).rejects.toThrow(
         BrowserCdpEndpointBlockedError,
       );
     });
@@ -1769,7 +1775,7 @@ describe('security.ts', () => {
 
     it('error message points users at the dangerouslyAllowPrivateNetwork fix', async () => {
       try {
-        await assertCdpEndpointAllowed('http://localhost:9222', {});
+        await assertCdpEndpointAllowed('http://192.168.1.100:9222', {});
         expect.fail('expected throw');
       } catch (err) {
         expect(err).toBeInstanceOf(BrowserCdpEndpointBlockedError);
@@ -1779,7 +1785,7 @@ describe('security.ts', () => {
 
     it('preserves the underlying error as cause', async () => {
       try {
-        await assertCdpEndpointAllowed('http://localhost:9222', {});
+        await assertCdpEndpointAllowed('http://192.168.1.100:9222', {});
         expect.fail('expected throw');
       } catch (err) {
         expect(err).toBeInstanceOf(BrowserCdpEndpointBlockedError);

--- a/src/security.ts
+++ b/src/security.ts
@@ -79,8 +79,16 @@ export async function assertCdpEndpointAllowed(cdpUrl: string, ssrfPolicy?: Ssrf
       `CDP endpoint blocked: protocol "${parsed.protocol.replace(':', '')}" is not allowed (use http/https/ws/wss)`,
     );
   }
+  const h = parsed.hostname.replace(/\.+$/, '');
+  const isLoopback = h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '[::1]';
+  const effectivePolicy = isLoopback
+    ? {
+        ...ssrfPolicy,
+        allowedHostnames: Array.from(new Set([...(ssrfPolicy.allowedHostnames ?? []), parsed.hostname])),
+      }
+    : ssrfPolicy;
   try {
-    await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy: ssrfPolicy });
+    await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy: effectivePolicy });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new BrowserCdpEndpointBlockedError(


### PR DESCRIPTION
Sync from OpenClaw `2026.4.19-beta.2` → `2026.4.20-beta.1`.

## Ported

**Direct CDP WebSocket endpoint classification + discovery refinement** (`src/chrome-launcher.ts`)

- New exported helper `isDirectCdpWebSocketEndpoint(url)` — returns `true` for `ws(s)://…/devtools/{browser,page,worker,shared_worker,service_worker}/<id>`.
- `isChromeReachable` and `getChromeWebSocketUrl` now use it: direct WS endpoints skip HTTP discovery (fast path), non-direct WS URLs try `/json/version` via `normalizeCdpHttpBaseForJsonEndpoints` first, then fall back. Handles WS-proxy setups (WSL port-forward, kubectl port-forward, custom tunnels) that expose HTTP discovery but wrap WS.
- 5 tests for `isDirectCdpWebSocketEndpoint` covering the five devtools kinds, non-WS protocols, bare ws roots, and invalid URLs.

**Timeout tightening**

- `canOpenWebSocket` timeout buffer: `Math.max(50, timeoutMs + 25)` → `Math.max(1, timeoutMs + Math.min(25, timeoutMs))`. Allows sub-50ms probes and caps the buffer to the timeout itself.
- `stopChrome` poll interval: `setTimeout(r, 100)` → `setTimeout(r, Math.max(1, Math.min(100, remainingMs)))`. Last tick no longer overruns the stop budget.

## Not ported

- **`ssrfPolicyFromHttpBaseUrlAllowedHostname`** (ssrf-D) — auto-allowlist helper built on `withAllowedHostname`. Covered by KD #49.
- **`asRecord` / `readNestedRecord`** (chrome) — OC-internal parsers for Chrome profile `info_cache` / theme prefs. browserclaw has no profile management.
- **`createTargetViaCdp` refactor** (chrome) — OC-specific target creation. browserclaw uses Playwright's `.newPage()`.
- **`closePlaywrightBrowserConnectionForProfile` rename + `formatChromeMcpAttachFailure`** (server-context) — OC's Chrome MCP server managed-profile concern.

## Checks

- `npm test` — all green
- `npm run typecheck` / `npm run lint` / `npm run format:check` / `npm run build` — clean

## Status

Draft — 2026.4.20 is still in beta (beta.1). Promote when stable ships.