### PR TITLE
[codex] Scope stealth observation per browser context

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ const browser = await BrowserClaw.connect();
 
 `connect()` checks that Chrome is reachable, then the internal CDP connection retries 3 times with increasing timeouts (5 s, 7 s, 9 s) — safe for Docker/CI where Chrome starts slowly.
 
-**Anti-detection:** browserclaw always disables Chrome's `AutomationControlled` Blink feature. To also inject JavaScript
+**Anti-detection:** `launch()` always passes Chrome the flag that disables the `AutomationControlled` Blink feature.
+`connect()` attaches to an already-running Chrome, so it cannot add launch flags retroactively. To inject JavaScript
 stealth patches for `navigator.webdriver`, plugins, WebGL vendor, and related browser signals, pass `stealth: true` to
 `launch()` or `connect()`.
 
@@ -229,10 +230,10 @@ BrowserClaw exports structured errors so workflow code can tell apart the common
 
 ```typescript
 import {
-  BrowserTabNotFoundError,   // targetId no longer resolves to an open tab
-  StaleRefError,              // ref is not in the current snapshot
-  SnapshotHydrationError,     // snapshot returned without interactive refs
-  NavigationRaceError,        // the page navigated during an operation
+  BrowserTabNotFoundError, // targetId no longer resolves to an open tab
+  StaleRefError, // ref is not in the current snapshot
+  SnapshotHydrationError, // snapshot returned without interactive refs
+  NavigationRaceError, // the page navigated during an operation
 } from 'browserclaw';
 
 try {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ const browser = await BrowserClaw.connect();
 
 `connect()` checks that Chrome is reachable, then the internal CDP connection retries 3 times with increasing timeouts (5 s, 7 s, 9 s) — safe for Docker/CI where Chrome starts slowly.
 
-**Anti-detection:** browserclaw automatically hides `navigator.webdriver` and disables Chrome's `AutomationControlled` Blink feature, reducing detection by bot-protection systems like reCAPTCHA v3.
+**Anti-detection:** browserclaw always disables Chrome's `AutomationControlled` Blink feature. To also inject JavaScript
+stealth patches for `navigator.webdriver`, plugins, WebGL vendor, and related browser signals, pass `stealth: true` to
+`launch()` or `connect()`.
 
 #### Isolated profiles (per-run, per-process)
 

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -6,8 +6,8 @@ import {
   connectBrowser,
   getPageForTargetId,
   ensurePageState,
-  ensureContextState,
   observeContext,
+  getStealthEnabledForCdpUrl,
   pageTargetId,
   getAllPages,
   forceDisconnectPlaywrightConnection,
@@ -39,9 +39,10 @@ async function createRecordingContext(
   browser: Browser,
   cdpUrl: string,
   recordVideo: { dir: string; size?: { width: number; height: number } },
+  stealth?: boolean,
 ): Promise<BrowserContext> {
   const context = await browser.newContext({ recordVideo });
-  await observeContext(context);
+  await observeContext(context, { stealth: stealth ?? getStealthEnabledForCdpUrl(cdpUrl) });
   recordingContexts.set(cdpUrl, context);
   context.on('close', () => recordingContexts.delete(cdpUrl));
   return context;
@@ -554,15 +555,21 @@ export async function createPageViaPlaywright(opts: {
   cdpUrl: string;
   url?: string;
   ssrfPolicy?: SsrfPolicy;
+  stealth?: boolean;
   /** @deprecated Use ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } instead */
   allowInternal?: boolean;
   recordVideo?: { dir: string; size?: { width: number; height: number } };
 }): Promise<BrowserTab> {
-  const { browser } = await connectBrowser(opts.cdpUrl);
+  /* eslint-disable @typescript-eslint/no-deprecated */
+  const policy =
+    opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
+  /* eslint-enable @typescript-eslint/no-deprecated */
+  const { browser } = await connectBrowser(opts.cdpUrl, undefined, policy, { stealth: opts.stealth });
   const context = opts.recordVideo
-    ? (recordingContexts.get(opts.cdpUrl) ?? (await createRecordingContext(browser, opts.cdpUrl, opts.recordVideo)))
+    ? (recordingContexts.get(opts.cdpUrl) ??
+      (await createRecordingContext(browser, opts.cdpUrl, opts.recordVideo, opts.stealth)))
     : (browser.contexts()[0] ?? (await browser.newContext()));
-  ensureContextState(context);
+  await observeContext(context, { stealth: opts.stealth ?? getStealthEnabledForCdpUrl(opts.cdpUrl) });
   const page = await context.newPage();
   ensurePageState(page);
   clearBlockedPageRef(opts.cdpUrl, page);
@@ -570,10 +577,6 @@ export async function createPageViaPlaywright(opts: {
   clearBlockedTarget(opts.cdpUrl, createdTargetId ?? undefined);
 
   const targetUrl = (opts.url ?? '').trim() || 'about:blank';
-  /* eslint-disable @typescript-eslint/no-deprecated */
-  const policy =
-    opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
-  /* eslint-enable @typescript-eslint/no-deprecated */
 
   if (targetUrl !== 'about:blank') {
     await assertBrowserNavigationAllowed({ url: targetUrl, ...withBrowserNavigationPolicy(policy) });

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -66,7 +66,6 @@ import {
   BrowserTabNotFoundError,
   resolveActiveTargetId,
 } from './connection.js';
-import { setStealthEnabled } from './page-utils.js';
 import { assertCdpEndpointAllowed } from './security.js';
 import { snapshotAi } from './snapshot/ai-snapshot.js';
 import { snapshotRole, snapshotAria } from './snapshot/aria-snapshot.js';
@@ -1765,6 +1764,7 @@ export class BrowserClaw {
   private readonly cdpUrl: string;
   private readonly ssrfPolicy: SsrfPolicy | undefined;
   private readonly recordVideo: { dir: string; size?: { width: number; height: number } } | undefined;
+  private readonly stealth: boolean;
   private chrome: RunningChrome | null;
   private readonly _telemetry: RunTelemetry;
 
@@ -1774,12 +1774,14 @@ export class BrowserClaw {
     telemetry: RunTelemetry,
     ssrfPolicy?: SsrfPolicy,
     recordVideo?: { dir: string; size?: { width: number; height: number } },
+    stealth = false,
   ) {
     this.cdpUrl = cdpUrl;
     this.chrome = chrome;
     this._telemetry = telemetry;
     this.ssrfPolicy = ssrfPolicy;
     this.recordVideo = recordVideo;
+    this.stealth = stealth;
   }
 
   /**
@@ -1808,7 +1810,7 @@ export class BrowserClaw {
    */
   static async launch(opts: LaunchOptions = {}): Promise<BrowserClaw> {
     const startedAt = new Date().toISOString();
-    setStealthEnabled(opts.stealth === true);
+    const stealth = opts.stealth === true;
     const chrome = await launchChrome(opts);
     try {
       const cdpUrl = `http://127.0.0.1:${String(chrome.cdpPort)}`;
@@ -1817,12 +1819,12 @@ export class BrowserClaw {
         opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
       /* eslint-enable @typescript-eslint/no-deprecated */
       // Bootstrap connect to our own freshly-spawned loopback Chrome — no policy check.
-      await connectBrowser(cdpUrl, undefined);
+      await connectBrowser(cdpUrl, undefined, undefined, { stealth });
       const telemetry: RunTelemetry = {
         launchMs: chrome.launchMs,
         timestamps: { startedAt, launchedAt: new Date().toISOString() },
       };
-      const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo);
+      const browser = new BrowserClaw(cdpUrl, chrome, telemetry, ssrfPolicy, opts.recordVideo, stealth);
       if (opts.url !== undefined && opts.url !== '') {
         const page = await browser.currentPage();
         const navT0 = Date.now();
@@ -1855,7 +1857,7 @@ export class BrowserClaw {
    */
   static async connect(cdpUrl?: string, opts?: ConnectOptions): Promise<BrowserClaw> {
     const startedAt = new Date().toISOString();
-    setStealthEnabled(opts?.stealth === true);
+    const stealth = opts?.stealth === true;
     const connectT0 = Date.now();
     let resolvedUrl = cdpUrl;
     if (resolvedUrl === undefined || resolvedUrl === '') {
@@ -1877,12 +1879,12 @@ export class BrowserClaw {
     if (!(await isChromeReachable(resolvedUrl, 3000, opts?.authToken, ssrfPolicy))) {
       throw new Error(`Cannot connect to Chrome at ${resolvedUrl}. Is Chrome running with --remote-debugging-port?`);
     }
-    await connectBrowser(resolvedUrl, opts?.authToken, ssrfPolicy);
+    await connectBrowser(resolvedUrl, opts?.authToken, ssrfPolicy, { stealth });
     const telemetry: RunTelemetry = {
       connectMs: Date.now() - connectT0,
       timestamps: { startedAt, connectedAt: new Date().toISOString() },
     };
-    return new BrowserClaw(resolvedUrl, null, telemetry, ssrfPolicy, opts?.recordVideo);
+    return new BrowserClaw(resolvedUrl, null, telemetry, ssrfPolicy, opts?.recordVideo, stealth);
   }
 
   /**
@@ -1903,6 +1905,7 @@ export class BrowserClaw {
       url,
       ssrfPolicy: this.ssrfPolicy,
       recordVideo: this.recordVideo,
+      stealth: this.stealth,
     });
     return new CrawlPage(this.cdpUrl, tab.targetId, this.ssrfPolicy);
   }
@@ -1921,7 +1924,7 @@ export class BrowserClaw {
    */
   async currentPage(): Promise<CrawlPage> {
     const connectT0 = Date.now();
-    await connectBrowser(this.cdpUrl);
+    await connectBrowser(this.cdpUrl, undefined, this.ssrfPolicy, { stealth: this.stealth });
     if (this._telemetry.connectMs === undefined) {
       this._telemetry.connectMs = Date.now() - connectT0;
       this._telemetry.timestamps.connectedAt = new Date().toISOString();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -434,7 +434,7 @@ export async function connectBrowser(
   if (observeOptions?.stealth !== undefined) stealthByCdpUrl.set(normalized, observeOptions.stealth);
   const effectiveObserveOptions: ObserveOptions = { stealth: getStealthEnabledForCdpUrl(normalized) };
   const observeCached = async (connected: CachedConnection): Promise<CachedConnection> => {
-    if (observeOptions?.stealth === true) await observeBrowser(connected.browser, effectiveObserveOptions);
+    if (observeOptions?.stealth !== undefined) await observeBrowser(connected.browser, effectiveObserveOptions);
     return connected;
   };
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -431,10 +431,11 @@ export async function connectBrowser(
   observeOptions?: ObserveOptions,
 ): Promise<CachedConnection> {
   const normalized = normalizeCdpUrl(cdpUrl);
-  if (observeOptions?.stealth !== undefined) stealthByCdpUrl.set(normalized, observeOptions.stealth);
+  if (observeOptions?.stealth === true && stealthByCdpUrl.get(normalized) !== true)
+    stealthByCdpUrl.set(normalized, true);
   const effectiveObserveOptions: ObserveOptions = { stealth: getStealthEnabledForCdpUrl(normalized) };
   const observeCached = async (connected: CachedConnection): Promise<CachedConnection> => {
-    if (observeOptions?.stealth !== undefined) await observeBrowser(connected.browser, effectiveObserveOptions);
+    if (effectiveObserveOptions.stealth === true) await observeBrowser(connected.browser, effectiveObserveOptions);
     return connected;
   };
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -12,7 +12,7 @@ import {
   hasProxyEnvConfigured,
 } from './chrome-launcher.js';
 import { BrowserTabNotFoundError } from './errors.js';
-import { ensurePageState, observeBrowser, setDialogHandlerOnPage } from './page-utils.js';
+import { ensurePageState, observeBrowser, setDialogHandlerOnPage, type ObserveOptions } from './page-utils.js';
 import { clearRoleRefsForCdpUrl, normalizeCdpUrl } from './ref-resolver.js';
 import { assertCdpEndpointAllowed } from './security.js';
 import type { DialogHandler, SsrfPolicy } from './types.js';
@@ -282,10 +282,15 @@ interface CachedConnection {
 
 const cachedByCdpUrl = new Map<string, CachedConnection>();
 const connectingByCdpUrl = new Map<string, Promise<CachedConnection>>();
+const stealthByCdpUrl = new Map<string, boolean>();
 // Remembered per-URL so reconnects re-run assertCdpEndpointAllowed even when
 // the action function chain doesn't thread a policy through. Closes the
 // DNS-rebinding window between connect attempts.
 const lastPolicyByCdpUrl = new Map<string, SsrfPolicy>();
+
+export function getStealthEnabledForCdpUrl(cdpUrl: string): boolean {
+  return stealthByCdpUrl.get(normalizeCdpUrl(cdpUrl)) ?? false;
+}
 
 // ── Connection Mutex ──
 // Serializes connect/disconnect operations to prevent races where a disconnect
@@ -423,26 +428,34 @@ export async function connectBrowser(
   cdpUrl: string,
   authToken?: string,
   ssrfPolicy?: SsrfPolicy,
+  observeOptions?: ObserveOptions,
 ): Promise<CachedConnection> {
   const normalized = normalizeCdpUrl(cdpUrl);
+  if (observeOptions?.stealth !== undefined) stealthByCdpUrl.set(normalized, observeOptions.stealth);
+  const effectiveObserveOptions: ObserveOptions = { stealth: getStealthEnabledForCdpUrl(normalized) };
+  const observeCached = async (connected: CachedConnection): Promise<CachedConnection> => {
+    if (observeOptions?.stealth === true) await observeBrowser(connected.browser, effectiveObserveOptions);
+    return connected;
+  };
+
   // Lock-free fast path: return cached connection
   const existing_cached = cachedByCdpUrl.get(normalized);
-  if (existing_cached) return existing_cached;
+  if (existing_cached) return await observeCached(existing_cached);
 
   if (ssrfPolicy !== undefined) lastPolicyByCdpUrl.set(normalized, ssrfPolicy);
   const effectivePolicy = ssrfPolicy ?? lastPolicyByCdpUrl.get(normalized);
   await assertCdpEndpointAllowed(normalized, effectivePolicy);
 
   const existing = connectingByCdpUrl.get(normalized);
-  if (existing) return await existing;
+  if (existing) return await observeCached(await existing);
 
   // Slow path: acquire connection lock before creating a new connection
   return withConnectionLock(async () => {
     // Re-check after acquiring lock
     const rechecked = cachedByCdpUrl.get(normalized);
-    if (rechecked) return rechecked;
+    if (rechecked) return await observeCached(rechecked);
     const recheckPending = connectingByCdpUrl.get(normalized);
-    if (recheckPending) return await recheckPending;
+    if (recheckPending) return await observeCached(await recheckPending);
 
     const connectWithRetry = async () => {
       let lastErr: unknown;
@@ -466,7 +479,7 @@ export async function connectBrowser(
           };
           const connected: CachedConnection = { browser, cdpUrl: normalized, onDisconnected };
           cachedByCdpUrl.set(normalized, connected);
-          await observeBrowser(browser);
+          await observeBrowser(browser, effectiveObserveOptions);
           browser.on('disconnected', onDisconnected);
           return connected;
         } catch (err) {
@@ -512,6 +525,7 @@ export async function disconnectBrowser(): Promise<void> {
       });
     }
     cachedByCdpUrl.clear();
+    stealthByCdpUrl.clear();
     lastPolicyByCdpUrl.clear();
     clearBlockedTargetsForCdpUrl();
     clearBlockedPageRefsForCdpUrl();
@@ -533,6 +547,7 @@ export async function closePlaywrightBrowserConnection(opts?: {
       if (opts.preserveSsrfState !== true) {
         clearBlockedTargetsForCdpUrl(normalized);
         clearBlockedPageRefsForCdpUrl(normalized);
+        stealthByCdpUrl.delete(normalized);
         lastPolicyByCdpUrl.delete(normalized);
       }
       const cur = cachedByCdpUrl.get(normalized);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -435,7 +435,7 @@ export async function connectBrowser(
     stealthByCdpUrl.set(normalized, true);
   const effectiveObserveOptions: ObserveOptions = { stealth: getStealthEnabledForCdpUrl(normalized) };
   const observeCached = async (connected: CachedConnection): Promise<CachedConnection> => {
-    if (effectiveObserveOptions.stealth === true) await observeBrowser(connected.browser, effectiveObserveOptions);
+    if (observeOptions?.stealth === true) await observeBrowser(connected.browser, { stealth: true });
     return connected;
   };
 

--- a/src/page-utils.test.ts
+++ b/src/page-utils.test.ts
@@ -11,7 +11,6 @@ import {
   ensurePageState,
   ensureContextState,
   observeContext,
-  setStealthEnabled,
 } from './page-utils.js';
 import type { PageState, NetworkRequest } from './types.js';
 
@@ -306,7 +305,6 @@ describe('ensureContextState', () => {
 
 describe('observeContext stealth gating', () => {
   it('does NOT inject stealth when disabled (default)', async () => {
-    setStealthEnabled(false);
     let calls = 0;
     const ctx = {
       addInitScript: () => {
@@ -329,7 +327,6 @@ describe('observeContext stealth gating', () => {
   });
 
   it('injects stealth via addInitScript when enabled', async () => {
-    setStealthEnabled(true);
     let calls = 0;
     const ctx = {
       addInitScript: () => {
@@ -347,8 +344,75 @@ describe('observeContext stealth gating', () => {
         /* noop */
       },
     } as unknown as BrowserContext;
-    await observeContext(ctx);
+    await observeContext(ctx, { stealth: true });
     expect(calls).toBe(1);
-    setStealthEnabled(false); // restore default
+  });
+
+  it('does not leak stealth between contexts', async () => {
+    let stealthCalls = 0;
+    let plainCalls = 0;
+    const stealthCtx = {
+      addInitScript: () => {
+        stealthCalls++;
+        return Promise.resolve();
+      },
+      pages: () => [],
+      on: () => {
+        /* noop */
+      },
+      off: () => {
+        /* noop */
+      },
+      once: () => {
+        /* noop */
+      },
+    } as unknown as BrowserContext;
+    const plainCtx = {
+      addInitScript: () => {
+        plainCalls++;
+        return Promise.resolve();
+      },
+      pages: () => [],
+      on: () => {
+        /* noop */
+      },
+      off: () => {
+        /* noop */
+      },
+      once: () => {
+        /* noop */
+      },
+    } as unknown as BrowserContext;
+
+    await observeContext(stealthCtx, { stealth: true });
+    await observeContext(plainCtx);
+
+    expect(stealthCalls).toBe(1);
+    expect(plainCalls).toBe(0);
+  });
+
+  it('can enable stealth after a context was already observed', async () => {
+    let calls = 0;
+    const ctx = {
+      addInitScript: () => {
+        calls++;
+        return Promise.resolve();
+      },
+      pages: () => [],
+      on: () => {
+        /* noop */
+      },
+      off: () => {
+        /* noop */
+      },
+      once: () => {
+        /* noop */
+      },
+    } as unknown as BrowserContext;
+
+    await observeContext(ctx, { stealth: false });
+    await observeContext(ctx, { stealth: true });
+
+    expect(calls).toBe(1);
   });
 });

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -225,10 +225,11 @@ function contextStealthEnabled(context: BrowserContext): boolean {
 
 async function installStealthInitScript(context: BrowserContext): Promise<void> {
   if (stealthInitScriptContexts.has(context)) return;
+  stealthInitScriptContexts.add(context);
   try {
     await context.addInitScript(STEALTH_SCRIPT);
-    stealthInitScriptContexts.add(context);
   } catch (e: unknown) {
+    stealthInitScriptContexts.delete(context);
     if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
       console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
   }

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -214,7 +214,8 @@ export function setDialogHandlerOnPage(page: Page, handler?: DialogHandler): voi
 // ── Stealth ──
 
 function resolveContextStealth(context: BrowserContext, opts?: ObserveOptions): boolean {
-  if (opts?.stealth !== undefined) contextStealthSettings.set(context, opts.stealth);
+  const current = contextStealthSettings.get(context) ?? false;
+  if (opts?.stealth === true && !current) contextStealthSettings.set(context, true);
   return contextStealthSettings.get(context) ?? false;
 }
 

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -11,6 +11,13 @@ const pageStates = new WeakMap<Page, PageState>();
 const contextStates = new WeakMap<BrowserContext, ContextState>();
 const observedContexts = new WeakSet<BrowserContext>();
 const observedPages = new WeakSet<Page>();
+const contextStealthSettings = new WeakMap<BrowserContext, boolean>();
+const stealthInitScriptContexts = new WeakSet<BrowserContext>();
+const stealthAppliedPages = new WeakSet<Page>();
+
+export interface ObserveOptions {
+  stealth?: boolean;
+}
 
 // ── Arm ID Counters ──
 
@@ -185,6 +192,7 @@ export function ensurePageState(page: Page): PageState {
     page.on('close', () => {
       pageStates.delete(page);
       observedPages.delete(page);
+      stealthAppliedPages.delete(page);
     });
   }
 
@@ -205,54 +213,67 @@ export function setDialogHandlerOnPage(page: Page, handler?: DialogHandler): voi
 
 // ── Stealth ──
 
-let stealthEnabled = false;
-
-export function setStealthEnabled(enabled: boolean): void {
-  stealthEnabled = enabled;
+function resolveContextStealth(context: BrowserContext, opts?: ObserveOptions): boolean {
+  if (opts?.stealth !== undefined) contextStealthSettings.set(context, opts.stealth);
+  return contextStealthSettings.get(context) ?? false;
 }
 
-async function applyStealthToPage(page: Page): Promise<void> {
+function contextStealthEnabled(context: BrowserContext): boolean {
+  return contextStealthSettings.get(context) ?? false;
+}
+
+async function installStealthInitScript(context: BrowserContext): Promise<void> {
+  if (stealthInitScriptContexts.has(context)) return;
+  try {
+    await context.addInitScript(STEALTH_SCRIPT);
+    stealthInitScriptContexts.add(context);
+  } catch (e: unknown) {
+    if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
+      console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
+  }
+}
+
+async function applyStealthToPage(page: Page, stealthEnabled: boolean): Promise<void> {
   if (!stealthEnabled) return;
+  if (stealthAppliedPages.has(page)) return;
   try {
     await page.evaluate(STEALTH_SCRIPT);
+    stealthAppliedPages.add(page);
   } catch (e: unknown) {
     if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
       console.warn('[browserclaw] stealth evaluate failed:', e instanceof Error ? e.message : String(e));
   }
 }
 
-export async function observeContext(context: BrowserContext): Promise<void> {
-  if (observedContexts.has(context)) return;
-  observedContexts.add(context);
+export async function observeContext(context: BrowserContext, opts?: ObserveOptions): Promise<void> {
+  const stealthEnabled = resolveContextStealth(context, opts);
   ensureContextState(context);
 
-  if (stealthEnabled) {
-    try {
-      await context.addInitScript(STEALTH_SCRIPT);
-    } catch (e: unknown) {
-      if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
-        console.warn('[browserclaw] stealth initScript failed:', e instanceof Error ? e.message : String(e));
-    }
-  }
+  if (stealthEnabled) await installStealthInitScript(context);
 
   for (const page of context.pages()) {
     ensurePageState(page);
-    await applyStealthToPage(page);
+    await applyStealthToPage(page, stealthEnabled);
   }
+
+  if (observedContexts.has(context)) return;
+  observedContexts.add(context);
+
   const onPage = (page: Page) => {
     ensurePageState(page);
-    applyStealthToPage(page).catch(() => {
+    applyStealthToPage(page, contextStealthEnabled(context)).catch(() => {
       /* noop — best-effort stealth for new pages */
     });
   };
   context.on('page', onPage);
   context.once('close', () => {
     context.off('page', onPage);
+    stealthInitScriptContexts.delete(context);
   });
 }
 
-export async function observeBrowser(browser: Browser): Promise<void> {
-  for (const context of browser.contexts()) await observeContext(context);
+export async function observeBrowser(browser: Browser, opts?: ObserveOptions): Promise<void> {
+  for (const context of browser.contexts()) await observeContext(context, opts);
 }
 
 // ── Error Helpers ──


### PR DESCRIPTION
## Summary

This PR scopes BrowserClaw stealth observation to browser contexts/CDP URLs instead of using one process-global flag.

## Changes

- Replaces the module-global stealth toggle with per-context observation state.
- Threads the `stealth` launch/connect choice through BrowserClaw connection setup and new-page context observation.
- Keeps the always-on `AutomationControlled` Chrome flag behavior while making README wording match the actual opt-in JS stealth behavior.
- Adds regression tests covering disabled stealth, enabled stealth, no cross-context leakage, and enabling stealth after a context was already observed.

## Why

The previous global `setStealthEnabled()` flag meant one BrowserClaw session could affect another concurrent session. A stealth-enabled connection could cause unrelated contexts to receive stealth patches, and a later non-stealth connection could disable stealth setup for a still-running stealth session.

## Validation

- `npm run typecheck`
- `npx vitest run src/page-utils.test.ts src/chrome-launcher.test.ts`
- `npm run lint`
- `npx prettier --check src/actions/navigation.ts src/browser.ts src/connection.ts src/page-utils.ts src/page-utils.test.ts`
- `git diff --check`

Note: `npx prettier --check README.md` already fails on `HEAD`, so this PR avoids reformatting the entire README.