### PR TITLE
Updates from OpenClaw 2026.4.24

### DIFF
--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -10,6 +11,9 @@ import {
   normalizeCdpWsUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
   resolveIsolatedProfile,
+  processExists,
+  clearChromeSingletonArtifacts,
+  clearStaleChromeSingletonLocks,
 } from './chrome-launcher.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -306,5 +310,124 @@ describe('resolveIsolatedProfile', () => {
     const namePart = path.basename(userDataDir);
     const label = namePart.split('-')[0];
     expect(label.length).toBe(32);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// processExists
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('processExists', () => {
+  it('returns true for the current process pid', () => {
+    expect(processExists(process.pid)).toBe(true);
+  });
+
+  it('returns false for an obviously dead pid', () => {
+    expect(processExists(2147483646)).toBe(false);
+  });
+
+  it('rejects non-positive integers', () => {
+    expect(processExists(0)).toBe(false);
+    expect(processExists(-1)).toBe(false);
+    expect(processExists(1.5)).toBe(false);
+    expect(processExists(Number.NaN)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// clearChromeSingletonArtifacts / clearStaleChromeSingletonLocks
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-singleton-'));
+}
+
+describe('clearChromeSingletonArtifacts', () => {
+  it('removes Singleton* files when present', () => {
+    const dir = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'SingletonLock'), 'x');
+      fs.writeFileSync(path.join(dir, 'SingletonSocket'), 'x');
+      fs.writeFileSync(path.join(dir, 'SingletonCookie'), 'x');
+      clearChromeSingletonArtifacts(dir);
+      expect(() => fs.lstatSync(path.join(dir, 'SingletonLock'))).toThrow();
+      expect(fs.existsSync(path.join(dir, 'SingletonSocket'))).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'SingletonCookie'))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op when no artifacts exist', () => {
+    const dir = makeTempDir();
+    try {
+      expect(() => {
+        clearChromeSingletonArtifacts(dir);
+      }).not.toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('clearStaleChromeSingletonLocks', () => {
+  // Skip on Windows where SingletonLock isn't a symlink
+  const itUnix = process.platform === 'win32' ? it.skip : it;
+
+  itUnix('returns false when SingletonLock is absent', () => {
+    const dir = makeTempDir();
+    try {
+      expect(clearStaleChromeSingletonLocks(dir)).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  itUnix('returns false when lock is held by a live process on the same host', () => {
+    const dir = makeTempDir();
+    try {
+      const target = `${os.hostname()}-${String(process.pid)}`;
+      fs.symlinkSync(target, path.join(dir, 'SingletonLock'));
+      expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(false);
+      expect(fs.lstatSync(path.join(dir, 'SingletonLock')).isSymbolicLink()).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  itUnix('clears artifacts when lock pid is dead', () => {
+    const dir = makeTempDir();
+    try {
+      const target = `${os.hostname()}-2147483646`;
+      fs.symlinkSync(target, path.join(dir, 'SingletonLock'));
+      fs.writeFileSync(path.join(dir, 'SingletonSocket'), 'x');
+      expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(true);
+      expect(() => fs.lstatSync(path.join(dir, 'SingletonLock'))).toThrow();
+      expect(fs.existsSync(path.join(dir, 'SingletonSocket'))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  itUnix('clears artifacts when lock host differs from current host', () => {
+    const dir = makeTempDir();
+    try {
+      const target = `some-other-host-${String(process.pid)}`;
+      fs.symlinkSync(target, path.join(dir, 'SingletonLock'));
+      expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(true);
+      expect(() => fs.lstatSync(path.join(dir, 'SingletonLock'))).toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  itUnix('returns false when lock target has unexpected format', () => {
+    const dir = makeTempDir();
+    try {
+      fs.symlinkSync('not-a-valid-target', path.join(dir, 'SingletonLock'));
+      expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -410,13 +410,13 @@ describe('clearStaleChromeSingletonLocks', () => {
     }
   });
 
-  itUnix('clears artifacts when lock host differs from current host', () => {
+  itUnix('does NOT clear when lock host differs (cross-host liveness unknown)', () => {
     const dir = makeTempDir();
     try {
       const target = `some-other-host-${String(process.pid)}`;
       fs.symlinkSync(target, path.join(dir, 'SingletonLock'));
-      expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(true);
-      expect(() => fs.lstatSync(path.join(dir, 'SingletonLock'))).toThrow();
+      expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(false);
+      expect(fs.lstatSync(path.join(dir, 'SingletonLock')).isSymbolicLink()).toBe(true);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -45,8 +45,6 @@ export function clearStaleChromeSingletonLocks(userDataDir: string, hostname: st
   if (!match?.groups) return false;
   const lockHost = match.groups.lockHost;
   const pid = Number.parseInt(match.groups.pid, 10);
-  // Cross-host: no way to check liveness, so leave it alone — user-data dirs on shared storage
-  // could have a live Chrome on the other machine. Same-host: only clear when the holder is dead.
   if (lockHost !== hostname) return false;
   if (processExists(pid)) return false;
   clearChromeSingletonArtifacts(userDataDir);

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -7,6 +7,76 @@ import path from 'node:path';
 import { assertCdpEndpointAllowed } from './security.js';
 import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome, SsrfPolicy } from './types.js';
 
+// ── Singleton Lock Recovery ──
+
+const CHROME_SINGLETON_LOCK_PATHS = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
+const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another chromium process/i;
+
+export function processExists(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPERM') return true;
+    return false;
+  }
+}
+
+export function clearChromeSingletonArtifacts(userDataDir: string): void {
+  for (const basename of CHROME_SINGLETON_LOCK_PATHS) {
+    try {
+      fs.rmSync(path.join(userDataDir, basename), { force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+export function clearStaleChromeSingletonLocks(userDataDir: string, hostname: string = os.hostname()): boolean {
+  const lockPath = path.join(userDataDir, 'SingletonLock');
+  let target: string;
+  try {
+    target = fs.readlinkSync(lockPath);
+  } catch {
+    return false;
+  }
+  const match = /^(?<lockHost>.+)-(?<pid>\d+)$/.exec(target);
+  if (!match?.groups) return false;
+  const lockHost = match.groups.lockHost;
+  const pid = Number.parseInt(match.groups.pid, 10);
+  if (lockHost === hostname && processExists(pid)) return false;
+  clearChromeSingletonArtifacts(userDataDir);
+  return true;
+}
+
+async function waitForChromeProcessExit(proc: ChildProcess, timeoutMs: number): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null || proc.killed) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      proc.off('exit', onExit);
+      proc.off('close', onExit);
+      resolve();
+    }, timeoutMs);
+    const onExit = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    proc.once('exit', onExit);
+    proc.once('close', onExit);
+  });
+}
+
+async function terminateChromeForRetry(proc: ChildProcess, userDataDir: string): Promise<void> {
+  try {
+    proc.kill('SIGKILL');
+  } catch {
+    /* may already be dead */
+  }
+  await waitForChromeProcessExit(proc, 5000);
+  clearStaleChromeSingletonLocks(userDataDir);
+}
+
 // ── Process Tree Kill ──
 
 /**
@@ -930,46 +1000,59 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     ensureCleanExit(userDataDir);
   } catch {}
 
-  const proc = spawnChrome();
   const cdpUrl = `http://127.0.0.1:${String(cdpPort)}`;
 
-  // Capture stderr for diagnostics on failure
-  const stderrChunks: Buffer[] = [];
-  const onStderr = (chunk: Buffer) => {
-    stderrChunks.push(chunk);
+  const launchOnceAndWait = async (
+    allowSingletonRecovery: boolean,
+  ): Promise<{ proc: ReturnType<typeof spawnChrome> }> => {
+    const proc = spawnChrome();
+    const stderrChunks: Buffer[] = [];
+    const onStderr = (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    };
+    proc.stderr.on('data', onStderr);
+
+    const readyDeadline = Date.now() + 15000;
+    let pollDelay = 200;
+    while (Date.now() < readyDeadline) {
+      if (await isChromeCdpReady(cdpUrl, 500)) break;
+      await new Promise((r) => setTimeout(r, pollDelay));
+      pollDelay = Math.min(pollDelay + 100, 1000);
+    }
+
+    if (!(await isChromeCdpReady(cdpUrl, 500))) {
+      const stderrOutput = Buffer.concat(stderrChunks).toString('utf8').trim();
+      if (
+        allowSingletonRecovery &&
+        CHROME_SINGLETON_IN_USE_PATTERN.test(stderrOutput) &&
+        clearStaleChromeSingletonLocks(userDataDir)
+      ) {
+        proc.stderr.off('data', onStderr);
+        await terminateChromeForRetry(proc, userDataDir);
+        return await launchOnceAndWait(false);
+      }
+      const stderrHint = stderrOutput ? `\nChrome stderr:\n${stderrOutput.slice(0, 2000)}` : '';
+      const sandboxHint =
+        process.platform === 'linux' && opts.noSandbox !== true
+          ? '\nHint: If running in a container or as root, try setting noSandbox: true.'
+          : '';
+      try {
+        proc.kill('SIGKILL');
+      } catch {}
+      try {
+        const lockFile = path.join(userDataDir, 'SingletonLock');
+        if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile);
+      } catch {}
+      throw new Error(`Failed to start Chrome CDP on port ${String(cdpPort)}.${sandboxHint}${stderrHint}`);
+    }
+
+    proc.stderr.off('data', onStderr);
+    proc.stderr.resume();
+    stderrChunks.length = 0;
+    return { proc };
   };
-  proc.stderr.on('data', onStderr);
 
-  const readyDeadline = Date.now() + 15000;
-  let pollDelay = 200;
-  while (Date.now() < readyDeadline) {
-    if (await isChromeCdpReady(cdpUrl, 500)) break;
-    await new Promise((r) => setTimeout(r, pollDelay));
-    // Back off polling to reduce CPU churn on slow launches
-    pollDelay = Math.min(pollDelay + 100, 1000);
-  }
-
-  if (!(await isChromeCdpReady(cdpUrl, 500))) {
-    const stderrOutput = Buffer.concat(stderrChunks).toString('utf8').trim();
-    const stderrHint = stderrOutput ? `\nChrome stderr:\n${stderrOutput.slice(0, 2000)}` : '';
-    const sandboxHint =
-      process.platform === 'linux' && opts.noSandbox !== true
-        ? '\nHint: If running in a container or as root, try setting noSandbox: true.'
-        : '';
-    try {
-      proc.kill('SIGKILL');
-    } catch {}
-    // Clean up userDataDir lock files on launch failure so subsequent retries don't stall
-    try {
-      const lockFile = path.join(userDataDir, 'SingletonLock');
-      if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile);
-    } catch {}
-    throw new Error(`Failed to start Chrome CDP on port ${String(cdpPort)}.${sandboxHint}${stderrHint}`);
-  }
-
-  proc.stderr.off('data', onStderr);
-  proc.stderr.resume(); // drain to prevent backpressure after removing the listener
-  stderrChunks.length = 0;
+  const { proc } = await launchOnceAndWait(true);
 
   return {
     pid: proc.pid ?? -1,

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -52,7 +52,6 @@ export function clearStaleChromeSingletonLocks(userDataDir: string, hostname: st
 }
 
 async function waitForChromeProcessExit(proc: ChildProcess, timeoutMs: number): Promise<void> {
-  // proc.killed only signals that a kill() call succeeded, not that the process exited.
   if (proc.exitCode !== null || proc.signalCode !== null) return;
   await new Promise<void>((resolve) => {
     const timer = setTimeout(() => {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -45,7 +45,10 @@ export function clearStaleChromeSingletonLocks(userDataDir: string, hostname: st
   if (!match?.groups) return false;
   const lockHost = match.groups.lockHost;
   const pid = Number.parseInt(match.groups.pid, 10);
-  if (lockHost === hostname && processExists(pid)) return false;
+  // Cross-host: no way to check liveness, so leave it alone — user-data dirs on shared storage
+  // could have a live Chrome on the other machine. Same-host: only clear when the holder is dead.
+  if (lockHost !== hostname) return false;
+  if (processExists(pid)) return false;
   clearChromeSingletonArtifacts(userDataDir);
   return true;
 }

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -51,7 +51,8 @@ export function clearStaleChromeSingletonLocks(userDataDir: string, hostname: st
 }
 
 async function waitForChromeProcessExit(proc: ChildProcess, timeoutMs: number): Promise<void> {
-  if (proc.exitCode !== null || proc.signalCode !== null || proc.killed) return;
+  // proc.killed only signals that a kill() call succeeded, not that the process exited.
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
   await new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
       proc.off('exit', onExit);

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -16,6 +16,7 @@ import {
   getAllPages,
   takeAiSnapshotText,
   pickActiveTargetId,
+  isRecoverableStalePageSelectionError,
 } from './connection.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -542,5 +543,39 @@ describe('pickActiveTargetId', () => {
 
     const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
     expect(result).toBe('t-b');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isRecoverableStalePageSelectionError
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isRecoverableStalePageSelectionError', () => {
+  it('returns false when no cached browser was reused', () => {
+    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), false)).toBe(false);
+  });
+
+  it('returns true for BrowserTabNotFoundError when cache was reused', () => {
+    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), true)).toBe(true);
+  });
+
+  it('returns true for "No pages available" error when cache was reused', () => {
+    const err = new Error('No pages available in the connected browser.');
+    expect(isRecoverableStalePageSelectionError(err, true)).toBe(true);
+  });
+
+  it('returns true for any error containing "tab not found" (case-insensitive) when cache was reused', () => {
+    expect(isRecoverableStalePageSelectionError(new Error('Tab Not Found'), true)).toBe(true);
+    expect(isRecoverableStalePageSelectionError(new Error('something: tab not found'), true)).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isRecoverableStalePageSelectionError(new Error('boom'), true)).toBe(false);
+    expect(isRecoverableStalePageSelectionError(new BlockedBrowserTargetError(), true)).toBe(false);
+  });
+
+  it('handles non-Error inputs', () => {
+    expect(isRecoverableStalePageSelectionError('tab not found', true)).toBe(true);
+    expect(isRecoverableStalePageSelectionError(null, true)).toBe(false);
   });
 });

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -552,30 +552,36 @@ describe('pickActiveTargetId', () => {
 
 describe('isRecoverableStalePageSelectionError', () => {
   it('returns false when no cached browser was reused', () => {
-    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), false)).toBe(false);
+    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), false, false)).toBe(false);
+    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), false, true)).toBe(false);
   });
 
-  it('returns true for BrowserTabNotFoundError when cache was reused', () => {
-    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), true)).toBe(true);
-  });
-
-  it('returns true for "No pages available" error when cache was reused', () => {
+  it('returns true for "No pages available" regardless of explicit targetId', () => {
     const err = new Error('No pages available in the connected browser.');
-    expect(isRecoverableStalePageSelectionError(err, true)).toBe(true);
+    expect(isRecoverableStalePageSelectionError(err, true, false)).toBe(true);
+    expect(isRecoverableStalePageSelectionError(err, true, true)).toBe(true);
   });
 
-  it('returns true for any error containing "tab not found" (case-insensitive) when cache was reused', () => {
-    expect(isRecoverableStalePageSelectionError(new Error('Tab Not Found'), true)).toBe(true);
-    expect(isRecoverableStalePageSelectionError(new Error('something: tab not found'), true)).toBe(true);
+  it('returns true for BrowserTabNotFoundError when no explicit targetId was passed', () => {
+    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), true, false)).toBe(true);
+  });
+
+  it('returns false for BrowserTabNotFoundError when caller passed an explicit targetId', () => {
+    expect(isRecoverableStalePageSelectionError(new BrowserTabNotFoundError(), true, true)).toBe(false);
+  });
+
+  it('returns true for "tab not found" message only when no explicit targetId', () => {
+    expect(isRecoverableStalePageSelectionError(new Error('Tab Not Found'), true, false)).toBe(true);
+    expect(isRecoverableStalePageSelectionError(new Error('Tab Not Found'), true, true)).toBe(false);
   });
 
   it('returns false for unrelated errors', () => {
-    expect(isRecoverableStalePageSelectionError(new Error('boom'), true)).toBe(false);
-    expect(isRecoverableStalePageSelectionError(new BlockedBrowserTargetError(), true)).toBe(false);
+    expect(isRecoverableStalePageSelectionError(new Error('boom'), true, false)).toBe(false);
+    expect(isRecoverableStalePageSelectionError(new BlockedBrowserTargetError(), true, false)).toBe(false);
   });
 
   it('handles non-Error inputs', () => {
-    expect(isRecoverableStalePageSelectionError('tab not found', true)).toBe(true);
-    expect(isRecoverableStalePageSelectionError(null, true)).toBe(false);
+    expect(isRecoverableStalePageSelectionError('tab not found', true, false)).toBe(true);
+    expect(isRecoverableStalePageSelectionError(null, true, false)).toBe(false);
   });
 });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -849,13 +849,26 @@ async function getPageForTargetIdOnce(opts: { cdpUrl: string; targetId?: string;
   return found;
 }
 
+function snapshotBlockedTargetsForCdpUrl(cdpUrl: string): string[] {
+  const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
+  const keys: string[] = [];
+  for (const key of blockedTargetsByCdpUrl) {
+    if (key.startsWith(prefix)) keys.push(key);
+  }
+  return keys;
+}
+
 export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
   const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
   try {
     return await getPageForTargetIdOnce(opts);
   } catch (err) {
     if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) throw err;
+    // Preserve blocked-target metadata across the cache eviction so a recovery
+    // retry can't re-select a previously SSRF-blocked target.
+    const preserved = snapshotBlockedTargetsForCdpUrl(opts.cdpUrl);
     await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
+    for (const key of preserved) blockedTargetsByCdpUrl.add(key);
     return await getPageForTargetIdOnce(opts);
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -820,10 +820,15 @@ export function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
   return cachedByCdpUrl.has(normalizeCdpUrl(cdpUrl));
 }
 
-export function isRecoverableStalePageSelectionError(err: unknown, reusedCachedBrowser: boolean): boolean {
+export function isRecoverableStalePageSelectionError(
+  err: unknown,
+  reusedCachedBrowser: boolean,
+  hadExplicitTargetId: boolean,
+): boolean {
   if (!reusedCachedBrowser) return false;
-  if (err instanceof BrowserTabNotFoundError) return true;
   if (err instanceof Error && err.message.includes('No pages available in the connected browser.')) return true;
+  if (hadExplicitTargetId) return false;
+  if (err instanceof BrowserTabNotFoundError) return true;
   const message = err instanceof Error ? err.message : String(err);
   return message.toLowerCase().includes('tab not found');
 }
@@ -856,10 +861,11 @@ async function getPageForTargetIdOnce(opts: { cdpUrl: string; targetId?: string;
 
 export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
   const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
+  const hadExplicitTargetId = opts.targetId !== undefined && opts.targetId !== '';
   try {
     return await getPageForTargetIdOnce(opts);
   } catch (err) {
-    if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) throw err;
+    if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser, hadExplicitTargetId)) throw err;
     await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveSsrfState: true });
     return await getPageForTargetIdOnce(opts);
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -520,15 +520,24 @@ export async function disconnectBrowser(): Promise<void> {
 
 /**
  * Close the Playwright connection for a specific CDP URL without affecting other connections.
+ *
+ * `preserveBlockedMetadata`: when true, do not clear SSRF-blocked target/page-ref tracking.
+ * Used by stale-cache recovery so a concurrent `markTargetBlocked` can't be lost in the
+ * snapshot/clear/restore window.
  */
-export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string }): Promise<void> {
+export async function closePlaywrightBrowserConnection(opts?: {
+  cdpUrl?: string;
+  preserveBlockedMetadata?: boolean;
+}): Promise<void> {
   if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
     return withConnectionLock(async () => {
       const cdpUrl = opts.cdpUrl;
       if (cdpUrl === undefined || cdpUrl === '') return;
       const normalized = normalizeCdpUrl(cdpUrl);
-      clearBlockedTargetsForCdpUrl(normalized);
-      clearBlockedPageRefsForCdpUrl(normalized);
+      if (opts.preserveBlockedMetadata !== true) {
+        clearBlockedTargetsForCdpUrl(normalized);
+        clearBlockedPageRefsForCdpUrl(normalized);
+      }
       const cur = cachedByCdpUrl.get(normalized);
       cachedByCdpUrl.delete(normalized);
       connectingByCdpUrl.delete(normalized);
@@ -849,26 +858,15 @@ async function getPageForTargetIdOnce(opts: { cdpUrl: string; targetId?: string;
   return found;
 }
 
-function snapshotBlockedTargetsForCdpUrl(cdpUrl: string): string[] {
-  const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
-  const keys: string[] = [];
-  for (const key of blockedTargetsByCdpUrl) {
-    if (key.startsWith(prefix)) keys.push(key);
-  }
-  return keys;
-}
-
 export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
   const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
   try {
     return await getPageForTargetIdOnce(opts);
   } catch (err) {
     if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) throw err;
-    // Preserve blocked-target metadata across the cache eviction so a recovery
-    // retry can't re-select a previously SSRF-blocked target.
-    const preserved = snapshotBlockedTargetsForCdpUrl(opts.cdpUrl);
-    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
-    for (const key of preserved) blockedTargetsByCdpUrl.add(key);
+    // Drop the stale cached connection but keep SSRF-blocked target metadata —
+    // a concurrent markTargetBlocked() during the close await would otherwise be lost.
+    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveBlockedMetadata: true });
     return await getPageForTargetIdOnce(opts);
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -520,10 +520,6 @@ export async function disconnectBrowser(): Promise<void> {
 
 /**
  * Close the Playwright connection for a specific CDP URL without affecting other connections.
- *
- * `preserveBlockedMetadata`: when true, do not clear SSRF-blocked target/page-ref tracking.
- * Used by stale-cache recovery so a concurrent `markTargetBlocked` can't be lost in the
- * snapshot/clear/restore window.
  */
 export async function closePlaywrightBrowserConnection(opts?: {
   cdpUrl?: string;
@@ -864,8 +860,6 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
     return await getPageForTargetIdOnce(opts);
   } catch (err) {
     if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) throw err;
-    // Drop the stale cached connection but keep SSRF-blocked target metadata —
-    // a concurrent markTargetBlocked() during the close await would otherwise be lost.
     await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveBlockedMetadata: true });
     return await getPageForTargetIdOnce(opts);
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -523,21 +523,21 @@ export async function disconnectBrowser(): Promise<void> {
  */
 export async function closePlaywrightBrowserConnection(opts?: {
   cdpUrl?: string;
-  preserveBlockedMetadata?: boolean;
+  preserveSsrfState?: boolean;
 }): Promise<void> {
   if (opts?.cdpUrl !== undefined && opts.cdpUrl !== '') {
     return withConnectionLock(async () => {
       const cdpUrl = opts.cdpUrl;
       if (cdpUrl === undefined || cdpUrl === '') return;
       const normalized = normalizeCdpUrl(cdpUrl);
-      if (opts.preserveBlockedMetadata !== true) {
+      if (opts.preserveSsrfState !== true) {
         clearBlockedTargetsForCdpUrl(normalized);
         clearBlockedPageRefsForCdpUrl(normalized);
+        lastPolicyByCdpUrl.delete(normalized);
       }
       const cur = cachedByCdpUrl.get(normalized);
       cachedByCdpUrl.delete(normalized);
       connectingByCdpUrl.delete(normalized);
-      lastPolicyByCdpUrl.delete(normalized);
       if (!cur) return;
       if (cur.onDisconnected && typeof cur.browser.off === 'function')
         cur.browser.off('disconnected', cur.onDisconnected);
@@ -860,7 +860,7 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
     return await getPageForTargetIdOnce(opts);
   } catch (err) {
     if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) throw err;
-    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveBlockedMetadata: true });
+    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveSsrfState: true });
     return await getPageForTargetIdOnce(opts);
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -811,7 +811,19 @@ async function partitionAccessiblePages(opts: {
   return { accessible, blockedCount };
 }
 
-export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
+export function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
+  return cachedByCdpUrl.has(normalizeCdpUrl(cdpUrl));
+}
+
+export function isRecoverableStalePageSelectionError(err: unknown, reusedCachedBrowser: boolean): boolean {
+  if (!reusedCachedBrowser) return false;
+  if (err instanceof BrowserTabNotFoundError) return true;
+  if (err instanceof Error && err.message.includes('No pages available in the connected browser.')) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return message.toLowerCase().includes('tab not found');
+}
+
+async function getPageForTargetIdOnce(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
   if (opts.targetId !== undefined && opts.targetId !== '' && isBlockedTarget(opts.cdpUrl, opts.targetId))
     throw new BlockedBrowserTargetError();
   const { browser } = await connectBrowser(opts.cdpUrl, undefined, opts.ssrfPolicy);
@@ -835,6 +847,17 @@ export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: stri
   if (foundTargetId !== null && foundTargetId !== '' && isBlockedTarget(opts.cdpUrl, foundTargetId))
     throw new BlockedBrowserTargetError();
   return found;
+}
+
+export async function getPageForTargetId(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: SsrfPolicy }) {
+  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
+  try {
+    return await getPageForTargetIdOnce(opts);
+  } catch (err) {
+    if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) throw err;
+    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
+    return await getPageForTargetIdOnce(opts);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- **`src/chrome-launcher.ts`**: port stale Chrome SingletonLock recovery — `clearStaleChromeSingletonLocks` + `processExists` + retry once when Chrome stderr matches the "profile appears to be in use by another chromium process" pattern. Lock symlinks are only cleared when the holder host differs or its pid is dead, so we never kick a live Chrome.
- **`src/connection.ts`**: stale-cache recovery in `getPageForTargetId` — when a tab disappears against a *cached* CDP browser connection, drop the cache and retry once. Adds `hasCachedPlaywrightBrowserConnection` and `isRecoverableStalePageSelectionError` helpers; extracts `getPageForTargetIdOnce`.
- Tests for `processExists`, `clearChromeSingletonArtifacts`, `clearStaleChromeSingletonLocks`, and `isRecoverableStalePageSelectionError`.

Mirrors OpenClaw 2026.4.24 `launchOpenClawChrome` and `getPageForTargetId` behavior.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 411 files / 17504 tests pass
- [ ] Manual: back-to-back launch with stale `SingletonLock` symlink no longer requires user intervention
- [ ] Manual: cached CDP connection recovers from stale tab handle on next call