### PR TITLE
Updates from OpenClaw 2026.4.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -3,11 +3,14 @@ import type { Browser, BrowserContext, Page, Route, Request, Frame } from 'playw
 import {
   BrowserTabNotFoundError,
   BlockedBrowserTargetError,
+  closePlaywrightBrowserConnection,
   connectBrowser,
   getPageForTargetId,
   ensurePageState,
   observeContext,
   getStealthEnabledForCdpUrl,
+  hasCachedPlaywrightBrowserConnection,
+  isRecoverablePlaywrightDisconnectError,
   pageTargetId,
   getAllPages,
   forceDisconnectPlaywrightConnection,
@@ -533,14 +536,14 @@ export async function navigateViaPlaywright(opts: {
   return { url: page.url() };
 }
 
-export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<BrowserTab[]> {
-  const { browser } = await connectBrowser(opts.cdpUrl);
+async function listPagesViaPlaywrightOnce(cdpUrl: string): Promise<BrowserTab[]> {
+  const { browser } = await connectBrowser(cdpUrl);
   const pages = getAllPages(browser);
   const results: BrowserTab[] = [];
   for (const page of pages) {
-    if (isBlockedPageRef(opts.cdpUrl, page)) continue;
+    if (isBlockedPageRef(cdpUrl, page)) continue;
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid !== null && tid !== '' && !isBlockedTarget(opts.cdpUrl, tid))
+    if (tid !== null && tid !== '' && !isBlockedTarget(cdpUrl, tid))
       results.push({
         targetId: tid,
         title: await page.title().catch(() => ''),
@@ -549,6 +552,17 @@ export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
       });
   }
   return results;
+}
+
+export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<BrowserTab[]> {
+  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
+  try {
+    return await listPagesViaPlaywrightOnce(opts.cdpUrl);
+  } catch (err) {
+    if (!reusedCachedBrowser || !isRecoverablePlaywrightDisconnectError(err)) throw err;
+    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveSsrfState: true });
+    return await listPagesViaPlaywrightOnce(opts.cdpUrl);
+  }
 }
 
 export async function createPageViaPlaywright(opts: {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -390,15 +390,19 @@ function findChromeLinux(): ChromeExecutable | null {
     { kind: 'chrome', path: '/usr/bin/google-chrome' },
     { kind: 'chrome', path: '/usr/bin/google-chrome-stable' },
     { kind: 'chrome', path: '/usr/bin/chrome' },
+    { kind: 'chrome', path: '/opt/google/chrome/chrome' },
     { kind: 'brave', path: '/usr/bin/brave-browser' },
     { kind: 'brave', path: '/usr/bin/brave-browser-stable' },
     { kind: 'brave', path: '/usr/bin/brave' },
     { kind: 'brave', path: '/snap/bin/brave' },
+    { kind: 'brave', path: '/opt/brave.com/brave/brave-browser' },
     { kind: 'edge', path: '/usr/bin/microsoft-edge' },
     { kind: 'edge', path: '/usr/bin/microsoft-edge-stable' },
     { kind: 'chromium', path: '/usr/bin/chromium' },
     { kind: 'chromium', path: '/usr/bin/chromium-browser' },
     { kind: 'chromium', path: '/snap/bin/chromium' },
+    { kind: 'chromium', path: '/usr/lib/chromium/chromium' },
+    { kind: 'chromium', path: '/usr/lib/chromium-browser/chromium-browser' },
   ]);
 }
 
@@ -646,7 +650,7 @@ export function resolveIsolatedProfile(value: boolean | string): { profileName: 
 
 // ── WebSocket / CDP URL Helpers ──
 
-function isWebSocketUrl(url: string): boolean {
+export function isWebSocketUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return parsed.protocol === 'ws:' || parsed.protocol === 'wss:';

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -16,6 +16,7 @@ import {
   getAllPages,
   takeAiSnapshotText,
   pickActiveTargetId,
+  isRecoverablePlaywrightDisconnectError,
   isRecoverableStalePageSelectionError,
 } from './connection.js';
 
@@ -583,5 +584,33 @@ describe('isRecoverableStalePageSelectionError', () => {
   it('handles non-Error inputs', () => {
     expect(isRecoverableStalePageSelectionError('tab not found', true, false)).toBe(true);
     expect(isRecoverableStalePageSelectionError(null, true, false)).toBe(false);
+  });
+});
+
+describe('isRecoverablePlaywrightDisconnectError', () => {
+  it.each([
+    'Target page, context or browser has been closed',
+    'Browser has been closed',
+    'browser disconnected',
+    'Target closed',
+    'Connection closed',
+    'WebSocket closed',
+    'CDP socket closed',
+  ])('returns true for %s', (msg) => {
+    expect(isRecoverablePlaywrightDisconnectError(new Error(msg))).toBe(true);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(isRecoverablePlaywrightDisconnectError(new Error('TARGET CLOSED'))).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isRecoverablePlaywrightDisconnectError(new Error('boom'))).toBe(false);
+    expect(isRecoverablePlaywrightDisconnectError(new Error('No pages available'))).toBe(false);
+  });
+
+  it('handles non-Error inputs', () => {
+    expect(isRecoverablePlaywrightDisconnectError('target closed')).toBe(true);
+    expect(isRecoverablePlaywrightDisconnectError(null)).toBe(false);
   });
 });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,6 +6,7 @@ import type { Browser, Page, CDPSession } from 'playwright-core';
 
 import {
   getChromeWebSocketUrl,
+  isWebSocketUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
   normalizeCdpWsUrl,
   isLoopbackHost,
@@ -466,12 +467,19 @@ export async function connectBrowser(
           const endpoint =
             (await getChromeWebSocketUrl(normalized, timeout, authToken, effectivePolicy).catch(() => null)) ??
             normalized;
-          const headers: Record<string, string> = getHeadersWithAuth(endpoint);
-          if (authToken !== undefined && authToken !== '' && !headers.Authorization)
-            headers.Authorization = `Bearer ${authToken}`;
-          const browser = await withNoProxyForCdpUrl(endpoint, () =>
-            chromium.connectOverCDP(endpoint, { timeout, headers }),
-          );
+          const connectAt = async (target: string) => {
+            const headers: Record<string, string> = getHeadersWithAuth(target);
+            if (authToken !== undefined && authToken !== '' && !headers.Authorization)
+              headers.Authorization = `Bearer ${authToken}`;
+            return await withNoProxyForCdpUrl(target, () => chromium.connectOverCDP(target, { timeout, headers }));
+          };
+          let browser: Browser;
+          try {
+            browser = await connectAt(endpoint);
+          } catch (connectErr) {
+            if (!isWebSocketUrl(normalized) || endpoint === normalized) throw connectErr;
+            browser = await connectAt(normalized);
+          }
           const onDisconnected = () => {
             if (cachedByCdpUrl.get(normalized)?.browser === browser) {
               cachedByCdpUrl.delete(normalized);
@@ -834,6 +842,19 @@ async function partitionAccessiblePages(opts: {
 
 export function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
   return cachedByCdpUrl.has(normalizeCdpUrl(cdpUrl));
+}
+
+export function isRecoverablePlaywrightDisconnectError(err: unknown): boolean {
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    message.includes('target page, context or browser has been closed') ||
+    message.includes('browser has been closed') ||
+    message.includes('browser disconnected') ||
+    message.includes('target closed') ||
+    message.includes('connection closed') ||
+    message.includes('websocket closed') ||
+    message.includes('cdp socket closed')
+  );
 }
 
 export function isRecoverableStalePageSelectionError(

--- a/src/ref-resolver.test.ts
+++ b/src/ref-resolver.test.ts
@@ -426,10 +426,35 @@ describe('refLocator', () => {
     expect(() => refLocator(page, 'e999')).toThrow('Unknown ref "e999"');
   });
 
-  it('rejects axN refs from snapshotAria with a helpful error', () => {
+  it('throws StaleRefError on axN ref when no aria snapshot was stored', () => {
     const page = mockPage();
-    expect(() => refLocator(page, 'ax1')).toThrow(/snapshotAria/);
-    expect(() => refLocator(page, 'ax42')).toThrow(/eN refs/);
+    ensurePageState(page);
+    expect(() => refLocator(page, 'ax1')).toThrow('Unknown ref "ax1"');
+  });
+
+  it('resolves axN ref via DOM marker selector when domMarker is set', () => {
+    const page = mockPage();
+    storeRoleRefsForTarget({
+      page,
+      cdpUrl: 'ws://localhost:9222',
+      refs: { ax1: { role: 'button', name: 'Submit', domMarker: true } },
+      mode: 'role',
+    });
+    const loc = refLocator(page, 'ax1') as unknown as { _selector: string };
+    expect(loc._selector).toBe('[data-browserclaw-ref="ax1"]');
+  });
+
+  it('falls back to getByRole for axN ref without domMarker', () => {
+    const page = mockPage();
+    storeRoleRefsForTarget({
+      page,
+      cdpUrl: 'ws://localhost:9222',
+      refs: { ax1: { role: 'button', name: 'Submit' } },
+      mode: 'role',
+    });
+    const loc = refLocator(page, 'ax1') as unknown as { _role: string; _name?: string };
+    expect(loc._role).toBe('button');
+    expect(loc._name).toBe('Submit');
   });
 
   it('returns getByRole locator for known role ref', () => {

--- a/src/ref-resolver.test.ts
+++ b/src/ref-resolver.test.ts
@@ -457,6 +457,23 @@ describe('refLocator', () => {
     expect(loc._name).toBe('Submit');
   });
 
+  it('disambiguates first duplicate ax ref with nth=0 in fallback', () => {
+    const page = mockPage();
+    storeRoleRefsForTarget({
+      page,
+      cdpUrl: 'ws://localhost:9222',
+      refs: {
+        ax1: { role: 'button', name: 'Submit', nth: 0 },
+        ax2: { role: 'button', name: 'Submit', nth: 1 },
+      },
+      mode: 'role',
+    });
+    const first = refLocator(page, 'ax1') as unknown as { _nth: number };
+    const second = refLocator(page, 'ax2') as unknown as { _nth: number };
+    expect(first._nth).toBe(0);
+    expect(second._nth).toBe(1);
+  });
+
   it('returns getByRole locator for known role ref', () => {
     const page = mockPage();
     storeRoleRefsForTarget({

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -147,15 +147,23 @@ export function resolveBoundedDelayMs(value: number | undefined, label: string, 
 // ── Ref Locator ──
 
 const AX_REF_PATTERN = /^ax\d+$/;
+export const BROWSER_REF_MARKER_ATTRIBUTE = 'data-browserclaw-ref';
 
 export function refLocator(page: Page, ref: string) {
   const normalized = ref.startsWith('@') ? ref.slice(1) : ref.startsWith('ref=') ? ref.slice(4) : ref;
   if (normalized.trim() === '') throw new Error('ref is required');
 
   if (AX_REF_PATTERN.test(normalized)) {
-    throw new Error(
-      `Ref "${normalized}" comes from a snapshotAria() result and cannot be used with actions. Call page.snapshot() and use the eN refs from that snapshot instead.`,
-    );
+    const state = getPageState(page);
+    const info = state?.roleRefs?.[normalized];
+    if (!info) throw new StaleRefError(normalized);
+    if (info.domMarker === true) return page.locator(`[${BROWSER_REF_MARKER_ATTRIBUTE}="${normalized}"]`);
+    const role = info.role as Parameters<Page['getByRole']>[0];
+    const locator =
+      info.name !== undefined && info.name !== ''
+        ? page.getByRole(role, { name: info.name, exact: true })
+        : page.getByRole(role);
+    return info.nth !== undefined ? locator.nth(info.nth) : locator;
   }
 
   if (/^e\d+$/.test(normalized)) {

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -261,7 +261,7 @@ function buildAriaSnapshotRefs(nodes: AriaNode[], markedRefs: Set<string>): Role
     refs[node.ref] = {
       role,
       ...(name !== undefined ? { name } : {}),
-      ...(nth > 0 ? { nth } : {}),
+      nth,
       ...(markedRefs.has(node.ref) ? { domMarker: true } : {}),
     };
   }

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -1,3 +1,5 @@
+import type { Page } from 'playwright-core';
+
 import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
 import {
   getPageForTargetId,
@@ -7,7 +9,8 @@ import {
   withPlaywrightPageCdpSession,
   takeAiSnapshotText,
 } from '../connection.js';
-import type { SnapshotResult, AriaSnapshotResult, AriaNode, SsrfPolicy } from '../types.js';
+import { BROWSER_REF_MARKER_ATTRIBUTE } from '../ref-resolver.js';
+import type { SnapshotResult, AriaSnapshotResult, AriaNode, RoleRefs, SsrfPolicy } from '../types.js';
 
 import { enrichSnapshotFromDom, mergeSnapshotWithEnrichment, nextRefCounter } from './dom-enrichment.js';
 import { buildRoleSnapshotFromAriaSnapshot, buildRoleSnapshotFromAiSnapshot, getRoleSnapshotStats } from './ref-map.js';
@@ -177,8 +180,18 @@ export async function snapshotAria(opts: {
     };
   });
 
+  const formatted = formatAriaNodes(Array.isArray(res.nodes) ? res.nodes : [], limit);
+  const markedRefs = await markBackendDomRefsOnPage(page, formatted);
+  storeRoleRefsForTarget({
+    page,
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    refs: buildAriaSnapshotRefs(formatted, markedRefs),
+    mode: 'role',
+  });
+
   return {
-    nodes: formatAriaNodes(Array.isArray(res.nodes) ? res.nodes : [], limit),
+    nodes: formatted,
     untrusted: true,
     contentMeta: {
       sourceUrl,
@@ -186,6 +199,78 @@ export async function snapshotAria(opts: {
       capturedAt: new Date().toISOString(),
     },
   };
+}
+
+async function markBackendDomRefsOnPage(page: Page, nodes: AriaNode[]): Promise<Set<string>> {
+  await page
+    .locator(`[${BROWSER_REF_MARKER_ATTRIBUTE}]`)
+    .evaluateAll((elements, attr) => {
+      for (const element of elements) if (element instanceof Element) element.removeAttribute(attr);
+    }, BROWSER_REF_MARKER_ATTRIBUTE)
+    .catch(() => {
+      /* best-effort cleanup of stale markers */
+    });
+  const targetable = nodes.filter(
+    (n) => typeof n.backendDOMNodeId === 'number' && Number.isFinite(n.backendDOMNodeId) && n.backendDOMNodeId > 0,
+  );
+  const marked = new Set<string>();
+  if (!targetable.length) return marked;
+  return await withPlaywrightPageCdpSession(page, async (session) => {
+    type Send = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+    const send: Send = (method, params) =>
+      session.send(method as Parameters<typeof session.send>[0], params as Parameters<typeof session.send>[1]);
+    await send('DOM.enable').catch(() => {
+      /* best-effort */
+    });
+    const backendNodeIds = [...new Set(targetable.map((n) => Math.floor(n.backendDOMNodeId ?? 0)))];
+    const pushed = (await send('DOM.pushNodesByBackendIdsToFrontend', { backendNodeIds }).catch(() => ({}))) as {
+      nodeIds?: unknown;
+    };
+    const nodeIds = Array.isArray(pushed.nodeIds) ? (pushed.nodeIds as number[]) : [];
+    const nodeIdByBackendId = new Map<number, number>();
+    for (let i = 0; i < backendNodeIds.length; i++) {
+      const backendNodeId = backendNodeIds[i];
+      const nodeId = nodeIds[i];
+      if (backendNodeId && typeof nodeId === 'number' && nodeId > 0) nodeIdByBackendId.set(backendNodeId, nodeId);
+    }
+    for (const node of targetable) {
+      const nodeId = nodeIdByBackendId.get(Math.floor(node.backendDOMNodeId ?? 0));
+      if (nodeId === undefined || nodeId <= 0) continue;
+      try {
+        await send('DOM.setAttributeValue', { nodeId, name: BROWSER_REF_MARKER_ATTRIBUTE, value: node.ref });
+        marked.add(node.ref);
+      } catch {
+        /* node may have been detached between push and set; skip */
+      }
+    }
+    return marked;
+  });
+}
+
+function buildAriaSnapshotRefs(nodes: AriaNode[], markedRefs: Set<string>): RoleRefs {
+  const refs: RoleRefs = {};
+  const counts = new Map<string, number>();
+  const refsByKey = new Map<string, string[]>();
+  for (const node of nodes) {
+    const role = (node.role || 'unknown').toLowerCase();
+    const name = node.name.trim() || undefined;
+    const key = `${role}:${name ?? ''}`;
+    const nth = counts.get(key) ?? 0;
+    counts.set(key, nth + 1);
+    refsByKey.set(key, [...(refsByKey.get(key) ?? []), node.ref]);
+    refs[node.ref] = {
+      role,
+      ...(name !== undefined ? { name } : {}),
+      ...(nth > 0 ? { nth } : {}),
+      ...(markedRefs.has(node.ref) ? { domMarker: true } : {}),
+    };
+  }
+  for (const refsForKey of refsByKey.values()) {
+    if (refsForKey.length > 1) continue;
+    const ref = refsForKey[0];
+    delete refs[ref].nth;
+  }
+  return refs;
 }
 
 function axValue(v: { value?: string | number | boolean } | undefined): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,12 @@ export interface RoleRefInfo {
    * this selector directly instead of `aria-ref` or `getByRole()`.
    */
   selector?: string;
+  /**
+   * For `axN` refs: set to true when a marker attribute was successfully
+   * stamped onto the live DOM node, allowing direct attribute-selector
+   * resolution instead of falling back to role+name+nth.
+   */
+  domMarker?: boolean;
 }
 
 /** Map of ref IDs (e.g. `'e1'`, `'e2'`) to their element information. */


### PR DESCRIPTION
## Summary

Sync browserclaw with OpenClaw 2026.4.25.

## Ported

1. **`chrome-launcher.ts`** — added Linux Chromium paths: `/opt/google/chrome/chrome`, `/opt/brave.com/brave/brave-browser`, `/usr/lib/chromium/chromium`, `/usr/lib/chromium-browser/chromium-browser` (#48563). Exported `isWebSocketUrl`.
2. **`connection.ts`** — `isRecoverablePlaywrightDisconnectError` matches the seven canonical Playwright/CDP-disconnect substrings. `connectBrowser` now falls back to the user's original `ws(s)://` URL when the resolved endpoint fails (#49815).
3. **`navigation.ts`** — `listPagesViaPlaywright` retries once after evicting the cached browser on a recoverable disconnect error (#67728).
4. **`aria-snapshot.ts` + `ref-resolver.ts` + `types.ts`** — `axN` refs from `snapshotAria()` are now usable for actions (#62434). After the snapshot, each backend DOM node is stamped with `data-browserclaw-ref="axN"` via CDP, and `refLocator` resolves `axN` refs through the marker selector (falls back to `getByRole(role, { name, nth })` when marking fails). New `domMarker?: boolean` on `RoleRefInfo`.

## Skipped

- `continueRouteSafely` — browserclaw already has stronger `safeContinue`/`safeAbort`.
- Take/evict cache helper refactor — cosmetic; browserclaw uses `withConnectionLock` so inline duplication is mutex-protected.
- Raw-CDP `createTargetViaCdp` path (handshake retries, attachOnly timeouts, ws:// readiness fallback, `diagnoseChromeCdp`) — N/A for Playwright-based connection.
- Managed download dir + `downloadWaiterDepth` + auto-capture handler — bigger architectural change; defer.
- `localLaunchTimeoutMs` knob — defer.
- CDP-native role snapshot (`buildCdpRoleSnapshot` etc.) — server-only fallback for Playwright-unavailable case.

## Version

`0.16.0` → `0.17.0` (minor — `axN` refs are newly usable, listPages recovery, ws-URL fallback are new observable behaviors).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` (411 files, 17534 tests pass)
- [x] `npx prettier --check src/`