### PR TITLE
Slim Chrome flags and make stealth opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -66,6 +66,7 @@ import {
   BrowserTabNotFoundError,
   resolveActiveTargetId,
 } from './connection.js';
+import { setStealthEnabled } from './page-utils.js';
 import { assertCdpEndpointAllowed } from './security.js';
 import { snapshotAi } from './snapshot/ai-snapshot.js';
 import { snapshotRole, snapshotAria } from './snapshot/aria-snapshot.js';
@@ -1807,6 +1808,7 @@ export class BrowserClaw {
    */
   static async launch(opts: LaunchOptions = {}): Promise<BrowserClaw> {
     const startedAt = new Date().toISOString();
+    setStealthEnabled(opts.stealth === true);
     const chrome = await launchChrome(opts);
     try {
       const cdpUrl = `http://127.0.0.1:${String(chrome.cdpPort)}`;
@@ -1853,6 +1855,7 @@ export class BrowserClaw {
    */
   static async connect(cdpUrl?: string, opts?: ConnectOptions): Promise<BrowserClaw> {
     const startedAt = new Date().toISOString();
+    setStealthEnabled(opts?.stealth === true);
     const connectT0 = Date.now();
     let resolvedUrl = cdpUrl;
     if (resolvedUrl === undefined || resolvedUrl === '') {

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeCdpWsUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
   resolveIsolatedProfile,
+  buildChromeLaunchArgs,
 } from './chrome-launcher.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -306,5 +307,93 @@ describe('resolveIsolatedProfile', () => {
     const namePart = path.basename(userDataDir);
     const label = namePart.split('-')[0];
     expect(label.length).toBe(32);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildChromeLaunchArgs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildChromeLaunchArgs', () => {
+  const baseOpts = {
+    cdpPort: 9222,
+    userDataDir: '/tmp/test',
+    headless: false,
+    noSandbox: false,
+    ignoreHTTPSErrors: false,
+    ciDefaults: false,
+    platform: 'darwin' as NodeJS.Platform,
+  };
+
+  it('emits the minimum CDP-required args by default', () => {
+    const args = buildChromeLaunchArgs(baseOpts);
+    expect(args).toContain('--remote-debugging-port=9222');
+    expect(args).toContain('--user-data-dir=/tmp/test');
+    expect(args).toContain('--no-first-run');
+    expect(args).toContain('--no-default-browser-check');
+    expect(args).toContain('--disable-blink-features=AutomationControlled');
+    expect(args).toContain('about:blank');
+  });
+
+  it('does NOT include CI-deterministic flags by default (anti-fingerprint)', () => {
+    const args = buildChromeLaunchArgs(baseOpts);
+    expect(args).not.toContain('--disable-sync');
+    expect(args).not.toContain('--disable-background-networking');
+    expect(args).not.toContain('--disable-component-update');
+    expect(args).not.toContain('--disable-features=Translate,MediaRouter');
+    expect(args).not.toContain('--password-store=basic');
+  });
+
+  it('adds CI-deterministic flags when ciDefaults: true', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, ciDefaults: true });
+    expect(args).toContain('--disable-sync');
+    expect(args).toContain('--disable-background-networking');
+    expect(args).toContain('--disable-component-update');
+    expect(args).toContain('--disable-features=Translate,MediaRouter');
+    expect(args).toContain('--password-store=basic');
+  });
+
+  it('adds --headless=new and --disable-gpu when headless', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, headless: true });
+    expect(args).toContain('--headless=new');
+    expect(args).toContain('--disable-gpu');
+  });
+
+  it('adds --no-sandbox when requested', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, noSandbox: true });
+    expect(args).toContain('--no-sandbox');
+  });
+
+  it('does NOT add --disable-setuid-sandbox (was redundant with --no-sandbox)', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, noSandbox: true });
+    expect(args).not.toContain('--disable-setuid-sandbox');
+  });
+
+  it('adds --disable-dev-shm-usage on linux', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, platform: 'linux' });
+    expect(args).toContain('--disable-dev-shm-usage');
+  });
+
+  it('does not add --disable-dev-shm-usage on darwin', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, platform: 'darwin' });
+    expect(args).not.toContain('--disable-dev-shm-usage');
+  });
+
+  it('appends extra chromeArgs after defaults but before about:blank', () => {
+    const args = buildChromeLaunchArgs({ ...baseOpts, chromeArgs: ['--start-maximized', '--lang=en-US'] });
+    expect(args).toContain('--start-maximized');
+    expect(args).toContain('--lang=en-US');
+    expect(args[args.length - 1]).toBe('about:blank');
+  });
+
+  it('filters non-string and empty chromeArgs entries', () => {
+    const args = buildChromeLaunchArgs({
+      ...baseOpts,
+      chromeArgs: ['--ok', '', '   ', null as unknown as string, '--also-ok'],
+    });
+    expect(args).toContain('--ok');
+    expect(args).toContain('--also-ok');
+    expect(args).not.toContain('');
+    expect(args).not.toContain('   ');
   });
 });

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -341,7 +341,6 @@ describe('buildChromeLaunchArgs', () => {
     expect(args).not.toContain('--disable-background-networking');
     expect(args).not.toContain('--disable-component-update');
     expect(args).not.toContain('--disable-features=Translate,MediaRouter');
-    expect(args).not.toContain('--password-store=basic');
   });
 
   it('adds CI-deterministic flags when ciDefaults: true', () => {
@@ -350,7 +349,23 @@ describe('buildChromeLaunchArgs', () => {
     expect(args).toContain('--disable-background-networking');
     expect(args).toContain('--disable-component-update');
     expect(args).toContain('--disable-features=Translate,MediaRouter');
-    expect(args).toContain('--password-store=basic');
+  });
+
+  it('adds --password-store=basic on linux always (avoid keyring hang)', () => {
+    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'linux' })).toContain('--password-store=basic');
+    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'linux', ciDefaults: true })).toContain(
+      '--password-store=basic',
+    );
+  });
+
+  it('does NOT add --password-store=basic on non-linux', () => {
+    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'darwin' })).not.toContain('--password-store=basic');
+    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'win32' })).not.toContain('--password-store=basic');
+  });
+
+  it('adds --ignore-certificate-errors when ignoreHTTPSErrors: true', () => {
+    expect(buildChromeLaunchArgs({ ...baseOpts, ignoreHTTPSErrors: true })).toContain('--ignore-certificate-errors');
+    expect(buildChromeLaunchArgs(baseOpts)).not.toContain('--ignore-certificate-errors');
   });
 
   it('adds --headless=new and --disable-gpu when headless', () => {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -847,6 +847,55 @@ async function canRunCdpHealthCommand(wsUrl: string, timeoutMs = 800): Promise<b
   });
 }
 
+export interface BuildChromeLaunchArgsOptions {
+  cdpPort: number;
+  userDataDir: string;
+  headless: boolean;
+  noSandbox: boolean;
+  ignoreHTTPSErrors: boolean;
+  ciDefaults: boolean;
+  chromeArgs?: string[];
+  platform: NodeJS.Platform;
+}
+
+export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): string[] {
+  const args = [
+    `--remote-debugging-port=${String(opts.cdpPort)}`,
+    '--remote-debugging-address=127.0.0.1',
+    `--user-data-dir=${opts.userDataDir}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-blink-features=AutomationControlled',
+    '--disable-session-crashed-bubble',
+    '--hide-crash-restore-bubble',
+  ];
+  if (opts.ciDefaults) {
+    args.push(
+      '--disable-sync',
+      '--disable-background-networking',
+      '--disable-component-update',
+      '--disable-features=Translate,MediaRouter',
+      '--password-store=basic',
+    );
+  }
+  if (opts.headless) {
+    args.push('--headless=new', '--disable-gpu');
+  }
+  if (opts.noSandbox) {
+    args.push('--no-sandbox');
+  }
+  if (opts.ignoreHTTPSErrors) {
+    args.push('--ignore-certificate-errors');
+  }
+  if (opts.platform === 'linux') args.push('--disable-dev-shm-usage');
+  const extraArgs = Array.isArray(opts.chromeArgs)
+    ? opts.chromeArgs.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
+    : [];
+  if (extraArgs.length) args.push(...extraArgs);
+  args.push('about:blank');
+  return args;
+}
+
 export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChrome> {
   const cdpPort = opts.cdpPort ?? DEFAULT_CDP_PORT;
   await ensurePortAvailable(cdpPort);
@@ -862,36 +911,16 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   fs.mkdirSync(userDataDir, { recursive: true });
 
   const spawnChrome = (spawnOpts?: { detached?: boolean }, runOpts?: { forceHeadless?: boolean }) => {
-    const args = [
-      `--remote-debugging-port=${String(cdpPort)}`,
-      '--remote-debugging-address=127.0.0.1',
-      `--user-data-dir=${userDataDir}`,
-      '--no-first-run',
-      '--no-default-browser-check',
-      '--disable-sync',
-      '--disable-background-networking',
-      '--disable-component-update',
-      '--disable-features=Translate,MediaRouter',
-      '--disable-blink-features=AutomationControlled',
-      '--disable-session-crashed-bubble',
-      '--hide-crash-restore-bubble',
-      '--password-store=basic',
-    ];
-    if (opts.headless === true || runOpts?.forceHeadless === true) {
-      args.push('--headless=new', '--disable-gpu');
-    }
-    if (opts.noSandbox === true) {
-      args.push('--no-sandbox', '--disable-setuid-sandbox');
-    }
-    if (opts.ignoreHTTPSErrors === true) {
-      args.push('--ignore-certificate-errors');
-    }
-    if (process.platform === 'linux') args.push('--disable-dev-shm-usage');
-    const extraArgs = Array.isArray(opts.chromeArgs)
-      ? opts.chromeArgs.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
-      : [];
-    if (extraArgs.length) args.push(...extraArgs);
-    args.push('about:blank');
+    const args = buildChromeLaunchArgs({
+      cdpPort,
+      userDataDir,
+      headless: opts.headless === true || runOpts?.forceHeadless === true,
+      noSandbox: opts.noSandbox === true,
+      ignoreHTTPSErrors: opts.ignoreHTTPSErrors === true,
+      ciDefaults: opts.ciDefaults === true,
+      chromeArgs: opts.chromeArgs,
+      platform: process.platform,
+    });
     return spawn(exe.path, args, {
       stdio: 'pipe',
       env: { ...process.env, HOME: os.homedir() },

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -875,9 +875,9 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
       '--disable-background-networking',
       '--disable-component-update',
       '--disable-features=Translate,MediaRouter',
-      '--password-store=basic',
     );
   }
+  if (opts.platform === 'linux') args.push('--password-store=basic');
   if (opts.headless) {
     args.push('--headless=new', '--disable-gpu');
   }

--- a/src/page-utils.test.ts
+++ b/src/page-utils.test.ts
@@ -10,6 +10,8 @@ import {
   findNetworkRequestById,
   ensurePageState,
   ensureContextState,
+  observeContext,
+  setStealthEnabled,
 } from './page-utils.js';
 import type { PageState, NetworkRequest } from './types.js';
 
@@ -295,5 +297,58 @@ describe('ensureContextState', () => {
     const state1 = ensureContextState(ctx);
     const state2 = ensureContextState(ctx);
     expect(state1).toBe(state2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stealth gating
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('observeContext stealth gating', () => {
+  it('does NOT inject stealth when disabled (default)', async () => {
+    setStealthEnabled(false);
+    let calls = 0;
+    const ctx = {
+      addInitScript: () => {
+        calls++;
+        return Promise.resolve();
+      },
+      pages: () => [],
+      on: () => {
+        /* noop */
+      },
+      off: () => {
+        /* noop */
+      },
+      once: () => {
+        /* noop */
+      },
+    } as unknown as BrowserContext;
+    await observeContext(ctx);
+    expect(calls).toBe(0);
+  });
+
+  it('injects stealth via addInitScript when enabled', async () => {
+    setStealthEnabled(true);
+    let calls = 0;
+    const ctx = {
+      addInitScript: () => {
+        calls++;
+        return Promise.resolve();
+      },
+      pages: () => [],
+      on: () => {
+        /* noop */
+      },
+      off: () => {
+        /* noop */
+      },
+      once: () => {
+        /* noop */
+      },
+    } as unknown as BrowserContext;
+    await observeContext(ctx);
+    expect(calls).toBe(1);
+    setStealthEnabled(false); // restore default
   });
 });

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -205,7 +205,14 @@ export function setDialogHandlerOnPage(page: Page, handler?: DialogHandler): voi
 
 // ── Stealth ──
 
+let stealthEnabled = false;
+
+export function setStealthEnabled(enabled: boolean): void {
+  stealthEnabled = enabled;
+}
+
 async function applyStealthToPage(page: Page): Promise<void> {
+  if (!stealthEnabled) return;
   try {
     await page.evaluate(STEALTH_SCRIPT);
   } catch (e: unknown) {
@@ -219,11 +226,13 @@ export async function observeContext(context: BrowserContext): Promise<void> {
   observedContexts.add(context);
   ensureContextState(context);
 
-  try {
-    await context.addInitScript(STEALTH_SCRIPT);
-  } catch (e: unknown) {
-    if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
-      console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
+  if (stealthEnabled) {
+    try {
+      await context.addInitScript(STEALTH_SCRIPT);
+    } catch (e: unknown) {
+      if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
+        console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
+    }
   }
 
   for (const page of context.pages()) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,14 @@ export interface LaunchOptions {
   /** Ignore HTTPS certificate errors (e.g. expired local dev certs). Default: `false` */
   ignoreHTTPSErrors?: boolean;
   /**
+   * Add CI-deterministic Chrome flags that suppress background networking,
+   * sync, component updates, the password store, and the Translate / MediaRouter
+   * features. These flags are useful for reproducible CI runs but make the
+   * browser easier to fingerprint as automation (the absence of safebrowsing,
+   * sync, and translate-fetcher traffic is itself a signal). Default: `false`.
+   */
+  ciDefaults?: boolean;
+  /**
    * Launch in a fully isolated profile: uses a unique per-run profile name,
    * a dedicated user-data directory, and does not share state with other
    * BrowserClaw sessions. Useful when running multiple concurrent browsers

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,8 @@ export interface LaunchOptions {
   ignoreHTTPSErrors?: boolean;
   /** Add CI-deterministic Chrome flags (sync/component-update/translate/safebrowsing). May fingerprint as automation. Default: `false`. */
   ciDefaults?: boolean;
+  /** Inject stealth patches (navigator.webdriver, plugins, WebGL vendor, etc.) to mimic native Chrome. The patches are themselves fingerprintable by sophisticated detectors and are off by default. Default: `false`. */
+  stealth?: boolean;
   /**
    * Launch in a fully isolated profile: uses a unique per-run profile name,
    * a dedicated user-data directory, and does not share state with other
@@ -163,6 +165,8 @@ export interface ConnectOptions {
    * Videos are saved when the page or context is closed.
    */
   recordVideo?: { dir: string; size?: { width: number; height: number } };
+  /** Inject stealth patches. See `LaunchOptions.stealth` — same caveat applies. Default: `false`. */
+  stealth?: boolean;
 }
 
 // ── Snapshot ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,13 +102,7 @@ export interface LaunchOptions {
   chromeArgs?: string[];
   /** Ignore HTTPS certificate errors (e.g. expired local dev certs). Default: `false` */
   ignoreHTTPSErrors?: boolean;
-  /**
-   * Add CI-deterministic Chrome flags that suppress background networking,
-   * sync, component updates, the password store, and the Translate / MediaRouter
-   * features. These flags are useful for reproducible CI runs but make the
-   * browser easier to fingerprint as automation (the absence of safebrowsing,
-   * sync, and translate-fetcher traffic is itself a signal). Default: `false`.
-   */
+  /** Add CI-deterministic Chrome flags (sync/component-update/translate/safebrowsing). May fingerprint as automation. Default: `false`. */
   ciDefaults?: boolean;
   /**
    * Launch in a fully isolated profile: uses a unique per-run profile name,


### PR DESCRIPTION
Investigation of #93 found two layers contributing to BC's anti-bot detection signal:

1. **Default Chrome launch flags** that double as fingerprint signals (`--disable-sync`, `--disable-background-networking`, etc.).
2. **The stealth module itself** — `addInitScript(STEALTH_SCRIPT)` injecting patches whose `.toString()` and unusual values are MORE detectable than the native Chrome state they replace.

## Verification (BC vs raw Chrome on the same machine)

Captured `navigator` / `window` state with both stacks. Diffs:

| Property | BC (stealth on) | Raw Chrome | Why bad |
|---|---|---|---|
| `chrome.runtime.connect.toString()` | `function() {\n      return { onMessage: { addListener: noop }...` | n/a (no runtime) | Real native code returns `function () { [native code] }`. The stub's source code is exposed verbatim — any detector calling `.toString()` instantly knows it's fake. |
| `webdriver` | `undefined` | `false` | Real Chrome returns `false`. Patching to `undefined` is itself the tell. |
| `chrome.runtime` | exists with stubs | doesn't exist | Real Chrome only has `chrome.runtime` when an extension is installed. Stubbing it = "automation pretending to have an extension." |
| `webglVendor/Renderer` | `"Intel Inc."`, `"Intel Iris OpenGL Engine"` | actual GPU | Hardcoded values in stealth-tool fingerprint databases. |
| `deviceMemory` | `8` | `undefined` (macOS native) | Fake-adding the property is a signal. |

The stealth module was added to evade detection. The actual measurement shows it makes the browser *easier* to detect.

## Changes

### Slim default Chrome flags
`launchChrome` no longer adds these unless explicitly requested:
- `--disable-sync`
- `--disable-background-networking`
- `--disable-component-update`
- `--disable-features=Translate,MediaRouter`
- `--password-store=basic` (still added on Linux only — keyring lock can hang launches)
- `--disable-setuid-sandbox` (was redundant with `--no-sandbox`)

### Make stealth opt-in (default off)
- New `LaunchOptions.stealth?: boolean` and `ConnectOptions.stealth?: boolean`. Default `false`.
- `setStealthEnabled(boolean)` exported from `page-utils` (set internally by `BrowserClaw.launch` / `.connect`).
- When off, no `addInitScript(STEALTH_SCRIPT)` is injected and `applyStealthToPage` is a no-op.
- The `STEALTH_SCRIPT` constant remains exported for callers who explicitly want to inject it.

### New opt-in: `LaunchOptions.ciDefaults`
Restores the previous deterministic flag set for CI runs that need it.

### Refactor
Extracted `buildChromeLaunchArgs(opts)` as a pure exported function. Lets us unit-test the arg list without launching real Chrome.

## What stays in defaults (CDP-required)
- `--remote-debugging-port`, `--user-data-dir`
- `--no-first-run`, `--no-default-browser-check`
- `--disable-blink-features=AutomationControlled` (without it, every site sees `navigator.webdriver=true`)
- `--disable-session-crashed-bubble`, `--hide-crash-restore-bubble`
- `--no-sandbox`, `--ignore-certificate-errors`, `--disable-dev-shm-usage` (Linux), `--headless=new` — conditional on existing options

## Tests

13 tests added across `chrome-launcher.test.ts` and `page-utils.test.ts` covering:
- Min-default arg emission
- `ciDefaults` gating
- `--password-store=basic` Linux-only behavior
- `--ignore-certificate-errors` toggle
- `chromeArgs` filtering and ordering
- `observeContext` no-ops on stealth when disabled
- `observeContext` injects on stealth when enabled

## Verification status

**Reproduced**: PerimeterX challenge on StreetEasy from a flagged IP.

**Recovery NOT verified end-to-end**: my IP appears flagged regardless of Chrome state, so I can't observe the BU-passes-BC-fails differential locally. The fingerprint diffs are real and measured, but whether removing them clears the challenge in the user's docker-compose stack still needs verification there.

The slim-flags + stealth-opt-in is defensible on its own merit (less unnecessary signal surface, sensible default for a library) — but treat it as "reduces fingerprint surface," not "fixes #93" until verified in the docker stack.

## Version

`0.15.3` → `0.16.0` (minor): new exported helper + new options + observable behavior change in `launchChrome` and the stealth path.

## Migration

If you were relying on stealth being on by default:

```ts
await BrowserClaw.launch({ stealth: true, ... });
```

If your CI relies on the old deterministic flag set:

```ts
await BrowserClaw.launch({ ciDefaults: true, ... });
```

Otherwise no migration needed.