### PR TITLE
Support cancellation for click actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.15.0",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.15.0",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1,20 +1,25 @@
 import type { Page } from 'playwright-core';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import type * as InteractionModule from './actions/interaction.js';
 import type * as ConnectionModule from './connection.js';
 import { BrowserTabNotFoundError } from './errors.js';
 
-const { mockGetPageForTargetId, mockResolveActiveTargetId, mockPageTargetId } = vi.hoisted(() => ({
-  mockGetPageForTargetId: vi.fn<(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: unknown }) => Promise<Page>>(),
-  mockResolveActiveTargetId:
-    vi.fn<
-      (
-        cdpUrl: string,
-        opts?: { preferTargetId?: string; preferUrl?: string; ssrfPolicy?: unknown },
-      ) => Promise<string | null>
-    >(),
-  mockPageTargetId: vi.fn<(page: Page) => Promise<string | null>>(),
-}));
+const { mockGetPageForTargetId, mockResolveActiveTargetId, mockPageTargetId, mockClickViaPlaywright } = vi.hoisted(
+  () => ({
+    mockGetPageForTargetId:
+      vi.fn<(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: unknown }) => Promise<Page>>(),
+    mockResolveActiveTargetId:
+      vi.fn<
+        (
+          cdpUrl: string,
+          opts?: { preferTargetId?: string; preferUrl?: string; ssrfPolicy?: unknown },
+        ) => Promise<string | null>
+      >(),
+    mockPageTargetId: vi.fn<(page: Page) => Promise<string | null>>(),
+    mockClickViaPlaywright: vi.fn<(opts: Record<string, unknown>) => Promise<void>>(),
+  }),
+);
 
 vi.mock('./connection.js', async (importOriginal) => {
   const actual = await importOriginal<typeof ConnectionModule>();
@@ -24,6 +29,14 @@ vi.mock('./connection.js', async (importOriginal) => {
     resolveActiveTargetId: mockResolveActiveTargetId,
     pageTargetId: mockPageTargetId,
     connectBrowser: () => Promise.resolve({ browser: {}, cdpUrl: 'http://localhost:9222' }),
+  };
+});
+
+vi.mock('./actions/interaction.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof InteractionModule>();
+  return {
+    ...actual,
+    clickViaPlaywright: mockClickViaPlaywright,
   };
 });
 
@@ -137,5 +150,47 @@ describe('CrawlPage.refreshTargetId', () => {
 
     const page = new CrawlPage('http://localhost:9222', 't-old');
     await expect(page.refreshTargetId()).rejects.toBeInstanceOf(BrowserTabNotFoundError);
+  });
+});
+
+describe('CrawlPage click — AbortSignal forwarding', () => {
+  beforeEach(() => {
+    mockClickViaPlaywright.mockReset();
+    mockClickViaPlaywright.mockResolvedValue(undefined);
+  });
+
+  it('forwards the signal from click(ref, { signal }) to clickViaPlaywright', async () => {
+    const controller = new AbortController();
+    const page = new CrawlPage('http://localhost:9222', 't-1');
+
+    await page.click('e4', { signal: controller.signal });
+
+    expect(mockClickViaPlaywright).toHaveBeenCalledTimes(1);
+    expect(mockClickViaPlaywright.mock.calls[0]?.[0]).toMatchObject({
+      ref: 'e4',
+      signal: controller.signal,
+    });
+  });
+
+  it('forwards the signal from clickBySelector(selector, { signal }) to clickViaPlaywright', async () => {
+    const controller = new AbortController();
+    const page = new CrawlPage('http://localhost:9222', 't-1');
+
+    await page.clickBySelector('button.submit', { signal: controller.signal });
+
+    expect(mockClickViaPlaywright).toHaveBeenCalledTimes(1);
+    expect(mockClickViaPlaywright.mock.calls[0]?.[0]).toMatchObject({
+      selector: 'button.submit',
+      signal: controller.signal,
+    });
+  });
+
+  it('passes signal: undefined when omitted', async () => {
+    const page = new CrawlPage('http://localhost:9222', 't-1');
+
+    await page.click('e4');
+
+    expect(mockClickViaPlaywright).toHaveBeenCalledTimes(1);
+    expect(mockClickViaPlaywright.mock.calls[0]?.[0]).toMatchObject({ signal: undefined });
   });
 });

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -331,6 +331,7 @@ export class CrawlPage {
       delayMs: opts?.delayMs,
       timeoutMs: opts?.timeoutMs,
       force: opts?.force,
+      signal: opts?.signal,
       ssrfPolicy: this.ssrfPolicy,
     });
   }
@@ -360,6 +361,7 @@ export class CrawlPage {
       delayMs: opts?.delayMs,
       timeoutMs: opts?.timeoutMs,
       force: opts?.force,
+      signal: opts?.signal,
       ssrfPolicy: this.ssrfPolicy,
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,6 +342,8 @@ export interface ClickOptions {
   timeoutMs?: number;
   /** Force click even if element is hidden or covered. Dispatches the event regardless of visibility. */
   force?: boolean;
+  /** AbortSignal to cancel the click mid-flight. Aborts tear down the Playwright connection to unblock the in-flight action. */
+  signal?: AbortSignal;
 }
 
 /** Options for type actions. */


### PR DESCRIPTION
## Summary

This follow-up exposes `signal?: AbortSignal` on `ClickOptions` and forwards it through `page.click(...)` and `page.clickBySelector(...)` to the already-merged `clickViaPlaywright` AbortSignal implementation.

## Changes

- `src/types.ts` — add `signal?: AbortSignal` to `ClickOptions` with a JSDoc note about the connection-level teardown.
- `src/browser.ts` — forward `opts?.signal` from `CrawlPage.click` and `CrawlPage.clickBySelector` into `clickViaPlaywright`.
- `src/browser.test.ts` — add 3 smoke tests asserting the signal reference is forwarded verbatim (and is `undefined` when omitted), using the same `vi.mock` + `importOriginal` pattern already used for `./connection.js`.
- `package.json` — bump to `0.15.3`.

## Out of scope

- No changes to the merged `clickViaPlaywright` abort semantics (full-connection teardown on abort remains documented in `interaction.ts`).
- No changes to abort-reason handling or post-click polling.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test -- --run src/browser.test.ts` — 11/11 pass (3 new)

https://claude.ai/code/session_01XRK5xgegtfZiuA7Wnsvo2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRK5xgegtfZiuA7Wnsvo2o)_