### PR TITLE
One window on first launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -831,7 +831,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   const userDataDir = opts.userDataDir ?? resolveUserDataDir(profileName);
   fs.mkdirSync(userDataDir, { recursive: true });
 
-  const spawnChrome = (spawnOpts?: { detached?: boolean }) => {
+  const spawnChrome = (spawnOpts?: { detached?: boolean }, runOpts?: { forceHeadless?: boolean }) => {
     const args = [
       `--remote-debugging-port=${String(cdpPort)}`,
       '--remote-debugging-address=127.0.0.1',
@@ -847,7 +847,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
       '--hide-crash-restore-bubble',
       '--password-store=basic',
     ];
-    if (opts.headless === true) {
+    if (opts.headless === true || runOpts?.forceHeadless === true) {
       args.push('--headless=new', '--disable-gpu');
     }
     if (opts.noSandbox === true) {
@@ -873,10 +873,13 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   const localStatePath = path.join(userDataDir, 'Local State');
   const preferencesPath = path.join(userDataDir, 'Default', 'Preferences');
 
-  // Bootstrap run if profile doesn't exist yet
+  // Bootstrap run if profile doesn't exist yet — forced headless so the user
+  // does not see a throwaway window flashing open and closed before the real
+  // session. Chrome still initializes the profile databases (Cookies, History,
+  // Web Data, etc.) during this headless run.
   if (!fileExists(localStatePath) || !fileExists(preferencesPath)) {
     const useDetached = process.platform !== 'win32';
-    const bootstrap = spawnChrome(useDetached ? { detached: true } : undefined);
+    const bootstrap = spawnChrome(useDetached ? { detached: true } : undefined, { forceHeadless: true });
     const deadline = Date.now() + 10000;
     while (Date.now() < deadline) {
       if (fileExists(localStatePath) && fileExists(preferencesPath)) break;


### PR DESCRIPTION
On a fresh user data directory, `launchChrome` first spawns a throwaway Chrome process to let it initialize the profile files and databases (`Local State`, `Default/Preferences`, `Cookies`, `History`, etc.), waits for the files to exist, kills that Chrome, decorates the profile, then launches the real Chrome session. This is necessary — Chrome needs the init to complete before navigation, and we need the files in place before `decorateProfile` / `ensureCleanExit` can edit them.

The visible symptom: on any first-time-profile run, users see a blank Chrome window open, sit for 2–3 seconds, close on its own, then a new window open with the real URL.

## Fix

Force `--headless=new --disable-gpu` on the bootstrap spawn regardless of the caller's `headless` option. The bootstrap's job is profile init, not rendering — there's no reason it needs a visible window. The real session still honors `headless`.

`spawnChrome` now takes an optional `runOpts.forceHeadless` flag; the bootstrap call passes it.

## Before / after

- **Before**: fresh profile → window flashes open, closes, new window opens on URL.
- **After**: fresh profile → Chrome initializes headlessly in the background, one window opens directly on URL.

## Verified

- Ran the bootstrap sequence on a fresh temp profile with `headless: false`. Confirmed visually that only one window opens and it lands on the target URL.
- All existing tests pass.
- Existing profiles (with `Local State` already present) are unaffected — they never hit the bootstrap branch.

## Status

Merge-ready. No API change, no behavior change for existing profiles.