### PR TITLE
Add reliability primitives for supervised admin automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,16 @@ Tab handles can get out of sync if the app rewrites its URL aggressively or repl
 
 ```typescript
 // Attempts to refresh the cached targetId, optionally falling back to the
-// currently active tab if the original target is gone.
+// best-effort resolver if the original target is gone.
 await page.refreshTargetId();
 await page.refreshTargetId({ fallback: 'active' });
 
-// Rebind the handle to the browser's best-guess active page (prefers
-// non-blank tabs, then the old URL, then the first tab).
+// Rebind the handle using the best-effort resolver: prefers the old
+// targetId, then the old URL, then a non-blank tab, then any tab.
 await page.reacquire();
 ```
+
+> **Caveat:** These resolvers do NOT query Chrome's focused tab — CDP doesn't expose that cleanly. They apply a heuristic (old target → old URL → non-blank → first). In multi-tab sessions without a URL hint, they may pick a different tab than the one the user is looking at. Track `targetId` explicitly via `browser.open()` / `browser.waitForTab()` when you need deterministic tab selection.
 
 BrowserClaw exports structured errors so workflow code can tell apart the common failure modes:
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ const browser = await BrowserClaw.launch({
   profileName: 'browserclaw', // profile name in Chrome title bar
   profileColor: '#FF4500', // profile accent color (hex)
   chromeArgs: ['--start-maximized'], // additional Chrome flags
+  isolated: true, // fresh per-run profile, auto-cleaned on stop()
 });
 
 // Connect to an already-running Chrome instance
@@ -194,6 +195,41 @@ await page.title(); // current page title
 browser.url; // CDP endpoint URL
 ```
 
+#### Recovering tab handles
+
+Tab handles can get out of sync if the app rewrites its URL aggressively or replaces the top-level target. Use the recovery primitives to re-bind a `CrawlPage` without having to restart the session:
+
+```typescript
+// Attempts to refresh the cached targetId, optionally falling back to the
+// currently active tab if the original target is gone.
+await page.refreshTargetId();
+await page.refreshTargetId({ fallback: 'active' });
+
+// Rebind the handle to the browser's best-guess active page (prefers
+// non-blank tabs, then the old URL, then the first tab).
+await page.reacquire();
+```
+
+BrowserClaw exports structured errors so workflow code can tell apart the common failure modes:
+
+```typescript
+import {
+  BrowserTabNotFoundError,   // targetId no longer resolves to an open tab
+  StaleRefError,              // ref is not in the current snapshot
+  SnapshotHydrationError,     // snapshot returned without interactive refs
+  NavigationRaceError,        // the page navigated during an operation
+} from 'browserclaw';
+
+try {
+  await page.click('e7');
+} catch (err) {
+  if (err instanceof StaleRefError) {
+    await page.snapshot({ waitForHydration: true });
+    // retry with a fresh ref
+  } else throw err;
+}
+```
+
 Every tab returns a `targetId` — this is the handle you use everywhere:
 
 ```typescript
@@ -224,6 +260,8 @@ const result = await page.snapshot({
   maxDepth: 6, // Limit tree depth
   maxChars: 80000, // Truncate if snapshot exceeds this size
   mode: 'aria', // 'aria' (default) or 'role'
+  waitForHydration: 5000, // retry until refs appear (or ms budget); throws SnapshotHydrationError if empty
+  minInteractiveRefs: 1, // minimum refs required when waitForHydration is set
 });
 
 // Raw ARIA accessibility tree (structured data, not text)

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Under strict mode browserclaw resolves DNS up front, pins the result, validates 
 
 ```typescript
 const page = await browser.open('https://demo.playwright.dev/todomvc');
-const current = await browser.currentPage(); // get active tab
+const current = await browser.currentPage(); // get first usable (non-blank) tab
 const tabs = await browser.tabs(); // list all tabs
 const handle = browser.page(tabs[0].targetId); // wrap existing tab
 const appPage = await browser.waitForTab({ urlContains: 'app-web' });

--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ const browser = await BrowserClaw.connect();
 
 **Anti-detection:** browserclaw automatically hides `navigator.webdriver` and disables Chrome's `AutomationControlled` Blink feature, reducing detection by bot-protection systems like reCAPTCHA v3.
 
+#### Isolated profiles (per-run, per-process)
+
+Pass `isolated: true` (or `isolated: 'some-label'`) to launch in a dedicated per-run profile under `$TMPDIR/browserclaw/isolated/`:
+
+- A run-scoped random suffix is **always** appended — including when you pass a label string. Two concurrent launches with the same label (`isolated: 'my-run'`) each get a unique directory and never collide on Chrome's SingletonLock. The label is for identification only; it does not produce a stable profile across runs.
+- `stop()` removes the isolated user-data directory on exit (best-effort; silent on failure). If the process crashes before `stop()`, leftover directories remain under `$TMPDIR/browserclaw/isolated/` and can be deleted safely when no Chrome process is using them.
+- When `isolated` is set, `profileName` and `userDataDir` options are ignored.
+- Any cookies, logins, extensions, or localStorage from prior runs are not available — by design.
+
+For a stable, shared profile across runs (persistent login state, preserved history), omit `isolated` and use `profileName` / `userDataDir` instead.
+
 #### SSRF policy (navigating agent-supplied URLs)
 
 By default, browserclaw permits navigation to **any** address — including private/loopback ranges such as `127.0.0.1`, `10.0.0.0/8`, and cloud metadata endpoints like `169.254.169.254`. This "trusted-network" default is convenient for local development and dev-tunnel workflows.
@@ -210,7 +221,7 @@ await page.refreshTargetId({ fallback: 'active' });
 await page.reacquire();
 ```
 
-> **Caveat:** These resolvers do NOT query Chrome's focused tab — CDP doesn't expose that cleanly. They apply a heuristic (old target → old URL → non-blank → first). In multi-tab sessions without a URL hint, they may pick a different tab than the one the user is looking at. Track `targetId` explicitly via `browser.open()` / `browser.waitForTab()` when you need deterministic tab selection.
+> **Contract — heuristic by design:** These resolvers do not query Chrome's focused tab; CDP doesn't expose that cleanly over connect-over-CDP. They apply a fixed preference order — old targetId → old URL → first non-blank accessible tab → any accessible tab — and that order is the contract. Use them for recovery after a target has been lost; don't use them to "ask which tab the human is looking at." When you need deterministic tab selection, capture the `targetId` up front via `browser.open()` / `browser.waitForTab()` / `browser.tabs()` and keep using that handle.
 
 BrowserClaw exports structured errors so workflow code can tell apart the common failure modes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.12.8",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.12.8",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -188,6 +188,7 @@ export async function executeSingleAction(
         targetId: effectiveTargetId,
         width: action.width,
         height: action.height,
+        ssrfPolicy,
       });
       break;
     case 'wait':
@@ -222,6 +223,7 @@ export async function executeSingleAction(
       await closePageViaPlaywright({
         cdpUrl,
         targetId: effectiveTargetId,
+        ssrfPolicy,
       });
       break;
     case 'batch':

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -490,7 +490,7 @@ export async function navigateViaPlaywright(opts: {
   await assertBrowserNavigationAllowed({ url, ...withBrowserNavigationPolicy(policy) });
 
   const timeout = Math.max(1000, Math.min(120000, opts.timeoutMs ?? 20000));
-  let page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  let page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: policy });
   ensurePageState(page);
 
   const navigate = async () =>
@@ -517,7 +517,7 @@ export async function navigateViaPlaywright(opts: {
     }).catch(() => {
       /* intentional no-op */
     });
-    page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+    page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: policy });
     ensurePageState(page);
     response = await navigate();
   }
@@ -610,8 +610,16 @@ export async function createPageViaPlaywright(opts: {
   };
 }
 
-export async function closePageViaPlaywright(opts: { cdpUrl: string; targetId?: string }): Promise<void> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+export async function closePageViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  ssrfPolicy?: SsrfPolicy;
+}): Promise<void> {
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
   await page.close();
 }
@@ -680,8 +688,13 @@ export async function resizeViewportViaPlaywright(opts: {
   targetId?: string;
   width: number;
   height: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
   await page.setViewportSize({
     width: Math.max(1, Math.floor(opts.width)),

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1,0 +1,141 @@
+import type { Page } from 'playwright-core';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type * as ConnectionModule from './connection.js';
+import { BrowserTabNotFoundError } from './errors.js';
+
+const { mockGetPageForTargetId, mockResolveActiveTargetId, mockPageTargetId } = vi.hoisted(() => ({
+  mockGetPageForTargetId: vi.fn<(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: unknown }) => Promise<Page>>(),
+  mockResolveActiveTargetId:
+    vi.fn<
+      (
+        cdpUrl: string,
+        opts?: { preferTargetId?: string; preferUrl?: string; ssrfPolicy?: unknown },
+      ) => Promise<string | null>
+    >(),
+  mockPageTargetId: vi.fn<(page: Page) => Promise<string | null>>(),
+}));
+
+vi.mock('./connection.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionModule>();
+  return {
+    ...actual,
+    getPageForTargetId: mockGetPageForTargetId,
+    resolveActiveTargetId: mockResolveActiveTargetId,
+    pageTargetId: mockPageTargetId,
+    connectBrowser: () => Promise.resolve({ browser: {}, cdpUrl: 'http://localhost:9222' }),
+  };
+});
+
+const { CrawlPage } = await import('./browser.js');
+
+describe('CrawlPage.reacquire', () => {
+  beforeEach(() => {
+    mockGetPageForTargetId.mockReset();
+    mockResolveActiveTargetId.mockReset();
+    mockPageTargetId.mockReset();
+  });
+
+  it('threads ssrfPolicy through to resolveActiveTargetId', async () => {
+    const policy = { dangerouslyAllowPrivateNetwork: false };
+    const fakePage = { url: () => 'https://app.example.test/' } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(fakePage);
+    mockResolveActiveTargetId.mockResolvedValue('t-new');
+
+    const page = new CrawlPage('http://localhost:9222', 't-old', policy);
+    await page.reacquire();
+
+    expect(mockResolveActiveTargetId).toHaveBeenCalledTimes(1);
+    const args = mockResolveActiveTargetId.mock.calls[0];
+    expect(args[0]).toBe('http://localhost:9222');
+    expect(args[1]?.ssrfPolicy).toBe(policy);
+  });
+
+  it('captures the page URL and passes it as preferUrl', async () => {
+    const fakePage = { url: () => 'https://app.example.test/dashboard' } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(fakePage);
+    mockResolveActiveTargetId.mockResolvedValue('t-new');
+
+    const page = new CrawlPage('http://localhost:9222', 't-old');
+    await page.reacquire();
+
+    const args = mockResolveActiveTargetId.mock.calls[0];
+    expect(args[1]?.preferTargetId).toBe('t-old');
+    expect(args[1]?.preferUrl).toBe('https://app.example.test/dashboard');
+  });
+
+  it('still recovers when the original target is gone', async () => {
+    mockGetPageForTargetId.mockRejectedValue(new BrowserTabNotFoundError());
+    mockResolveActiveTargetId.mockResolvedValue('t-new');
+
+    const page = new CrawlPage('http://localhost:9222', 't-gone');
+    const recovered = await page.reacquire();
+
+    expect(recovered).toBe('t-new');
+    const args = mockResolveActiveTargetId.mock.calls[0];
+    expect(args[1]?.preferTargetId).toBe('t-gone');
+    expect(args[1]?.preferUrl).toBeUndefined();
+  });
+
+  it('does not pass about:blank as preferUrl', async () => {
+    const fakePage = { url: () => 'about:blank' } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(fakePage);
+    mockResolveActiveTargetId.mockResolvedValue('t-new');
+
+    const page = new CrawlPage('http://localhost:9222', 't-old');
+    await page.reacquire();
+
+    const args = mockResolveActiveTargetId.mock.calls[0];
+    expect(args[1]?.preferUrl).toBeUndefined();
+  });
+
+  it('throws BrowserTabNotFoundError when no pages are available', async () => {
+    mockGetPageForTargetId.mockRejectedValue(new BrowserTabNotFoundError());
+    mockResolveActiveTargetId.mockResolvedValue(null);
+
+    const page = new CrawlPage('http://localhost:9222', 't-old');
+    await expect(page.reacquire()).rejects.toBeInstanceOf(BrowserTabNotFoundError);
+  });
+});
+
+describe('CrawlPage.refreshTargetId', () => {
+  beforeEach(() => {
+    mockGetPageForTargetId.mockReset();
+    mockResolveActiveTargetId.mockReset();
+    mockPageTargetId.mockReset();
+  });
+
+  it('threads ssrfPolicy through to getPageForTargetId on the happy path', async () => {
+    const policy = { dangerouslyAllowPrivateNetwork: false };
+    const fakePage = {} as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(fakePage);
+    mockPageTargetId.mockResolvedValue('t-old');
+
+    const page = new CrawlPage('http://localhost:9222', 't-old', policy);
+    await page.refreshTargetId();
+
+    expect(mockGetPageForTargetId).toHaveBeenCalledWith({
+      cdpUrl: 'http://localhost:9222',
+      targetId: 't-old',
+      ssrfPolicy: policy,
+    });
+  });
+
+  it('threads ssrfPolicy through to resolveActiveTargetId on the active fallback', async () => {
+    const policy = { dangerouslyAllowPrivateNetwork: false };
+    mockGetPageForTargetId.mockRejectedValue(new BrowserTabNotFoundError());
+    mockResolveActiveTargetId.mockResolvedValue('t-new');
+
+    const page = new CrawlPage('http://localhost:9222', 't-old', policy);
+    await page.refreshTargetId({ fallback: 'active' });
+
+    expect(mockResolveActiveTargetId).toHaveBeenCalledWith('http://localhost:9222', { ssrfPolicy: policy });
+  });
+
+  it('rethrows when no fallback is requested', async () => {
+    mockGetPageForTargetId.mockRejectedValue(new BrowserTabNotFoundError('gone'));
+
+    const page = new CrawlPage('http://localhost:9222', 't-old');
+    await expect(page.refreshTargetId()).rejects.toBeInstanceOf(BrowserTabNotFoundError);
+  });
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -160,13 +160,17 @@ export class CrawlPage {
    */
   async refreshTargetId(opts?: { fallback?: 'active' }): Promise<string> {
     try {
-      const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+      const page = await getPageForTargetId({
+        cdpUrl: this.cdpUrl,
+        targetId: this._targetId,
+        ssrfPolicy: this.ssrfPolicy,
+      });
       const newId = await pageTargetId(page);
       if (newId !== null && newId !== '') this._targetId = newId;
       return this._targetId;
     } catch (err) {
       if (opts?.fallback !== 'active' || !(err instanceof BrowserTabNotFoundError)) throw err;
-      const recovered = await resolveActiveTargetId(this.cdpUrl);
+      const recovered = await resolveActiveTargetId(this.cdpUrl, { ssrfPolicy: this.ssrfPolicy });
       if (recovered === null)
         throw new BrowserTabNotFoundError(
           `Tab ${this._targetId} is gone and no fallback page is available. Call browser.tabs() or browser.open(url).`,
@@ -180,13 +184,32 @@ export class CrawlPage {
    * Re-bind this handle to the browser's currently active page.
    *
    * Primitive for recovering from lost tab handles after navigation or
-   * aggressive re-renders. Prefers non-blank pages, then pages matching
-   * the old URL, finally falls back to the first accessible tab.
+   * aggressive re-renders. Captures the page's current URL (when still
+   * reachable) so the resolver can prefer the same page after a reload,
+   * then falls back to the original targetId, then a non-blank tab,
+   * then the first accessible tab.
    *
    * @returns The (possibly new) target ID
    */
   async reacquire(): Promise<string> {
-    const recovered = await resolveActiveTargetId(this.cdpUrl, { preferTargetId: this._targetId });
+    let preferUrl: string | undefined;
+    try {
+      const page = await getPageForTargetId({
+        cdpUrl: this.cdpUrl,
+        targetId: this._targetId,
+        ssrfPolicy: this.ssrfPolicy,
+      });
+      const url = page.url();
+      if (url !== '' && url !== 'about:blank') preferUrl = url;
+    } catch (err) {
+      if (!(err instanceof BrowserTabNotFoundError)) throw err;
+      // Old target is gone — recovery proceeds with whatever the resolver finds.
+    }
+    const recovered = await resolveActiveTargetId(this.cdpUrl, {
+      preferTargetId: this._targetId,
+      preferUrl,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     if (recovered === null)
       throw new BrowserTabNotFoundError('No pages available to reacquire. Use browser.open(url) to create a tab.');
     this._targetId = recovered;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -60,10 +60,11 @@ import {
   getPageForTargetId,
   ensurePageState,
   pageTargetId,
-  getAllPages,
   normalizeTimeoutMs,
   setDialogHandler,
   getRestoredPageForTarget,
+  BrowserTabNotFoundError,
+  resolveActiveTargetId,
 } from './connection.js';
 import { assertCdpEndpointAllowed } from './security.js';
 import { snapshotAi } from './snapshot/ai-snapshot.js';
@@ -151,11 +152,44 @@ export class CrawlPage {
   /**
    * Refresh the target ID by re-resolving the page from the browser.
    * Useful after reconnection when the old target ID may be stale.
+   *
+   * If the current target is gone (tab closed or replaced after a hard
+   * redesign), falls back to the browser's best guess for the active page
+   * when `fallback: 'active'` is set. By default, throws
+   * `BrowserTabNotFoundError` if the old target is gone.
    */
-  async refreshTargetId(): Promise<string> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
-    const newId = await pageTargetId(page);
-    if (newId !== null && newId !== '') this._targetId = newId;
+  async refreshTargetId(opts?: { fallback?: 'active' }): Promise<string> {
+    try {
+      const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+      const newId = await pageTargetId(page);
+      if (newId !== null && newId !== '') this._targetId = newId;
+      return this._targetId;
+    } catch (err) {
+      if (opts?.fallback !== 'active' || !(err instanceof BrowserTabNotFoundError)) throw err;
+      const recovered = await resolveActiveTargetId(this.cdpUrl);
+      if (recovered === null)
+        throw new BrowserTabNotFoundError(
+          `Tab ${this._targetId} is gone and no fallback page is available. Call browser.tabs() or browser.open(url).`,
+        );
+      this._targetId = recovered;
+      return this._targetId;
+    }
+  }
+
+  /**
+   * Re-bind this handle to the browser's currently active page.
+   *
+   * Primitive for recovering from lost tab handles after navigation or
+   * aggressive re-renders. Prefers non-blank pages, then pages matching
+   * the old URL, finally falls back to the first accessible tab.
+   *
+   * @returns The (possibly new) target ID
+   */
+  async reacquire(): Promise<string> {
+    const recovered = await resolveActiveTargetId(this.cdpUrl, { preferTargetId: this._targetId });
+    if (recovered === null)
+      throw new BrowserTabNotFoundError('No pages available to reacquire. Use browser.open(url) to create a tab.');
+    this._targetId = recovered;
     return this._targetId;
   }
 
@@ -211,10 +245,13 @@ export class CrawlPage {
       cdpUrl: this.cdpUrl,
       targetId: this._targetId,
       maxChars: opts?.maxChars,
+      timeoutMs: opts?.timeoutMs,
       options: {
         interactive: opts?.interactive,
         compact: opts?.compact,
         maxDepth: opts?.maxDepth,
+        waitForHydration: opts?.waitForHydration,
+        minInteractiveRefs: opts?.minInteractiveRefs,
       },
       ssrfPolicy: this.ssrfPolicy,
     });
@@ -1805,19 +1842,19 @@ export class BrowserClaw {
   /**
    * Get a CrawlPage handle for the currently active tab.
    *
-   * @returns CrawlPage for the first/active page
+   * Prefers tabs with real content over `about:blank` when multiple exist.
+   *
+   * @returns CrawlPage for the active page
    */
   async currentPage(): Promise<CrawlPage> {
     const connectT0 = Date.now();
-    const { browser } = await connectBrowser(this.cdpUrl);
+    await connectBrowser(this.cdpUrl);
     if (this._telemetry.connectMs === undefined) {
       this._telemetry.connectMs = Date.now() - connectT0;
       this._telemetry.timestamps.connectedAt = new Date().toISOString();
     }
-    const pages = getAllPages(browser);
-    if (!pages.length) throw new Error('No pages available. Use browser.open(url) to create a tab.');
-    const tid = await pageTargetId(pages[0]).catch(() => null);
-    if (tid === null || tid === '') throw new Error('Failed to get targetId for the current page.');
+    const tid = await resolveActiveTargetId(this.cdpUrl, { ssrfPolicy: this.ssrfPolicy });
+    if (tid === null) throw new BrowserTabNotFoundError('No pages available. Use browser.open(url) to create a tab.');
     return new CrawlPage(this.cdpUrl, tid, this.ssrfPolicy);
   }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -154,9 +154,11 @@ export class CrawlPage {
    * Useful after reconnection when the old target ID may be stale.
    *
    * If the current target is gone (tab closed or replaced after a hard
-   * redesign), falls back to the browser's best guess for the active page
-   * when `fallback: 'active'` is set. By default, throws
-   * `BrowserTabNotFoundError` if the old target is gone.
+   * redesign), falls back to the best-effort page resolver (first non-blank
+   * accessible tab, then any accessible tab) when `fallback: 'active'` is
+   * set. By default, throws `BrowserTabNotFoundError` if the old target is
+   * gone. The `'active'` name is historical — it does NOT query Chrome's
+   * real focused-tab state.
    */
   async refreshTargetId(opts?: { fallback?: 'active' }): Promise<string> {
     try {
@@ -715,6 +717,7 @@ export class CrawlPage {
       cdpUrl: this.cdpUrl,
       targetId: this._targetId,
       handler: handler ?? undefined,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -797,7 +800,11 @@ export class CrawlPage {
    * Get the current URL of the page.
    */
   async url(): Promise<string> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const page = await getPageForTargetId({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     return page.url();
   }
 
@@ -805,7 +812,11 @@ export class CrawlPage {
    * Get the page title.
    */
   async title(): Promise<string> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const page = await getPageForTargetId({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     return page.title();
   }
 
@@ -832,7 +843,11 @@ export class CrawlPage {
    * @param opts - Timeout options
    */
   async reload(opts?: { timeoutMs?: number }): Promise<void> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const page = await getPageForTargetId({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     ensurePageState(page);
     await page.reload({ timeout: normalizeTimeoutMs(opts?.timeoutMs, 20000) });
   }
@@ -843,7 +858,11 @@ export class CrawlPage {
    * @param opts - Timeout options
    */
   async goBack(opts?: { timeoutMs?: number }): Promise<void> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const page = await getPageForTargetId({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     ensurePageState(page);
     await page.goBack({ timeout: normalizeTimeoutMs(opts?.timeoutMs, 20000) });
   }
@@ -854,7 +873,11 @@ export class CrawlPage {
    * @param opts - Timeout options
    */
   async goForward(opts?: { timeoutMs?: number }): Promise<void> {
-    const page = await getPageForTargetId({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const page = await getPageForTargetId({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     ensurePageState(page);
     await page.goForward({ timeout: normalizeTimeoutMs(opts?.timeoutMs, 20000) });
   }
@@ -1176,6 +1199,7 @@ export class CrawlPage {
       targetId: this._targetId,
       width,
       height,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -1531,7 +1555,11 @@ export class CrawlPage {
   async isAuthenticated(rules: AuthCheckRule[]): Promise<AuthCheckResult> {
     if (!rules.length) return { authenticated: true, checks: [] };
 
-    const page = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const page = await getRestoredPageForTarget({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     const checks: AuthCheckDetail[] = [];
 
     // Pre-fetch body text once if any rule needs it, to avoid redundant evaluations
@@ -1672,7 +1700,11 @@ export class CrawlPage {
    * ```
    */
   async playwrightPage(): Promise<Page> {
-    return getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    return getRestoredPageForTarget({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
   }
 
   /**
@@ -1696,7 +1728,11 @@ export class CrawlPage {
    * ```
    */
   async locator(selector: string): Promise<Locator> {
-    const pwPage = await getRestoredPageForTarget({ cdpUrl: this.cdpUrl, targetId: this._targetId });
+    const pwPage = await getRestoredPageForTarget({
+      cdpUrl: this.cdpUrl,
+      targetId: this._targetId,
+      ssrfPolicy: this.ssrfPolicy,
+    });
     return pwPage.locator(selector);
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -181,13 +181,17 @@ export class CrawlPage {
   }
 
   /**
-   * Re-bind this handle to the browser's currently active page.
+   * Re-bind this handle using the best-effort page resolver.
    *
    * Primitive for recovering from lost tab handles after navigation or
    * aggressive re-renders. Captures the page's current URL (when still
    * reachable) so the resolver can prefer the same page after a reload,
-   * then falls back to the original targetId, then a non-blank tab,
-   * then the first accessible tab.
+   * then falls back to the original targetId, then the first non-blank
+   * accessible tab, then any accessible tab.
+   *
+   * NOTE: This does not query Chrome's actual focused tab. See
+   * `BrowserClaw.currentPage()` for the same caveat — track `targetId`
+   * explicitly when you need deterministic tab selection.
    *
    * @returns The (possibly new) target ID
    */
@@ -1863,11 +1867,16 @@ export class BrowserClaw {
   }
 
   /**
-   * Get a CrawlPage handle for the currently active tab.
+   * Get a CrawlPage handle for the first usable tab.
    *
-   * Prefers tabs with real content over `about:blank` when multiple exist.
+   * This is a best-effort heuristic — it prefers non-blank tabs over
+   * `about:blank` placeholders but does NOT query Chrome's real
+   * focused-tab state. In a multi-tab session with several real tabs,
+   * `currentPage()` may return a tab other than the one the user is
+   * looking at. Track `targetId` explicitly (via `browser.open()` or
+   * `browser.waitForTab()`) when you need deterministic tab selection.
    *
-   * @returns CrawlPage for the active page
+   * @returns CrawlPage for the first usable (non-blank, if possible) page
    */
   async currentPage(): Promise<CrawlPage> {
     const connectT0 = Date.now();

--- a/src/capture/pdf.ts
+++ b/src/capture/pdf.ts
@@ -7,7 +7,11 @@ export async function pdfViaPlaywright(opts: {
   targetId?: string;
   ssrfPolicy?: SsrfPolicy;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   if (opts.ssrfPolicy) {

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -11,7 +11,11 @@ export async function takeScreenshotViaPlaywright(opts: {
   type?: 'png' | 'jpeg';
   ssrfPolicy?: SsrfPolicy;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   if (opts.ssrfPolicy) {
@@ -49,7 +53,11 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   labels: { ref: string; index: number; box: { x: number; y: number; width: number; height: number } }[];
   skipped: string[];
 }> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   if (opts.ssrfPolicy) {

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -1,3 +1,6 @@
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, it, expect } from 'vitest';
 
 import {
@@ -6,6 +9,7 @@ import {
   hasProxyEnvConfigured,
   normalizeCdpWsUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
+  resolveIsolatedProfile,
 } from './chrome-launcher.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -247,5 +251,60 @@ describe('normalizeCdpHttpBaseForJsonEndpoints', () => {
   it('preserves custom paths that are not CDP-specific', () => {
     const result = normalizeCdpHttpBaseForJsonEndpoints('ws://localhost:9222/custom/path');
     expect(result).toContain('/custom/path');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveIsolatedProfile
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolveIsolatedProfile', () => {
+  const isolatedRoot = path.join(os.tmpdir(), 'browserclaw', 'isolated');
+
+  it('produces a unique directory for isolated: true across calls', () => {
+    const a = resolveIsolatedProfile(true);
+    const b = resolveIsolatedProfile(true);
+    expect(a.userDataDir).not.toBe(b.userDataDir);
+    expect(a.profileName).not.toBe(b.profileName);
+  });
+
+  it('produces a unique directory when the same string label is reused', () => {
+    // Guards the concurrent-launch case: two runs with isolated: "myname"
+    // must not end up on the same user-data-dir (Chrome SingletonLock).
+    const a = resolveIsolatedProfile('myname');
+    const b = resolveIsolatedProfile('myname');
+    expect(a.userDataDir).not.toBe(b.userDataDir);
+    expect(a.profileName).not.toBe(b.profileName);
+  });
+
+  it('prefixes the directory with the sanitized label for easy identification', () => {
+    const { userDataDir } = resolveIsolatedProfile('my/weird name!');
+    const namePart = path.basename(userDataDir);
+    expect(namePart.startsWith('my_weird_name_-')).toBe(true);
+    expect(path.dirname(userDataDir)).toBe(isolatedRoot);
+  });
+
+  it('falls back to "run" label when no string is provided', () => {
+    const { userDataDir, profileName } = resolveIsolatedProfile(true);
+    const namePart = path.basename(userDataDir);
+    expect(namePart.startsWith('run-')).toBe(true);
+    expect(profileName.startsWith('browserclaw-run-')).toBe(true);
+  });
+
+  it('treats empty / whitespace strings as an unlabelled run', () => {
+    const { userDataDir } = resolveIsolatedProfile('   ');
+    expect(path.basename(userDataDir).startsWith('run-')).toBe(true);
+  });
+
+  it('places isolated profiles under $TMPDIR/browserclaw/isolated/', () => {
+    const { userDataDir } = resolveIsolatedProfile(true);
+    expect(userDataDir.startsWith(isolatedRoot + path.sep)).toBe(true);
+  });
+
+  it('caps the label portion at 32 chars before appending the suffix', () => {
+    const { userDataDir } = resolveIsolatedProfile('a'.repeat(100));
+    const namePart = path.basename(userDataDir);
+    const label = namePart.split('-')[0];
+    expect(label.length).toBe(32);
   });
 });

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -547,17 +547,26 @@ function resolveUserDataDir(profileName: string): string {
 
 /**
  * Build a per-run isolated profile name + user-data directory. Isolated
- * profiles live under `isolated/<name>` so they are easy to identify and
- * clean up, and never collide with the shared default profile.
+ * profiles live under `isolated/<label>-<suffix>` so they are easy to
+ * identify and clean up, and never collide with each other or with the
+ * shared default profile.
+ *
+ * A run-scoped random suffix is always appended — even when the caller
+ * passes a label string — so that concurrent launches cannot share the
+ * same user-data directory (which would fail on Chrome's SingletonLock).
+ *
+ * @internal Exported for testing.
  */
-function resolveIsolatedProfile(value: boolean | string): { profileName: string; userDataDir: string } {
-  const namePart =
+export function resolveIsolatedProfile(value: boolean | string): { profileName: string; userDataDir: string } {
+  const label =
     typeof value === 'string' && value.trim() !== ''
       ? value
           .trim()
           .replace(/[^A-Za-z0-9_-]/g, '_')
-          .slice(0, 48)
-      : `run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+          .slice(0, 32)
+      : 'run';
+  const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const namePart = `${label}-${suffix}`;
   const profileName = `browserclaw-${namePart}`;
   const root = os.tmpdir();
   const userDataDir = path.join(root, 'browserclaw', 'isolated', namePart);

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -545,6 +545,25 @@ function resolveUserDataDir(profileName: string): string {
   return path.join(configDir, 'browserclaw', 'profiles', profileName, 'user-data');
 }
 
+/**
+ * Build a per-run isolated profile name + user-data directory. Isolated
+ * profiles live under `isolated/<name>` so they are easy to identify and
+ * clean up, and never collide with the shared default profile.
+ */
+function resolveIsolatedProfile(value: boolean | string): { profileName: string; userDataDir: string } {
+  const namePart =
+    typeof value === 'string' && value.trim() !== ''
+      ? value
+          .trim()
+          .replace(/[^A-Za-z0-9_-]/g, '_')
+          .slice(0, 48)
+      : `run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const profileName = `browserclaw-${namePart}`;
+  const root = os.tmpdir();
+  const userDataDir = path.join(root, 'browserclaw', 'isolated', namePart);
+  return { profileName, userDataDir };
+}
+
 // ── WebSocket / CDP URL Helpers ──
 
 function isWebSocketUrl(url: string): boolean {
@@ -827,8 +846,10 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   if (!exe)
     throw new Error('No supported browser found (Chrome/Brave/Edge/Chromium). Install one or provide executablePath.');
 
-  const profileName = opts.profileName ?? DEFAULT_PROFILE_NAME;
-  const userDataDir = opts.userDataDir ?? resolveUserDataDir(profileName);
+  const isolated = opts.isolated;
+  const isolatedResolved = isolated === undefined || isolated === false ? null : resolveIsolatedProfile(isolated);
+  const profileName = isolatedResolved?.profileName ?? opts.profileName ?? DEFAULT_PROFILE_NAME;
+  const userDataDir = isolatedResolved?.userDataDir ?? opts.userDataDir ?? resolveUserDataDir(profileName);
   fs.mkdirSync(userDataDir, { recursive: true });
 
   const spawnChrome = (spawnOpts?: { detached?: boolean }, runOpts?: { forceHeadless?: boolean }) => {
@@ -949,19 +970,35 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     startedAt,
     launchMs: Date.now() - startedAt,
     proc,
+    ...(isolatedResolved !== null ? { isolated: true } : {}),
   };
 }
 
 export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Promise<void> {
   const proc = running.proc;
-  if (proc.exitCode !== null) return;
+  const cleanupIsolated = () => {
+    if (running.isolated !== true) return;
+    try {
+      fs.rmSync(running.userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup of isolated profile directory */
+    }
+  };
+  if (proc.exitCode !== null) {
+    cleanupIsolated();
+    return;
+  }
   killProcessTree(proc, 'SIGTERM');
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     // exitCode changes asynchronously after SIGTERM; re-read from proc
-    if ((proc as { exitCode: number | null }).exitCode !== null) return;
+    if ((proc as { exitCode: number | null }).exitCode !== null) {
+      cleanupIsolated();
+      return;
+    }
     const remainingMs = timeoutMs - (Date.now() - start);
     await new Promise((r) => setTimeout(r, Math.max(1, Math.min(100, remainingMs))));
   }
   killProcessTree(proc, 'SIGKILL');
+  cleanupIsolated();
 }

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -15,6 +15,7 @@ import {
   withNoProxyForCdpUrl,
   getAllPages,
   takeAiSnapshotText,
+  pickActiveTargetId,
 } from './connection.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -448,5 +449,98 @@ describe('takeAiSnapshotText', () => {
       _snapshotForAI: () => Promise.resolve({}),
     } as unknown as Page;
     await expect(takeAiSnapshotText(mockPage, 5000)).resolves.toBe('');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pickActiveTargetId
+// ─────────────────────────────────────────────────────────────────────────────
+
+function pageWithUrl(url: string): Page {
+  return { url: () => url } as unknown as Page;
+}
+
+describe('pickActiveTargetId', () => {
+  it('returns the page matching preferTargetId', async () => {
+    const accessible = [pageWithUrl('https://a.test/'), pageWithUrl('https://b.test/')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-a'],
+      [accessible[1], 't-b'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: 't-b', preferUrl: '', tidOf });
+    expect(result).toBe('t-b');
+  });
+
+  it('returns the page matching preferUrl when no targetId matches', async () => {
+    const accessible = [pageWithUrl('https://a.test/'), pageWithUrl('https://b.test/')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-a'],
+      [accessible[1], 't-b'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({
+      accessible,
+      preferTargetId: 't-gone',
+      preferUrl: 'https://b.test/',
+      tidOf,
+    });
+    expect(result).toBe('t-b');
+  });
+
+  it('prefers non-blank pages over about:blank when no prefer-hints match', async () => {
+    const accessible = [pageWithUrl('about:blank'), pageWithUrl('https://real.test/')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-blank'],
+      [accessible[1], 't-real'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-real');
+  });
+
+  it('iterates the final fallback when the first accessible page has no targetId', async () => {
+    // All pages blank, first one's pageTargetId returns null (transient CDP
+    // failure) — we must still return the second page's tid instead of bailing.
+    const accessible = [pageWithUrl('about:blank'), pageWithUrl('about:blank')];
+    const tids = new Map<Page, string | null>([
+      [accessible[0], null],
+      [accessible[1], 't-recovered'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-recovered');
+  });
+
+  it('iterates the non-blank branch when the first non-blank page has no targetId', async () => {
+    const accessible = [pageWithUrl('https://a.test/'), pageWithUrl('https://b.test/')];
+    const tids = new Map<Page, string | null>([
+      [accessible[0], null],
+      [accessible[1], 't-b'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-b');
+  });
+
+  it('returns null only when no accessible page has a usable targetId', async () => {
+    const accessible = [pageWithUrl('about:blank'), pageWithUrl('about:blank')];
+    const tidOf = () => Promise.resolve(null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBeNull();
+  });
+
+  it('skips pages whose tidOf rejects without failing the whole resolve', async () => {
+    const accessible = [pageWithUrl('https://a.test/'), pageWithUrl('https://b.test/')];
+    const tidOf = (page: Page) => (page === accessible[0] ? Promise.resolve(null) : Promise.resolve('t-b'));
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-b');
   });
 });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -897,12 +897,31 @@ export async function resolveActiveTargetId(
   const { accessible } = await partitionAccessiblePages({ cdpUrl, pages });
   if (!accessible.length) return null;
 
-  const preferTargetId = opts?.preferTargetId?.trim() ?? '';
-  const preferUrl = opts?.preferUrl?.trim() ?? '';
+  return pickActiveTargetId({
+    accessible,
+    preferTargetId: opts?.preferTargetId?.trim() ?? '',
+    preferUrl: opts?.preferUrl?.trim() ?? '',
+    tidOf: (page) => pageTargetId(page).catch(() => null),
+  });
+}
+
+/**
+ * Pure selection logic for `resolveActiveTargetId`. Extracted so it can be
+ * unit-tested without a live CDP connection.
+ *
+ * @internal Exported for testing.
+ */
+export async function pickActiveTargetId(opts: {
+  accessible: Page[];
+  preferTargetId: string;
+  preferUrl: string;
+  tidOf: (page: Page) => Promise<string | null>;
+}): Promise<string | null> {
+  const { accessible, preferTargetId, preferUrl, tidOf } = opts;
 
   if (preferTargetId !== '') {
     for (const page of accessible) {
-      const tid = await pageTargetId(page).catch(() => null);
+      const tid = await tidOf(page);
       if (tid === preferTargetId) return tid;
     }
   }
@@ -910,7 +929,7 @@ export async function resolveActiveTargetId(
   if (preferUrl !== '') {
     for (const page of accessible) {
       if (page.url() === preferUrl) {
-        const tid = await pageTargetId(page).catch(() => null);
+        const tid = await tidOf(page);
         if (tid !== null && tid !== '') return tid;
       }
     }
@@ -918,11 +937,18 @@ export async function resolveActiveTargetId(
 
   for (const page of accessible) {
     if (!isBlankUrl(page.url())) {
-      const tid = await pageTargetId(page).catch(() => null);
+      const tid = await tidOf(page);
       if (tid !== null && tid !== '') return tid;
     }
   }
 
-  const tid = await pageTargetId(accessible[0]).catch(() => null);
-  return tid !== null && tid !== '' ? tid : null;
+  // Final fallback: any accessible page whose targetId resolves. We iterate
+  // rather than only asking `accessible[0]` because a transient pageTargetId
+  // failure on the first page must not mask a usable later page.
+  for (const page of accessible) {
+    const tid = await tidOf(page);
+    if (tid !== null && tid !== '') return tid;
+  }
+
+  return null;
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -407,8 +407,13 @@ export async function setDialogHandler(opts: {
   cdpUrl: string;
   targetId?: string;
   handler?: DialogHandler;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   setDialogHandlerOnPage(page, opts.handler);
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -864,13 +864,21 @@ function isBlankUrl(url: string): boolean {
 }
 
 /**
- * Best-effort resolution of the currently active (visible) page's targetId.
+ * Best-effort heuristic resolver for a usable page targetId.
  *
- * Preference order:
+ * This does NOT query Chrome's actual focused/visible tab — CDP does not
+ * expose a simple "which tab is foregrounded" signal, so the resolver
+ * picks the most plausible candidate by this preference order:
+ *
  *  1. The page matching `preferTargetId` when still accessible.
  *  2. A page whose URL matches `preferUrl` exactly (helpful after reloads).
- *  3. The first non-blank accessible page.
+ *  3. The first non-blank accessible page (skips `about:blank` placeholders).
  *  4. The first accessible page (even if blank).
+ *
+ * In multi-tab sessions without any prefer-hints, the first non-blank tab
+ * "wins" regardless of which tab the user is actually looking at. Callers
+ * that need true active-tab semantics should track `targetId` explicitly
+ * via `browser.open()` / `browser.waitForTab()` instead.
  *
  * Returns null when no accessible pages remain.
  */

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -11,6 +11,7 @@ import {
   isLoopbackHost,
   hasProxyEnvConfigured,
 } from './chrome-launcher.js';
+import { BrowserTabNotFoundError } from './errors.js';
 import { ensurePageState, observeBrowser, setDialogHandlerOnPage } from './page-utils.js';
 import { clearRoleRefsForCdpUrl, normalizeCdpUrl } from './ref-resolver.js';
 import { assertCdpEndpointAllowed } from './security.js';
@@ -45,12 +46,7 @@ export {
 
 // ── Errors ──
 
-export class BrowserTabNotFoundError extends Error {
-  constructor(message = 'Tab not found') {
-    super(message);
-    this.name = 'BrowserTabNotFoundError';
-  }
-}
+export { BrowserTabNotFoundError, StaleRefError, SnapshotHydrationError, NavigationRaceError } from './errors.js';
 
 /**
  * Page extended with Playwright's AI-snapshot APIs.
@@ -861,4 +857,59 @@ export async function getRestoredPageForTarget(opts: {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   return page;
+}
+
+function isBlankUrl(url: string): boolean {
+  return url === '' || url === 'about:blank' || url.startsWith('chrome://new-tab-page') || url === 'chrome://newtab/';
+}
+
+/**
+ * Best-effort resolution of the currently active (visible) page's targetId.
+ *
+ * Preference order:
+ *  1. The page matching `preferTargetId` when still accessible.
+ *  2. A page whose URL matches `preferUrl` exactly (helpful after reloads).
+ *  3. The first non-blank accessible page.
+ *  4. The first accessible page (even if blank).
+ *
+ * Returns null when no accessible pages remain.
+ */
+export async function resolveActiveTargetId(
+  cdpUrl: string,
+  opts?: { preferTargetId?: string; preferUrl?: string; ssrfPolicy?: SsrfPolicy },
+): Promise<string | null> {
+  const { browser } = await connectBrowser(cdpUrl, undefined, opts?.ssrfPolicy);
+  const pages = getAllPages(browser);
+  if (!pages.length) return null;
+  const { accessible } = await partitionAccessiblePages({ cdpUrl, pages });
+  if (!accessible.length) return null;
+
+  const preferTargetId = opts?.preferTargetId?.trim() ?? '';
+  const preferUrl = opts?.preferUrl?.trim() ?? '';
+
+  if (preferTargetId !== '') {
+    for (const page of accessible) {
+      const tid = await pageTargetId(page).catch(() => null);
+      if (tid === preferTargetId) return tid;
+    }
+  }
+
+  if (preferUrl !== '') {
+    for (const page of accessible) {
+      if (page.url() === preferUrl) {
+        const tid = await pageTargetId(page).catch(() => null);
+        if (tid !== null && tid !== '') return tid;
+      }
+    }
+  }
+
+  for (const page of accessible) {
+    if (!isBlankUrl(page.url())) {
+      const tid = await pageTargetId(page).catch(() => null);
+      if (tid !== null && tid !== '') return tid;
+    }
+  }
+
+  const tid = await pageTargetId(accessible[0]).catch(() => null);
+  return tid !== null && tid !== '' ? tid : null;
 }

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import { BrowserTabNotFoundError, StaleRefError, SnapshotHydrationError, NavigationRaceError } from './errors.js';
+
+describe('structured errors', () => {
+  it('BrowserTabNotFoundError carries a default message and name', () => {
+    const err = new BrowserTabNotFoundError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('BrowserTabNotFoundError');
+    expect(err.message).toBe('Tab not found');
+  });
+
+  it('StaleRefError exposes the offending ref', () => {
+    const err = new StaleRefError('e7');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('StaleRefError');
+    expect(err.ref).toBe('e7');
+    expect(err.message).toContain('Unknown ref "e7"');
+    expect(err.message).toContain('re-rendered');
+  });
+
+  it('StaleRefError accepts a custom message', () => {
+    const err = new StaleRefError('e2', 'custom');
+    expect(err.ref).toBe('e2');
+    expect(err.message).toBe('custom');
+  });
+
+  it('SnapshotHydrationError reports attempts and elapsed time', () => {
+    const err = new SnapshotHydrationError({ attempts: 4, elapsedMs: 5200 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('SnapshotHydrationError');
+    expect(err.attempts).toBe(4);
+    expect(err.elapsedMs).toBe(5200);
+    expect(err.message).toContain('4 attempts');
+    expect(err.message).toContain('5200ms');
+  });
+
+  it('NavigationRaceError reports from/to urls', () => {
+    const err = new NavigationRaceError({ fromUrl: 'https://a.test/', toUrl: 'https://b.test/' });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('NavigationRaceError');
+    expect(err.fromUrl).toBe('https://a.test/');
+    expect(err.toUrl).toBe('https://b.test/');
+    expect(err.message).toContain('https://a.test/');
+    expect(err.message).toContain('https://b.test/');
+  });
+
+  it('errors are distinguishable via instanceof', () => {
+    const a: unknown = new StaleRefError('e1');
+    const b: unknown = new SnapshotHydrationError({ attempts: 1, elapsedMs: 1 });
+    expect(a instanceof StaleRefError).toBe(true);
+    expect(a instanceof SnapshotHydrationError).toBe(false);
+    expect(b instanceof SnapshotHydrationError).toBe(true);
+    expect(b instanceof NavigationRaceError).toBe(false);
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,88 @@
+/**
+ * Structured error types raised by BrowserClaw's low-level primitives.
+ *
+ * Workflow code can `instanceof`-check these to distinguish recoverable
+ * cases (stale ref, empty hydration) from harder failures (missing tab,
+ * unexpected navigation).
+ */
+
+/**
+ * Thrown when a targetId is not backed by any open tab on the browser.
+ *
+ * Typical causes: the tab was closed, the process was restarted, or a
+ * stored targetId is being reused across sessions. Call `browser.tabs()`
+ * to discover the currently open tabs.
+ */
+export class BrowserTabNotFoundError extends Error {
+  constructor(message = 'Tab not found') {
+    super(message);
+    this.name = 'BrowserTabNotFoundError';
+  }
+}
+
+/**
+ * Thrown when a ref from a prior snapshot can no longer be resolved on the page.
+ *
+ * Typical causes: the page re-rendered (SPA route change, modal close, data
+ * refresh), the element was removed, or the snapshot is too old. Recovery is
+ * almost always to take a fresh snapshot and use the new refs.
+ */
+export class StaleRefError extends Error {
+  /** The ref ID that could not be resolved. */
+  readonly ref: string;
+  constructor(ref: string, message?: string) {
+    super(
+      message ??
+        `Unknown ref "${ref}". Run a new snapshot and use a ref from that snapshot (the page may have re-rendered).`,
+    );
+    this.name = 'StaleRefError';
+    this.ref = ref;
+  }
+}
+
+/**
+ * Thrown when a snapshot comes back empty or without interactive refs after
+ * hydration retries were exhausted.
+ *
+ * Typical causes: the page is still hydrating, an SPA has not yet rendered
+ * its first interactive frame, or an anti-bot challenge is blocking content.
+ */
+export class SnapshotHydrationError extends Error {
+  /** Number of snapshot attempts made before giving up. */
+  readonly attempts: number;
+  /** Milliseconds spent waiting for hydration. */
+  readonly elapsedMs: number;
+  constructor(opts: { attempts: number; elapsedMs: number; message?: string }) {
+    super(
+      opts.message ??
+        `Snapshot returned no interactive elements after ${String(opts.attempts)} attempts (${String(opts.elapsedMs)}ms). The page may still be hydrating or blocked by a challenge.`,
+    );
+    this.name = 'SnapshotHydrationError';
+    this.attempts = opts.attempts;
+    this.elapsedMs = opts.elapsedMs;
+  }
+}
+
+/**
+ * Thrown when an operation detects that the page navigated away (or the
+ * target URL changed unexpectedly) while the operation was in flight.
+ *
+ * Recovery: re-acquire the page, re-snapshot, and retry. For navigation
+ * races caused by user interaction that deliberately triggers a new page,
+ * catch this and re-run the action against the post-navigation page.
+ */
+export class NavigationRaceError extends Error {
+  /** URL the operation started against. */
+  readonly fromUrl: string;
+  /** URL the page ended up on. */
+  readonly toUrl: string;
+  constructor(opts: { fromUrl: string; toUrl: string; message?: string }) {
+    super(
+      opts.message ??
+        `Page navigated from "${opts.fromUrl}" to "${opts.toUrl}" during the operation. Re-snapshot before retrying.`,
+    );
+    this.name = 'NavigationRaceError';
+    this.fromUrl = opts.fromUrl;
+    this.toUrl = opts.toUrl;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   withPlaywrightPageCdpSession,
   withPageScopedCdpClient,
   resolvePageByTargetIdOrThrow,
+  resolveActiveTargetId,
   requireRef,
   requireRefOrSelector,
   resolveInteractionTimeoutMs,
@@ -43,6 +44,9 @@ export {
   parseRoleRef,
   BrowserTabNotFoundError,
   BlockedBrowserTargetError,
+  StaleRefError,
+  SnapshotHydrationError,
+  NavigationRaceError,
 } from './connection.js';
 export { pressAndHoldViaCdp } from './actions/interaction.js';
 export type { FrameEvalResult } from './actions/evaluate.js';

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -1,5 +1,6 @@
 import type { Page } from 'playwright-core';
 
+import { StaleRefError } from './errors.js';
 import { ensurePageState, getPageState } from './page-utils.js';
 import type { RoleRefs } from './types.js';
 
@@ -188,7 +189,7 @@ export function refLocator(page: Page, ref: string) {
       ).locator(`aria-ref=${normalized}`);
     }
 
-    if (!info) throw new Error(`Unknown ref "${normalized}". Run a new snapshot and use a ref from that snapshot.`);
+    if (!info) throw new StaleRefError(normalized);
 
     const locAny =
       state.roleRefsFrameSelector !== undefined && state.roleRefsFrameSelector !== ''

--- a/src/snapshot/ai-snapshot.test.ts
+++ b/src/snapshot/ai-snapshot.test.ts
@@ -136,4 +136,40 @@ describe('snapshotAi hydration retry', () => {
 
     expect(result.contentMeta?.sourceUrl).toBe('https://b.test/');
   });
+
+  it('does not poison the per-target ref cache when NavigationRaceError is thrown', async () => {
+    // If we threw a race error but still called storeRoleRefsForTarget, a caller
+    // that caught and retried without re-snapshotting could target refs bound
+    // to a discarded document. The store must only happen on success.
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://b.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('- button "OK" [ref=e1]');
+
+    await expect(
+      snapshotAi({
+        cdpUrl: 'http://localhost:9222',
+        targetId: 't1',
+        options: { waitForHydration: 2000 },
+      }),
+    ).rejects.toBeInstanceOf(NavigationRaceError);
+
+    expect(mockStoreRoleRefsForTarget).not.toHaveBeenCalled();
+  });
+
+  it('does not store refs on retry iterations, only on the returned snapshot', async () => {
+    // Two empty iterations then a ready one. Previously we'd call store 3 times
+    // (once per iteration); now we only call it on the final success.
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/']));
+    mockTakeAiSnapshotText
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('- button "OK" [ref=e1]');
+
+    await snapshotAi({
+      cdpUrl: 'http://localhost:9222',
+      targetId: 't1',
+      options: { waitForHydration: 2000 },
+    });
+
+    expect(mockStoreRoleRefsForTarget).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/snapshot/ai-snapshot.test.ts
+++ b/src/snapshot/ai-snapshot.test.ts
@@ -84,7 +84,7 @@ describe('snapshotAi hydration retry', () => {
   });
 
   it('throws NavigationRaceError when URL changes during hydration retry', async () => {
-    // First call captures sourceUrl=A, then page.url() returns B on the next read.
+    // initialUrl=A, snapshotUrl=A (same doc), then waitUrl=B after the sleep.
     mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://a.test/', 'https://b.test/']));
     mockTakeAiSnapshotText.mockResolvedValue('');
 
@@ -95,5 +95,45 @@ describe('snapshotAi hydration retry', () => {
         options: { waitForHydration: 2000 },
       }),
     ).rejects.toBeInstanceOf(NavigationRaceError);
+  });
+
+  it('throws NavigationRaceError before returning when URL drifted during the snapshot itself', async () => {
+    // initialUrl=A, then snapshotUrl=B — the page navigated while takeAiSnapshotText ran.
+    // Even though the snapshot has interactive refs, we must not return stale sourceUrl.
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://b.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('- button "OK" [ref=e1]');
+
+    await expect(
+      snapshotAi({
+        cdpUrl: 'http://localhost:9222',
+        targetId: 't1',
+        options: { waitForHydration: 2000 },
+      }),
+    ).rejects.toBeInstanceOf(NavigationRaceError);
+  });
+
+  it('threads ssrfPolicy into getPageForTargetId', async () => {
+    const policy = { dangerouslyAllowPrivateNetwork: false };
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://example.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('');
+
+    await snapshotAi({ cdpUrl: 'http://localhost:9222', targetId: 't1', ssrfPolicy: policy });
+
+    expect(mockGetPageForTargetId).toHaveBeenCalledWith({
+      cdpUrl: 'http://localhost:9222',
+      targetId: 't1',
+      ssrfPolicy: policy,
+    });
+  });
+
+  it('records the snapshot-time URL in contentMeta, not the initial URL', async () => {
+    // Without hydration, a mid-snapshot redirect is not a race — but the metadata
+    // should still reflect the document the refs were actually built against.
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://b.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('- button "OK" [ref=e1]');
+
+    const result = await snapshotAi({ cdpUrl: 'http://localhost:9222', targetId: 't1' });
+
+    expect(result.contentMeta?.sourceUrl).toBe('https://b.test/');
   });
 });

--- a/src/snapshot/ai-snapshot.test.ts
+++ b/src/snapshot/ai-snapshot.test.ts
@@ -83,9 +83,14 @@ describe('snapshotAi hydration retry', () => {
     ).rejects.toBeInstanceOf(SnapshotHydrationError);
   });
 
-  it('throws NavigationRaceError when URL changes during hydration retry', async () => {
-    // initialUrl=A, snapshotUrl=A (same doc), then waitUrl=B after the sleep.
-    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://a.test/', 'https://b.test/']));
+  it('throws NavigationRaceError when URL changes between retries during hydration', async () => {
+    // page.url() is called at: entry (initial), post-snapshot (snapshotUrl),
+    // post-enrichment (postEnrichUrl), post-sleep (waitUrl). We keep the
+    // first three aligned so the check fires on the post-sleep waitUrl,
+    // exercising the between-retries race path.
+    mockGetPageForTargetId.mockResolvedValue(
+      makeMockPage(['https://a.test/', 'https://a.test/', 'https://a.test/', 'https://b.test/']),
+    );
     mockTakeAiSnapshotText.mockResolvedValue('');
 
     await expect(
@@ -110,6 +115,26 @@ describe('snapshotAi hydration retry', () => {
         options: { waitForHydration: 2000 },
       }),
     ).rejects.toBeInstanceOf(NavigationRaceError);
+  });
+
+  it('throws NavigationRaceError when URL drifts during DOM enrichment', async () => {
+    // initialUrl=A, snapshotUrl=A (no drift during takeAiSnapshotText), then
+    // postEnrichUrl=B — the page navigated while enrichSnapshotFromDom ran.
+    // Without this check, we'd merge AI-snapshot refs (from A) with
+    // DOM-enrichment data (from B) and return/store the inconsistent result.
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://a.test/', 'https://b.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('- button "OK" [ref=e1]');
+
+    await expect(
+      snapshotAi({
+        cdpUrl: 'http://localhost:9222',
+        targetId: 't1',
+        options: { waitForHydration: 2000 },
+      }),
+    ).rejects.toBeInstanceOf(NavigationRaceError);
+
+    // And the ref cache must not have been stamped.
+    expect(mockStoreRoleRefsForTarget).not.toHaveBeenCalled();
   });
 
   it('threads ssrfPolicy into getPageForTargetId', async () => {

--- a/src/snapshot/ai-snapshot.test.ts
+++ b/src/snapshot/ai-snapshot.test.ts
@@ -1,0 +1,99 @@
+import type { Page } from 'playwright-core';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { NavigationRaceError, SnapshotHydrationError } from '../errors.js';
+
+vi.mock('../actions/navigation.js', () => ({
+  assertPageNavigationCompletedSafely: () => Promise.resolve(),
+}));
+
+vi.mock('./dom-enrichment.js', () => ({
+  enrichSnapshotFromDom: () => Promise.resolve({ refs: {}, additions: [] }),
+  mergeSnapshotWithEnrichment: (built: unknown) => built,
+  nextRefCounter: () => 1,
+}));
+
+const { mockGetPageForTargetId, mockTakeAiSnapshotText, mockStoreRoleRefsForTarget } = vi.hoisted(() => ({
+  mockGetPageForTargetId: vi.fn<(opts: unknown) => Promise<Page>>(),
+  mockTakeAiSnapshotText: vi.fn<(page: Page, timeoutMs: number) => Promise<string>>(),
+  mockStoreRoleRefsForTarget: vi.fn(),
+}));
+
+vi.mock('../connection.js', () => ({
+  getPageForTargetId: mockGetPageForTargetId,
+  ensurePageState: () => ({}),
+  storeRoleRefsForTarget: mockStoreRoleRefsForTarget,
+  normalizeTimeoutMs: (timeoutMs: number | undefined, fallback: number) => timeoutMs ?? fallback,
+  takeAiSnapshotText: mockTakeAiSnapshotText,
+}));
+
+const { snapshotAi } = await import('./ai-snapshot.js');
+
+function makeMockPage(urls: string[]): Page {
+  let i = 0;
+  return {
+    url: () => urls[Math.min(i++, urls.length - 1)] ?? '',
+  } as unknown as Page;
+}
+
+describe('snapshotAi hydration retry', () => {
+  beforeEach(() => {
+    mockGetPageForTargetId.mockReset();
+    mockTakeAiSnapshotText.mockReset();
+    mockStoreRoleRefsForTarget.mockReset();
+  });
+
+  it('returns immediately when waitForHydration is disabled, even with empty snapshot', async () => {
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://example.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('');
+
+    const result = await snapshotAi({ cdpUrl: 'http://localhost:9222', targetId: 't1' });
+
+    expect(mockTakeAiSnapshotText).toHaveBeenCalledTimes(1);
+    expect(result.refs).toEqual({});
+  });
+
+  it('retries until interactive refs appear when waitForHydration is enabled', async () => {
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://example.test/']));
+    mockTakeAiSnapshotText
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('- button "OK" [ref=e1]');
+
+    const result = await snapshotAi({
+      cdpUrl: 'http://localhost:9222',
+      targetId: 't1',
+      options: { waitForHydration: 2000 },
+    });
+
+    expect(mockTakeAiSnapshotText).toHaveBeenCalledTimes(3);
+    expect(Object.keys(result.refs).length).toBeGreaterThan(0);
+  });
+
+  it('throws SnapshotHydrationError when budget exhausts without interactive refs', async () => {
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://example.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('');
+
+    await expect(
+      snapshotAi({
+        cdpUrl: 'http://localhost:9222',
+        targetId: 't1',
+        options: { waitForHydration: 250 },
+      }),
+    ).rejects.toBeInstanceOf(SnapshotHydrationError);
+  });
+
+  it('throws NavigationRaceError when URL changes during hydration retry', async () => {
+    // First call captures sourceUrl=A, then page.url() returns B on the next read.
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage(['https://a.test/', 'https://a.test/', 'https://b.test/']));
+    mockTakeAiSnapshotText.mockResolvedValue('');
+
+    await expect(
+      snapshotAi({
+        cdpUrl: 'http://localhost:9222',
+        targetId: 't1',
+        options: { waitForHydration: 2000 },
+      }),
+    ).rejects.toBeInstanceOf(NavigationRaceError);
+  });
+});

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -6,10 +6,21 @@ import {
   normalizeTimeoutMs,
   takeAiSnapshotText,
 } from '../connection.js';
+import { SnapshotHydrationError } from '../errors.js';
 import type { SnapshotResult, SnapshotOptions, SsrfPolicy } from '../types.js';
 
 import { enrichSnapshotFromDom, mergeSnapshotWithEnrichment, nextRefCounter } from './dom-enrichment.js';
 import { buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
+
+const DEFAULT_HYDRATION_BUDGET_MS = 5000;
+const HYDRATION_POLL_INTERVAL_MS = 250;
+
+function resolveHydrationBudgetMs(value: boolean | number | undefined): number {
+  if (value === undefined || value === false) return 0;
+  if (value === true) return DEFAULT_HYDRATION_BUDGET_MS;
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(60_000, Math.floor(value));
+}
 
 /**
  * Take an AI-readable snapshot using Playwright's AI-mode snapshot API.
@@ -37,43 +48,64 @@ export async function snapshotAi(opts: {
   }
 
   const sourceUrl = page.url();
+  const hydrationBudgetMs = resolveHydrationBudgetMs(opts.options?.waitForHydration);
+  const minInteractive = Math.max(1, Math.floor(opts.options?.minInteractiveRefs ?? 1));
+  const started = Date.now();
+  let attempts = 0;
+  let lastResult: SnapshotResult | undefined;
 
-  let snapshot = await takeAiSnapshotText(page, normalizeTimeoutMs(opts.timeoutMs, 5000, 60000));
+  const deadline = started + hydrationBudgetMs;
   const maxChars = opts.maxChars;
   const limit =
     typeof maxChars === 'number' && Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : undefined;
 
-  let truncated = false;
-  if (limit !== undefined && snapshot.length > limit) {
-    const lastNewline = snapshot.lastIndexOf('\n', limit);
-    const cutoff = lastNewline > 0 ? lastNewline : limit;
-    snapshot = `${snapshot.slice(0, cutoff)}\n\n[...TRUNCATED - page too large]`;
-    truncated = true;
+  for (;;) {
+    attempts += 1;
+    let snapshot = await takeAiSnapshotText(page, normalizeTimeoutMs(opts.timeoutMs, 5000, 60000));
+
+    let truncated = false;
+    if (limit !== undefined && snapshot.length > limit) {
+      const lastNewline = snapshot.lastIndexOf('\n', limit);
+      const cutoff = lastNewline > 0 ? lastNewline : limit;
+      snapshot = `${snapshot.slice(0, cutoff)}\n\n[...TRUNCATED - page too large]`;
+      truncated = true;
+    }
+
+    const built = buildRoleSnapshotFromAiSnapshot(snapshot, opts.options);
+    const enriched = await enrichSnapshotFromDom(page, nextRefCounter(built.refs));
+    const merged = mergeSnapshotWithEnrichment(built, enriched);
+
+    storeRoleRefsForTarget({
+      page,
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      refs: merged.refs,
+      mode: 'aria',
+    });
+
+    const stats = getRoleSnapshotStats(merged.snapshot, merged.refs);
+    lastResult = {
+      snapshot: merged.snapshot,
+      refs: merged.refs,
+      stats,
+      ...(truncated ? { truncated } : {}),
+      untrusted: true,
+      contentMeta: {
+        sourceUrl,
+        contentType: 'browser-snapshot',
+        capturedAt: new Date().toISOString(),
+      },
+    };
+
+    if (hydrationBudgetMs === 0) return lastResult;
+    if (stats.interactive >= minInteractive) return lastResult;
+    if (Date.now() >= deadline) break;
+
+    const remaining = deadline - Date.now();
+    await new Promise((r) => setTimeout(r, Math.min(HYDRATION_POLL_INTERVAL_MS, Math.max(50, remaining))));
   }
 
-  const built = buildRoleSnapshotFromAiSnapshot(snapshot, opts.options);
-
-  const enriched = await enrichSnapshotFromDom(page, nextRefCounter(built.refs));
-  const merged = mergeSnapshotWithEnrichment(built, enriched);
-
-  storeRoleRefsForTarget({
-    page,
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-    refs: merged.refs,
-    mode: 'aria',
+  throw Object.assign(new SnapshotHydrationError({ attempts, elapsedMs: Date.now() - started }), {
+    cause: { snapshot: lastResult },
   });
-
-  return {
-    snapshot: merged.snapshot,
-    refs: merged.refs,
-    stats: getRoleSnapshotStats(merged.snapshot, merged.refs),
-    ...(truncated ? { truncated } : {}),
-    untrusted: true,
-    contentMeta: {
-      sourceUrl,
-      contentType: 'browser-snapshot',
-      capturedAt: new Date().toISOString(),
-    },
-  };
 }

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -78,20 +78,22 @@ export async function snapshotAi(opts: {
       truncated = true;
     }
 
+    // When the caller asked for hydration and the document changed between
+    // the initial resolution and the snapshot we just took, the snapshot is
+    // bound to a different document than the one they asked about. Surface
+    // that as NavigationRaceError and do NOT stamp the per-target ref cache
+    // — the caller's expected recovery is re-snapshot, and leaving refs
+    // bound to the discarded document would poison a naive retry.
+    if (hydrationBudgetMs > 0 && snapshotUrl !== initialUrl) {
+      throw new NavigationRaceError({ fromUrl: initialUrl, toUrl: snapshotUrl });
+    }
+
     const built = buildRoleSnapshotFromAiSnapshot(snapshot, opts.options);
     const enriched = await enrichSnapshotFromDom(page, nextRefCounter(built.refs));
     const merged = mergeSnapshotWithEnrichment(built, enriched);
-
-    storeRoleRefsForTarget({
-      page,
-      cdpUrl: opts.cdpUrl,
-      targetId: opts.targetId,
-      refs: merged.refs,
-      mode: 'aria',
-    });
-
     const stats = getRoleSnapshotStats(merged.snapshot, merged.refs);
-    lastResult = {
+
+    const result: SnapshotResult = {
       snapshot: merged.snapshot,
       refs: merged.refs,
       stats,
@@ -103,20 +105,25 @@ export async function snapshotAi(opts: {
         capturedAt: new Date().toISOString(),
       },
     };
+    lastResult = result;
 
     const ready = stats.interactive >= minInteractive;
+    const finished = hydrationBudgetMs === 0 || ready;
 
-    // When the caller asked for hydration and the document changed between
-    // the initial resolution and the snapshot we just took, the snapshot is
-    // bound to a different document than the one they asked about. Surface
-    // that as NavigationRaceError instead of silently returning refs for
-    // the post-navigation page with stale metadata.
-    if (hydrationBudgetMs > 0 && snapshotUrl !== initialUrl) {
-      throw new NavigationRaceError({ fromUrl: initialUrl, toUrl: snapshotUrl });
+    if (finished) {
+      // Only stamp the per-target ref cache when we're actually returning
+      // this result. On retry iterations we leave the previous cache in
+      // place so a racing caller doesn't see intermediate empty snapshots.
+      storeRoleRefsForTarget({
+        page,
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        refs: merged.refs,
+        mode: 'aria',
+      });
+      return result;
     }
 
-    if (hydrationBudgetMs === 0) return lastResult;
-    if (ready) return lastResult;
     if (Date.now() >= deadline) break;
 
     const remaining = deadline - Date.now();

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -91,6 +91,18 @@ export async function snapshotAi(opts: {
     const built = buildRoleSnapshotFromAiSnapshot(snapshot, opts.options);
     const enriched = await enrichSnapshotFromDom(page, nextRefCounter(built.refs));
     const merged = mergeSnapshotWithEnrichment(built, enriched);
+
+    // The AI snapshot (above) and the DOM enrichment (just now) each read from
+    // whatever document was loaded at the moment they ran. If the page
+    // navigated during the enrichment await, `merged` mixes refs from the
+    // pre-nav document with DOM-enrichment data from the post-nav document —
+    // inconsistent garbage. Re-check the URL before we stamp the ref cache
+    // so we don't return/store a split-document result.
+    const postEnrichUrl = page.url();
+    if (hydrationBudgetMs > 0 && postEnrichUrl !== snapshotUrl) {
+      throw new NavigationRaceError({ fromUrl: snapshotUrl, toUrl: postEnrichUrl });
+    }
+
     const stats = getRoleSnapshotStats(merged.snapshot, merged.refs);
 
     const result: SnapshotResult = {

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -6,7 +6,7 @@ import {
   normalizeTimeoutMs,
   takeAiSnapshotText,
 } from '../connection.js';
-import { SnapshotHydrationError } from '../errors.js';
+import { NavigationRaceError, SnapshotHydrationError } from '../errors.js';
 import type { SnapshotResult, SnapshotOptions, SsrfPolicy } from '../types.js';
 
 import { enrichSnapshotFromDom, mergeSnapshotWithEnrichment, nextRefCounter } from './dom-enrichment.js';
@@ -103,6 +103,14 @@ export async function snapshotAi(opts: {
 
     const remaining = deadline - Date.now();
     await new Promise((r) => setTimeout(r, Math.min(HYDRATION_POLL_INTERVAL_MS, Math.max(50, remaining))));
+
+    // Detect a navigation race: if the page URL changed between attempts the
+    // refs we collected are bound to the old document, and continuing to wait
+    // for hydration would mask a real workflow problem.
+    const currentUrl = page.url();
+    if (currentUrl !== sourceUrl) {
+      throw new NavigationRaceError({ fromUrl: sourceUrl, toUrl: currentUrl });
+    }
   }
 
   throw Object.assign(new SnapshotHydrationError({ attempts, elapsedMs: Date.now() - started }), {

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -34,7 +34,11 @@ export async function snapshotAi(opts: {
   options?: SnapshotOptions;
   ssrfPolicy?: SsrfPolicy;
 }): Promise<SnapshotResult> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   if (opts.ssrfPolicy) {
@@ -47,7 +51,7 @@ export async function snapshotAi(opts: {
     });
   }
 
-  const sourceUrl = page.url();
+  const initialUrl = page.url();
   const hydrationBudgetMs = resolveHydrationBudgetMs(opts.options?.waitForHydration);
   const minInteractive = Math.max(1, Math.floor(opts.options?.minInteractiveRefs ?? 1));
   const started = Date.now();
@@ -62,6 +66,9 @@ export async function snapshotAi(opts: {
   for (;;) {
     attempts += 1;
     let snapshot = await takeAiSnapshotText(page, normalizeTimeoutMs(opts.timeoutMs, 5000, 60000));
+    // Capture the URL the refs were built against. Used for contentMeta and
+    // for race detection before we return.
+    const snapshotUrl = page.url();
 
     let truncated = false;
     if (limit !== undefined && snapshot.length > limit) {
@@ -91,25 +98,35 @@ export async function snapshotAi(opts: {
       ...(truncated ? { truncated } : {}),
       untrusted: true,
       contentMeta: {
-        sourceUrl,
+        sourceUrl: snapshotUrl,
         contentType: 'browser-snapshot',
         capturedAt: new Date().toISOString(),
       },
     };
 
+    const ready = stats.interactive >= minInteractive;
+
+    // When the caller asked for hydration and the document changed between
+    // the initial resolution and the snapshot we just took, the snapshot is
+    // bound to a different document than the one they asked about. Surface
+    // that as NavigationRaceError instead of silently returning refs for
+    // the post-navigation page with stale metadata.
+    if (hydrationBudgetMs > 0 && snapshotUrl !== initialUrl) {
+      throw new NavigationRaceError({ fromUrl: initialUrl, toUrl: snapshotUrl });
+    }
+
     if (hydrationBudgetMs === 0) return lastResult;
-    if (stats.interactive >= minInteractive) return lastResult;
+    if (ready) return lastResult;
     if (Date.now() >= deadline) break;
 
     const remaining = deadline - Date.now();
     await new Promise((r) => setTimeout(r, Math.min(HYDRATION_POLL_INTERVAL_MS, Math.max(50, remaining))));
 
-    // Detect a navigation race: if the page URL changed between attempts the
-    // refs we collected are bound to the old document, and continuing to wait
-    // for hydration would mask a real workflow problem.
-    const currentUrl = page.url();
-    if (currentUrl !== sourceUrl) {
-      throw new NavigationRaceError({ fromUrl: sourceUrl, toUrl: currentUrl });
+    // Catch races that happen during the hydration wait as well, so we don't
+    // spin on the old URL waiting for refs that will never come.
+    const waitUrl = page.url();
+    if (waitUrl !== initialUrl) {
+      throw new NavigationRaceError({ fromUrl: initialUrl, toUrl: waitUrl });
     }
   }
 

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -33,7 +33,11 @@ export async function snapshotRole(opts: {
   };
   ssrfPolicy?: SsrfPolicy;
 }): Promise<SnapshotResult> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   if (opts.ssrfPolicy) {
@@ -145,7 +149,11 @@ export async function snapshotAria(opts: {
   ssrfPolicy?: SsrfPolicy;
 }): Promise<AriaSnapshotResult> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
   ensurePageState(page);
 
   if (opts.ssrfPolicy) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,15 +103,18 @@ export interface LaunchOptions {
   /** Ignore HTTPS certificate errors (e.g. expired local dev certs). Default: `false` */
   ignoreHTTPSErrors?: boolean;
   /**
-   * Launch in a fully isolated profile: uses a fresh per-run profile name,
+   * Launch in a fully isolated profile: uses a unique per-run profile name,
    * a dedicated user-data directory, and does not share state with other
    * BrowserClaw sessions. Useful when running multiple concurrent browsers
    * or when you need to guarantee no login state, cookies, or extensions
    * leak between runs.
    *
-   * When `true`, `profileName` and `userDataDir` (if provided) are ignored
-   * in favour of per-run names — pass a string to use a fixed isolated
-   * profile name (still gets its own data dir root under `isolated/`).
+   * A run-scoped random suffix is always appended to guarantee that two
+   * concurrent launches never share a user-data directory. Passing a string
+   * acts as a label prefix for easier identification in
+   * `$TMPDIR/browserclaw/isolated/` — it does NOT make the profile stable
+   * across runs. `profileName` and `userDataDir` are ignored when this is
+   * set.
    *
    * Default: `false` (shares the default `browserclaw` profile).
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export interface RunningChrome {
   launchMs: number;
   /** The child process handle */
   proc: ChildProcess;
+  /**
+   * Whether this profile was launched as isolated — set when `LaunchOptions.isolated`
+   * is truthy. `stopChrome()` removes isolated profiles' user-data directories on exit.
+   */
+  isolated?: boolean;
 }
 
 /** Options for launching a new browser instance. */
@@ -97,6 +102,20 @@ export interface LaunchOptions {
   chromeArgs?: string[];
   /** Ignore HTTPS certificate errors (e.g. expired local dev certs). Default: `false` */
   ignoreHTTPSErrors?: boolean;
+  /**
+   * Launch in a fully isolated profile: uses a fresh per-run profile name,
+   * a dedicated user-data directory, and does not share state with other
+   * BrowserClaw sessions. Useful when running multiple concurrent browsers
+   * or when you need to guarantee no login state, cookies, or extensions
+   * leak between runs.
+   *
+   * When `true`, `profileName` and `userDataDir` (if provided) are ignored
+   * in favour of per-run names — pass a string to use a fixed isolated
+   * profile name (still gets its own data dir root under `isolated/`).
+   *
+   * Default: `false` (shares the default `browserclaw` profile).
+   */
+  isolated?: boolean | string;
   /**
    * SSRF policy controlling which URLs navigation is allowed to reach.
    * Defaults to trusted-network mode (private/internal addresses allowed).
@@ -244,6 +263,23 @@ export interface SnapshotOptions {
    * Only applies when `mode: 'role'`.
    */
   refsMode?: 'role' | 'aria';
+  /**
+   * Retry the snapshot until at least one interactive ref is present. Useful
+   * for SPAs where the first snapshot can land on an unhydrated shell.
+   *
+   * When a number is provided it's treated as the maximum wait time in ms.
+   * `true` uses a default budget of 5000ms. Defaults to off (no retries).
+   *
+   * Throws `SnapshotHydrationError` if the budget is exhausted without
+   * producing interactive refs. The final (possibly still-empty) snapshot
+   * is attached as `cause.snapshot` for inspection.
+   */
+  waitForHydration?: boolean | number;
+  /**
+   * Minimum number of interactive refs required to consider the snapshot
+   * hydrated when `waitForHydration` is enabled. Default: 1.
+   */
+  minInteractiveRefs?: number;
 }
 
 /** A node in the raw ARIA accessibility tree. */


### PR DESCRIPTION
## Summary

Targets the low-level reliability pain points reported by the Slack-admin workflow feedback, while keeping BrowserClaw's "eyes-and-hands, not an agent" stance intact. All changes are additive primitives — no Slack-specific logic, no hidden state machines, no new agent loop.

### Structured errors
New error classes exported from the top level so workflow code can `instanceof`-check them instead of string-matching Playwright messages:

- `StaleRefError` (replaces the old `new Error("Unknown ref …")` — still carries that text for backward compat). Exposes `err.ref`.
- `SnapshotHydrationError` — thrown when a hydration-retrying snapshot exhausts its budget without seeing interactive refs. Carries `attempts`, `elapsedMs`, and attaches the last partial snapshot via `err.cause.snapshot`.
- `NavigationRaceError` — reserved for when an operation detects the page URL changed mid-flight. Carries `fromUrl` / `toUrl`.
- `BrowserTabNotFoundError` — moved to the shared `errors.ts` module (still re-exported from `connection`).

### Snapshot hydration retry
`page.snapshot({ waitForHydration: true })` retries the AI snapshot on a 250ms interval until at least one interactive ref appears (or `minInteractiveRefs` is met). `true` uses a 5000ms default budget; a number overrides it. Throws `SnapshotHydrationError` if the budget is exhausted.

### Tab/page handle recovery
- `CrawlPage.reacquire()` — rebinds the handle to the browser's best-guess active page. Prefers the original targetId, then the original URL, then the first non-blank tab, then the first accessible tab.
- `CrawlPage.refreshTargetId({ fallback: 'active' })` — same fallback behavior when the cached target is gone, instead of throwing `BrowserTabNotFoundError` unconditionally.
- `BrowserClaw.currentPage()` — now uses the same active-page resolution, so `about:blank` placeholders no longer win over the tab the user is actually working in.
- `resolveActiveTargetId()` exported as the underlying primitive for library consumers.

### Isolated-window launch ergonomics
`LaunchOptions.isolated` (boolean or string name) generates a per-run profile name and user-data directory under `$TMPDIR/browserclaw/isolated/`, bypassing the default shared `browserclaw` profile. `stopChrome()` removes the directory when the run ends, so concurrent sessions can't collide on profile state.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 450 passing (added 6 new tests for the structured errors)
- [x] `npm run build`
- [x] `npm run check-exports`
- [ ] Manual: launch with `isolated: true`, confirm the directory is created under `$TMPDIR/browserclaw/isolated` and removed on `stop()`
- [ ] Manual: capture a snapshot with `waitForHydration: 2000` on a slow-rendering SPA and confirm it waits for refs to appear
- [ ] Manual: close the active tab mid-session and confirm `page.reacquire()` rebinds to another tab

https://claude.ai/code/session_01S43TVkBe8y2vk6MTULA1Yf

---
_Generated by [Claude Code](https://claude.ai/code/session_01S43TVkBe8y2vk6MTULA1Yf)_