### PR TITLE
Updates from OpenClaw 2026.4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/interaction.test.ts
+++ b/src/actions/interaction.test.ts
@@ -46,7 +46,11 @@ describe('awaitActionWithAbort', () => {
       /* suppress */
     });
 
-    const slowAction = new Promise<string>((resolve) => setTimeout(() => resolve('done'), 100));
+    const slowAction = new Promise<string>((resolve) =>
+      setTimeout(() => {
+        resolve('done');
+      }, 100),
+    );
     const racePromise = awaitActionWithAbort(slowAction, abortPromise);
     abortReject(abortError);
 

--- a/src/actions/interaction.test.ts
+++ b/src/actions/interaction.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+import { awaitActionWithAbort } from './interaction.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// awaitActionWithAbort
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('awaitActionWithAbort', () => {
+  it('resolves with action result when no abort promise provided', async () => {
+    const result = await awaitActionWithAbort(Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+
+  it('resolves with action result when abort promise is pending', async () => {
+    const abortPromise = new Promise<never>(() => {
+      /* never rejects */
+    });
+    abortPromise.catch(() => {
+      /* suppress */
+    });
+    const result = await awaitActionWithAbort(Promise.resolve('ok'), abortPromise);
+    expect(result).toBe('ok');
+  });
+
+  it('throws action error when action rejects before abort', async () => {
+    const actionError = new Error('action failed');
+    let abortReject!: (r: unknown) => void;
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortReject = reject;
+    });
+    abortPromise.catch(() => {
+      /* suppress */
+    });
+    await expect(awaitActionWithAbort(Promise.reject(actionError), abortPromise)).rejects.toThrow('action failed');
+    abortReject(new Error('cleanup'));
+  });
+
+  it('throws abort error when abort promise rejects before action resolves', async () => {
+    const abortError = new Error('aborted');
+    let abortReject!: (r: unknown) => void;
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortReject = reject;
+    });
+    abortPromise.catch(() => {
+      /* suppress */
+    });
+
+    const slowAction = new Promise<string>((resolve) => setTimeout(() => resolve('done'), 100));
+    const racePromise = awaitActionWithAbort(slowAction, abortPromise);
+    abortReject(abortError);
+
+    await expect(racePromise).rejects.toThrow('aborted');
+  });
+
+  it('swallows losing action rejection after abort wins — no unhandled rejection', async () => {
+    let abortReject!: (r: unknown) => void;
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortReject = reject;
+    });
+    abortPromise.catch(() => {
+      /* suppress */
+    });
+
+    let actionReject!: (r: unknown) => void;
+    const actionPromise = new Promise<never>((_, reject) => {
+      actionReject = reject;
+    });
+
+    const racePromise = awaitActionWithAbort(actionPromise, abortPromise);
+    abortReject(new Error('aborted'));
+    await expect(racePromise).rejects.toThrow('aborted');
+    // Rejecting the action after abort has won must not cause unhandled rejection
+    actionReject(new Error('late action error'));
+    // Give microtasks a tick to flush
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -15,6 +15,7 @@ import {
   getRestoredPageForTarget,
   parseRoleRef,
   withPageScopedCdpClient,
+  forceDisconnectPlaywrightConnection,
 } from '../connection.js';
 import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
 import type { FormField, SsrfPolicy } from '../types.js';
@@ -27,6 +28,18 @@ type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
 const MAX_CLICK_DELAY_MS = 5000;
 const DEFAULT_SCROLL_TIMEOUT_MS = 20_000;
 const CHECKABLE_ROLES = new Set(['menuitemcheckbox', 'menuitemradio', 'checkbox', 'radio', 'switch']);
+
+async function awaitActionWithAbort<T>(actionPromise: Promise<T>, abortPromise?: Promise<never>): Promise<T> {
+  if (!abortPromise) return await actionPromise;
+  try {
+    return await Promise.race([actionPromise, abortPromise]);
+  } catch (err) {
+    actionPromise.catch(() => {
+      /* swallow — surface the abort cause */
+    });
+    throw err;
+  }
+}
 
 /**
  * Fallback for setChecked on hidden styled inputs (opacity:0, position:absolute).
@@ -202,6 +215,7 @@ export async function clickViaPlaywright(opts: {
   timeoutMs?: number;
   force?: boolean;
   ssrfPolicy?: SsrfPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -209,6 +223,37 @@ export async function clickViaPlaywright(opts: {
   const locator = resolveLocator(page, resolved);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   const previousUrl = page.url();
+
+  const signal = opts.signal;
+  let abortListener: (() => void) | undefined;
+  let abortReject: ((reason: unknown) => void) | undefined;
+  let abortPromise: Promise<never> | undefined;
+  if (signal) {
+    abortPromise = new Promise<never>((_, reject) => {
+      abortReject = reject;
+    });
+    abortPromise.catch(() => {
+      /* consumed via awaitActionWithAbort */
+    });
+    const disconnect = () => {
+      forceDisconnectPlaywrightConnection({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        reason: 'click aborted',
+      }).catch(() => {
+        /* best-effort disconnect */
+      });
+    };
+    if (signal.aborted) {
+      disconnect();
+      throw (signal.reason as Error | undefined) ?? new Error('aborted');
+    }
+    abortListener = () => {
+      disconnect();
+      abortReject?.((signal.reason as Error | undefined) ?? new Error('aborted'));
+    };
+    signal.addEventListener('abort', abortListener, { once: true });
+  }
 
   // Determine if this is a checkable role element so we can verify the click worked.
   let checkableRole = false;
@@ -226,7 +271,7 @@ export async function clickViaPlaywright(opts: {
       action: async () => {
         const delayMs = resolveBoundedDelayMs(opts.delayMs, 'click delayMs', MAX_CLICK_DELAY_MS);
         if (delayMs > 0) {
-          await locator.hover({ timeout, force: opts.force });
+          await awaitActionWithAbort(locator.hover({ timeout, force: opts.force }), abortPromise);
           await new Promise((resolve) => setTimeout(resolve, delayMs));
         }
 
@@ -237,9 +282,15 @@ export async function clickViaPlaywright(opts: {
         }
 
         if (opts.doubleClick === true) {
-          await locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
+          await awaitActionWithAbort(
+            locator.dblclick({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force }),
+            abortPromise,
+          );
         } else {
-          await locator.click({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force });
+          await awaitActionWithAbort(
+            locator.click({ timeout, button: opts.button, modifiers: opts.modifiers, force: opts.force }),
+            abortPromise,
+          );
         }
 
         // If this is a checkable role and aria-checked didn't change, fall back to JS click.
@@ -279,6 +330,8 @@ export async function clickViaPlaywright(opts: {
     });
   } catch (err) {
     throw toAIFriendlyError(err, label);
+  } finally {
+    if (signal && abortListener) signal.removeEventListener('abort', abortListener);
   }
 }
 

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -29,7 +29,7 @@ const MAX_CLICK_DELAY_MS = 5000;
 const DEFAULT_SCROLL_TIMEOUT_MS = 20_000;
 const CHECKABLE_ROLES = new Set(['menuitemcheckbox', 'menuitemradio', 'checkbox', 'radio', 'switch']);
 
-async function awaitActionWithAbort<T>(actionPromise: Promise<T>, abortPromise?: Promise<never>): Promise<T> {
+export async function awaitActionWithAbort<T>(actionPromise: Promise<T>, abortPromise?: Promise<never>): Promise<T> {
   if (!abortPromise) return await actionPromise;
   try {
     return await Promise.race([actionPromise, abortPromise]);
@@ -246,13 +246,17 @@ export async function clickViaPlaywright(opts: {
     };
     if (signal.aborted) {
       disconnect();
-      throw (signal.reason as Error | undefined) ?? new Error('aborted');
+      throw signal.reason ?? new Error('aborted');
     }
     abortListener = () => {
       disconnect();
-      abortReject?.((signal.reason as Error | undefined) ?? new Error('aborted'));
+      abortReject?.(signal.reason ?? new Error('aborted'));
     };
     signal.addEventListener('abort', abortListener, { once: true });
+    if (signal.aborted) {
+      abortListener();
+      throw signal.reason ?? new Error('aborted');
+    }
   }
 
   // Determine if this is a checkable role element so we can verify the click worked.
@@ -272,7 +276,7 @@ export async function clickViaPlaywright(opts: {
         const delayMs = resolveBoundedDelayMs(opts.delayMs, 'click delayMs', MAX_CLICK_DELAY_MS);
         if (delayMs > 0) {
           await awaitActionWithAbort(locator.hover({ timeout, force: opts.force }), abortPromise);
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          await awaitActionWithAbort(new Promise<void>((resolve) => setTimeout(resolve, delayMs)), abortPromise);
         }
 
         // For checkable roles, capture aria-checked before the click.
@@ -332,6 +336,8 @@ export async function clickViaPlaywright(opts: {
     throw toAIFriendlyError(err, label);
   } finally {
     if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+    abortReject = undefined;
+    abortListener = undefined;
   }
 }
 

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -235,6 +235,10 @@ export async function clickViaPlaywright(opts: {
     abortPromise.catch(() => {
       /* consumed via awaitActionWithAbort */
     });
+    // Unlike JS evaluation (where Runtime.terminateExecution can kill a stuck eval
+    // without closing the browser), Playwright click/hover is orchestrated through
+    // the Playwright protocol and cannot be cancelled via a targeted CDP command.
+    // Tearing down the full connection is the only way to unblock the in-flight action.
     const disconnect = () => {
       forceDisconnectPlaywrightConnection({
         cdpUrl: opts.cdpUrl,
@@ -282,7 +286,10 @@ export async function clickViaPlaywright(opts: {
         // For checkable roles, capture aria-checked before the click.
         let ariaCheckedBefore: string | null | undefined;
         if (checkableRole && opts.doubleClick !== true) {
-          ariaCheckedBefore = await locator.getAttribute('aria-checked', { timeout }).catch(() => undefined);
+          ariaCheckedBefore = await awaitActionWithAbort(
+            locator.getAttribute('aria-checked', { timeout }).catch(() => undefined),
+            abortPromise,
+          );
         }
 
         if (opts.doubleClick === true) {

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -257,10 +257,6 @@ export async function clickViaPlaywright(opts: {
       abortReject?.(signal.reason ?? new Error('aborted'));
     };
     signal.addEventListener('abort', abortListener, { once: true });
-    if (signal.aborted) {
-      abortListener();
-      throw signal.reason ?? new Error('aborted');
-    }
   }
 
   // Determine if this is a checkable role element so we can verify the click worked.


### PR DESCRIPTION
Sync from OpenClaw `2026.4.21` → `2026.4.22`.

## Ported

**`clickViaPlaywright` AbortSignal support** (`src/actions/interaction.ts`)

New `signal?: AbortSignal` option on `page.click(...)`. When aborted mid-click:
- Listener fires → `forceDisconnectPlaywrightConnection` tears down the CDP target
- The racing `Promise.race` throws `signal.reason` (or a generic `"aborted"` error)
- `finally` cleans up the abort listener

Wrapped hover / click / dblclick via new helper `awaitActionWithAbort(action, abortPromise)` (`Promise.race` with catch-swallow on the losing side). Checkable-role polling is bounded to 500ms and runs only after a successful click, so it stays unwrapped.

## Not ported (registered as KD #67)

**Linux OOM-score adjustment shell wrapper** — OC 2026.4.22 added `prepareOomScoreAdjustedSpawn` (new `linux-oom-score-*.js` bundle) that wraps Chrome spawn in a shell script writing to `/proc/self/oom_score_adj`. Server-environment concern; library callers handle OOM externally (cgroups, containers, systemd-run).

## Known-differences registry additions

Also recorded the 0.15.0 / PR #88 additions as browserclaw-ahead so the next sync doesn't flag them:

- KD #68 — Structured error module (`src/errors.ts`)
- KD #69 — Snapshot hydration retry (`waitForHydration` / `minInteractiveRefs`)
- KD #70 — Tab/page handle recovery (`reacquire()`, `refreshTargetId({ fallback: 'active' })`)
- KD #71 — `resolveActiveTargetId` / `pickActiveTargetId` exports
- KD #72 — Isolated profile launch (`LaunchOptions.isolated`)

(These live in `sync/known-differences.md`, which is gitignored — not in the PR diff. Noted here for visibility.)

## Walk

- 2026.4.22-beta.1: no browser-relevant entries (TUI / providers / gateway features).
- 2026.4.22: big release, no browser primitive changes. Bundle diffs are the AbortSignal port + OOM wrapper.

## Checks

- `npm run typecheck` / `npm run lint` / `npm run format:check` — clean
- `npm test` — all green