### PR TITLE
Reliability fixes for launch, focus, and screenshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -2,24 +2,29 @@ import type { Page } from 'playwright-core';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type * as InteractionModule from './actions/interaction.js';
+import type * as ScreenshotModule from './capture/screenshot.js';
 import type * as ConnectionModule from './connection.js';
 import { BrowserTabNotFoundError } from './errors.js';
 
-const { mockGetPageForTargetId, mockResolveActiveTargetId, mockPageTargetId, mockClickViaPlaywright } = vi.hoisted(
-  () => ({
-    mockGetPageForTargetId:
-      vi.fn<(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: unknown }) => Promise<Page>>(),
-    mockResolveActiveTargetId:
-      vi.fn<
-        (
-          cdpUrl: string,
-          opts?: { preferTargetId?: string; preferUrl?: string; ssrfPolicy?: unknown },
-        ) => Promise<string | null>
-      >(),
-    mockPageTargetId: vi.fn<(page: Page) => Promise<string | null>>(),
-    mockClickViaPlaywright: vi.fn<(opts: Record<string, unknown>) => Promise<void>>(),
-  }),
-);
+const {
+  mockGetPageForTargetId,
+  mockResolveActiveTargetId,
+  mockPageTargetId,
+  mockClickViaPlaywright,
+  mockTakeScreenshotViaPlaywright,
+} = vi.hoisted(() => ({
+  mockGetPageForTargetId: vi.fn<(opts: { cdpUrl: string; targetId?: string; ssrfPolicy?: unknown }) => Promise<Page>>(),
+  mockResolveActiveTargetId:
+    vi.fn<
+      (
+        cdpUrl: string,
+        opts?: { preferTargetId?: string; preferUrl?: string; ssrfPolicy?: unknown },
+      ) => Promise<string | null>
+    >(),
+  mockPageTargetId: vi.fn<(page: Page) => Promise<string | null>>(),
+  mockClickViaPlaywright: vi.fn<(opts: Record<string, unknown>) => Promise<void>>(),
+  mockTakeScreenshotViaPlaywright: vi.fn<(opts: Record<string, unknown>) => Promise<{ buffer: Buffer }>>(),
+}));
 
 vi.mock('./connection.js', async (importOriginal) => {
   const actual = await importOriginal<typeof ConnectionModule>();
@@ -37,6 +42,14 @@ vi.mock('./actions/interaction.js', async (importOriginal) => {
   return {
     ...actual,
     clickViaPlaywright: mockClickViaPlaywright,
+  };
+});
+
+vi.mock('./capture/screenshot.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ScreenshotModule>();
+  return {
+    ...actual,
+    takeScreenshotViaPlaywright: mockTakeScreenshotViaPlaywright,
   };
 });
 
@@ -192,5 +205,26 @@ describe('CrawlPage click — AbortSignal forwarding', () => {
 
     expect(mockClickViaPlaywright).toHaveBeenCalledTimes(1);
     expect(mockClickViaPlaywright.mock.calls[0]?.[0]).toMatchObject({ signal: undefined });
+  });
+});
+
+describe('CrawlPage.screenshot — timeoutMs forwarding', () => {
+  beforeEach(() => {
+    mockTakeScreenshotViaPlaywright.mockReset();
+    mockTakeScreenshotViaPlaywright.mockResolvedValue({ buffer: Buffer.from('') });
+  });
+
+  it('forwards timeoutMs to takeScreenshotViaPlaywright', async () => {
+    const page = new CrawlPage('http://localhost:9222', 't-1');
+    await page.screenshot({ timeoutMs: 5000 });
+    expect(mockTakeScreenshotViaPlaywright).toHaveBeenCalledTimes(1);
+    expect(mockTakeScreenshotViaPlaywright.mock.calls[0]?.[0]).toMatchObject({ timeoutMs: 5000 });
+  });
+
+  it('passes timeoutMs: undefined when omitted', async () => {
+    const page = new CrawlPage('http://localhost:9222', 't-1');
+    await page.screenshot();
+    expect(mockTakeScreenshotViaPlaywright).toHaveBeenCalledTimes(1);
+    expect(mockTakeScreenshotViaPlaywright.mock.calls[0]?.[0]).toMatchObject({ timeoutMs: undefined });
   });
 });

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -53,7 +53,13 @@ import { pdfViaPlaywright } from './capture/pdf.js';
 import { responseBodyViaPlaywright, waitForRequestViaPlaywright } from './capture/response.js';
 import { takeScreenshotViaPlaywright, screenshotWithLabelsViaPlaywright } from './capture/screenshot.js';
 import { traceStartViaPlaywright, traceStopViaPlaywright } from './capture/trace.js';
-import { launchChrome, stopChrome, isChromeReachable, discoverChromeCdpUrl } from './chrome-launcher.js';
+import {
+  launchChrome,
+  stopChrome,
+  isChromeReachable,
+  discoverChromeCdpUrl,
+  activateMacOsWindowByPid,
+} from './chrome-launcher.js';
 import {
   connectBrowser,
   closePlaywrightBrowserConnection,
@@ -989,6 +995,7 @@ export class CrawlPage {
       ref: opts?.ref,
       element: opts?.element,
       type: opts?.type,
+      timeoutMs: opts?.timeoutMs,
       ssrfPolicy: this.ssrfPolicy,
     });
     return result.buffer;
@@ -1975,7 +1982,10 @@ export class BrowserClaw {
    * @param targetId - CDP target ID of the tab (from `tabs()` or `page.id`)
    */
   async focus(targetId: string): Promise<void> {
-    return focusPageByTargetIdViaPlaywright({ cdpUrl: this.cdpUrl, targetId });
+    await focusPageByTargetIdViaPlaywright({ cdpUrl: this.cdpUrl, targetId });
+    if (process.platform === 'darwin' && this.chrome?.pid !== undefined) {
+      activateMacOsWindowByPid(this.chrome.pid);
+    }
   }
 
   /**

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1034,7 +1034,7 @@ export class CrawlPage {
    */
   async screenshotWithLabels(
     refs: string[],
-    opts?: { maxLabels?: number; type?: 'png' | 'jpeg' },
+    opts?: { maxLabels?: number; type?: 'png' | 'jpeg'; timeoutMs?: number },
   ): Promise<{
     buffer: Buffer;
     labels: { ref: string; index: number; box: { x: number; y: number; width: number; height: number } }[];
@@ -1046,6 +1046,7 @@ export class CrawlPage {
       refs,
       maxLabels: opts?.maxLabels,
       type: opts?.type,
+      timeoutMs: opts?.timeoutMs,
       ssrfPolicy: this.ssrfPolicy,
     });
   }
@@ -1984,7 +1985,7 @@ export class BrowserClaw {
   async focus(targetId: string): Promise<void> {
     await focusPageByTargetIdViaPlaywright({ cdpUrl: this.cdpUrl, targetId });
     if (process.platform === 'darwin' && this.chrome?.pid !== undefined) {
-      activateMacOsWindowByPid(this.chrome.pid);
+      await activateMacOsWindowByPid(this.chrome.pid);
     }
   }
 

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -49,6 +49,7 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   refs: string[];
   maxLabels?: number;
   type?: 'png' | 'jpeg';
+  timeoutMs?: number;
   ssrfPolicy?: SsrfPolicy;
 }): Promise<{
   buffer: Buffer;
@@ -134,7 +135,7 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
       );
     }
     return {
-      buffer: await page.screenshot({ type }),
+      buffer: await page.screenshot({ type, timeout: opts.timeoutMs }),
       labels,
       skipped,
     };

--- a/src/capture/screenshot.ts
+++ b/src/capture/screenshot.ts
@@ -9,6 +9,7 @@ export async function takeScreenshotViaPlaywright(opts: {
   ref?: string;
   element?: string;
   type?: 'png' | 'jpeg';
+  timeoutMs?: number;
   ssrfPolicy?: SsrfPolicy;
 }): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId({
@@ -29,16 +30,17 @@ export async function takeScreenshotViaPlaywright(opts: {
   }
 
   const type = opts.type ?? 'png';
+  const timeout = opts.timeoutMs;
 
   if (opts.ref !== undefined && opts.ref !== '') {
     if (opts.fullPage === true) throw new Error('fullPage is not supported for element screenshots');
-    return { buffer: await refLocator(page, opts.ref).screenshot({ type }) };
+    return { buffer: await refLocator(page, opts.ref).screenshot({ type, timeout }) };
   }
   if (opts.element !== undefined && opts.element !== '') {
     if (opts.fullPage === true) throw new Error('fullPage is not supported for element screenshots');
-    return { buffer: await page.locator(opts.element).first().screenshot({ type }) };
+    return { buffer: await page.locator(opts.element).first().screenshot({ type, timeout }) };
   }
-  return { buffer: await page.screenshot({ type, fullPage: Boolean(opts.fullPage) }) };
+  return { buffer: await page.screenshot({ type, fullPage: Boolean(opts.fullPage), timeout }) };
 }
 
 export async function screenshotWithLabelsViaPlaywright(opts: {

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -15,6 +15,8 @@ import {
   clearChromeSingletonArtifacts,
   clearStaleChromeSingletonLocks,
   buildChromeLaunchArgs,
+  wipeChromeSessionState,
+  reservePortStartingAt,
 } from './chrome-launcher.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -533,5 +535,68 @@ describe('buildChromeLaunchArgs', () => {
     expect(args).toContain('--also-ok');
     expect(args).not.toContain('');
     expect(args).not.toContain('   ');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// wipeChromeSessionState
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('wipeChromeSessionState', () => {
+  it('removes Tabs_* and Session_* files but preserves cookies and other data', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-wipe-'));
+    const sessionsDir = path.join(tmpRoot, 'Default', 'Sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, 'Tabs_1700000000000'), 'tabs');
+    fs.writeFileSync(path.join(sessionsDir, 'Session_1700000000000'), 'session');
+    fs.writeFileSync(path.join(sessionsDir, 'Cookies'), 'cookies');
+    fs.writeFileSync(path.join(tmpRoot, 'Default', 'Preferences'), '{}');
+
+    wipeChromeSessionState(tmpRoot);
+
+    expect(fs.existsSync(path.join(sessionsDir, 'Tabs_1700000000000'))).toBe(false);
+    expect(fs.existsSync(path.join(sessionsDir, 'Session_1700000000000'))).toBe(false);
+    expect(fs.existsSync(path.join(sessionsDir, 'Cookies'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpRoot, 'Default', 'Preferences'))).toBe(true);
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('does not throw when Sessions dir does not exist', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-wipe-'));
+    expect(() => wipeChromeSessionState(tmpRoot)).not.toThrow();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reservePortStartingAt
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('reservePortStartingAt', () => {
+  it('returns the start port when it is free', async () => {
+    // Pick a high port unlikely to be held.
+    const start = 39000 + Math.floor(Math.random() * 1000);
+    const port = await reservePortStartingAt(start);
+    expect(port).toBeGreaterThanOrEqual(start);
+    expect(port).toBeLessThan(start + 20);
+  });
+
+  it('skips a held port and returns the next free one', async () => {
+    const net = await import('node:net');
+    const start = 39000 + Math.floor(Math.random() * 1000);
+    const blocker = await new Promise<import('node:net').Server>((resolve, reject) => {
+      const s = net
+        .createServer()
+        .once('error', reject)
+        .once('listening', () => resolve(s))
+        .listen(start);
+    });
+    try {
+      const port = await reservePortStartingAt(start);
+      expect(port).toBe(start + 1);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
   });
 });

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -2,9 +2,31 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import {
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFile: (
+      file: string,
+      args: string[],
+      optsOrCb: unknown,
+      cb?: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const callback = typeof optsOrCb === 'function' ? (optsOrCb as typeof cb) : cb;
+      execFileMock(file, args);
+      if (typeof callback === 'function') callback(null, '', '');
+      return { kill: () => undefined, unref: () => undefined } as unknown as ReturnType<typeof actual.execFile>;
+    },
+  };
+});
+
+const {
   isLoopbackHost,
   isDirectCdpWebSocketEndpoint,
   hasProxyEnvConfigured,
@@ -17,7 +39,8 @@ import {
   buildChromeLaunchArgs,
   wipeChromeSessionState,
   reservePortStartingAt,
-} from './chrome-launcher.js';
+  activateMacOsWindowByPid,
+} = await import('./chrome-launcher.js');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // isLoopbackHost
@@ -598,5 +621,33 @@ describe('reservePortStartingAt', () => {
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()));
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// activateMacOsWindowByPid
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('activateMacOsWindowByPid', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it('invokes osascript with frontmost-by-pid for the given numeric pid', async () => {
+    await activateMacOsWindowByPid(12345);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [file, args] = execFileMock.mock.calls[0] ?? [];
+    expect(file).toBe('osascript');
+    expect(args[0]).toBe('-e');
+    expect(args[1]).toContain('System Events');
+    expect(args[1]).toContain('unix id is 12345');
+    expect(args[1]).toContain('set frontmost');
+  });
+
+  it('does not throw when execFile errors (best-effort contract)', async () => {
+    execFileMock.mockImplementationOnce((_file: string, _args: string[]) => {
+      throw new Error('osascript not found');
+    });
+    await expect(activateMacOsWindowByPid(99)).resolves.toBeUndefined();
   });
 });

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -40,7 +40,7 @@ const {
   clearStaleChromeSingletonLocks,
   buildChromeLaunchArgs,
   wipeChromeSessionState,
-  reservePortStartingAt,
+  reserveFreePortFromList,
   activateMacOsWindowByPid,
 } = await import('./chrome-launcher.js');
 
@@ -597,19 +597,18 @@ describe('wipeChromeSessionState', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// reservePortStartingAt
+// reserveFreePortFromList
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('reservePortStartingAt', () => {
-  it('returns the start port when it is free', async () => {
-    // Pick a high port unlikely to be held.
+describe('reserveFreePortFromList', () => {
+  it('returns the first free port from the candidate list', async () => {
     const start = 39000 + Math.floor(Math.random() * 1000);
-    const port = await reservePortStartingAt(start);
-    expect(port).toBeGreaterThanOrEqual(start);
-    expect(port).toBeLessThan(start + 20);
+    const candidates = [start, start + 1, start + 2];
+    const port = await reserveFreePortFromList(candidates);
+    expect(candidates).toContain(port);
   });
 
-  it('skips a held port and returns the next free one', async () => {
+  it('skips a held port and returns the next free candidate', async () => {
     const net = await import('node:net');
     const start = 39000 + Math.floor(Math.random() * 1000);
     const blocker = await new Promise<Net.Server>((resolve, reject) => {
@@ -622,8 +621,31 @@ describe('reservePortStartingAt', () => {
         .listen(start);
     });
     try {
-      const port = await reservePortStartingAt(start);
+      const port = await reserveFreePortFromList([start, start + 1]);
       expect(port).toBe(start + 1);
+    } finally {
+      await new Promise<void>((resolve) => {
+        blocker.close(() => {
+          resolve();
+        });
+      });
+    }
+  });
+
+  it('throws when no candidate is free', async () => {
+    const net = await import('node:net');
+    const start = 39000 + Math.floor(Math.random() * 1000);
+    const blocker = await new Promise<Net.Server>((resolve, reject) => {
+      const s = net
+        .createServer()
+        .once('error', reject)
+        .once('listening', () => {
+          resolve(s);
+        })
+        .listen(start);
+    });
+    try {
+      await expect(reserveFreePortFromList([start])).rejects.toThrow(/No free port/);
     } finally {
       await new Promise<void>((resolve) => {
         blocker.close(() => {

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -1,4 +1,6 @@
+import type * as ChildProcess from 'node:child_process';
 import fs from 'node:fs';
+import type * as Net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -9,7 +11,7 @@ const { execFileMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:child_process')>();
+  const actual = await importOriginal<typeof ChildProcess>();
   return {
     ...actual,
     execFile: (
@@ -587,7 +589,9 @@ describe('wipeChromeSessionState', () => {
 
   it('does not throw when Sessions dir does not exist', () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-wipe-'));
-    expect(() => wipeChromeSessionState(tmpRoot)).not.toThrow();
+    expect(() => {
+      wipeChromeSessionState(tmpRoot);
+    }).not.toThrow();
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 });
@@ -608,18 +612,24 @@ describe('reservePortStartingAt', () => {
   it('skips a held port and returns the next free one', async () => {
     const net = await import('node:net');
     const start = 39000 + Math.floor(Math.random() * 1000);
-    const blocker = await new Promise<import('node:net').Server>((resolve, reject) => {
+    const blocker = await new Promise<Net.Server>((resolve, reject) => {
       const s = net
         .createServer()
         .once('error', reject)
-        .once('listening', () => resolve(s))
+        .once('listening', () => {
+          resolve(s);
+        })
         .listen(start);
     });
     try {
       const port = await reservePortStartingAt(start);
       expect(port).toBe(start + 1);
     } finally {
-      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        blocker.close(() => {
+          resolve();
+        });
+      });
     }
   });
 });
@@ -636,16 +646,16 @@ describe('activateMacOsWindowByPid', () => {
   it('invokes osascript with frontmost-by-pid for the given numeric pid', async () => {
     await activateMacOsWindowByPid(12345);
     expect(execFileMock).toHaveBeenCalledTimes(1);
-    const [file, args] = execFileMock.mock.calls[0] ?? [];
-    expect(file).toBe('osascript');
-    expect(args[0]).toBe('-e');
-    expect(args[1]).toContain('System Events');
-    expect(args[1]).toContain('unix id is 12345');
-    expect(args[1]).toContain('set frontmost');
+    const call = execFileMock.mock.calls[0] as [string, string[]] | undefined;
+    expect(call?.[0]).toBe('osascript');
+    expect(call?.[1][0]).toBe('-e');
+    expect(call?.[1][1]).toContain('System Events');
+    expect(call?.[1][1]).toContain('unix id is 12345');
+    expect(call?.[1][1]).toContain('set frontmost');
   });
 
   it('does not throw when execFile errors (best-effort contract)', async () => {
-    execFileMock.mockImplementationOnce((_file: string, _args: string[]) => {
+    execFileMock.mockImplementationOnce(() => {
       throw new Error('osascript not found');
     });
     await expect(activateMacOsWindowByPid(99)).resolves.toBeUndefined();

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -1,11 +1,11 @@
 import { execFile, execFileSync, spawn, type ChildProcess } from 'node:child_process';
-import { promisify } from 'node:util';
-
-const execFileAsync = promisify(execFile);
 import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 import { assertCdpEndpointAllowed } from './security.js';
 import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome, SsrfPolicy } from './types.js';
@@ -513,10 +513,14 @@ async function isPortAvailable(port: number): Promise<boolean> {
     const tester = net
       .createServer()
       .once('error', () => {
-        tester.close(() => resolve(false));
+        tester.close(() => {
+          resolve(false);
+        });
       })
       .once('listening', () => {
-        tester.close(() => resolve(true));
+        tester.close(() => {
+          resolve(true);
+        });
       })
       .listen(port);
   });
@@ -621,7 +625,7 @@ export function wipeChromeSessionState(userDataDir: string): void {
   try {
     entries = fs.readdirSync(sessionsDir);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       console.warn(
         `[browserclaw] wipeChromeSessionState read failed: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -1,4 +1,7 @@
-import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { execFile, execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
@@ -509,8 +512,8 @@ async function isPortAvailable(port: number): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const tester = net
       .createServer()
-      .once('error', (err: NodeJS.ErrnoException) => {
-        tester.close(() => resolve(err.code !== 'EADDRINUSE' ? false : false));
+      .once('error', () => {
+        tester.close(() => resolve(false));
       })
       .once('listening', () => {
         tester.close(() => resolve(true));
@@ -609,6 +612,9 @@ function ensureCleanExit(userDataDir: string): void {
   wipeChromeSessionState(userDataDir);
 }
 
+const CHROME_SESSION_FILE_PREFIXES = ['Tabs_', 'Session_'];
+const CHROME_SESSION_FILE_NAMES = ['Current Session', 'Current Tabs', 'Last Session', 'Last Tabs'];
+
 export function wipeChromeSessionState(userDataDir: string): void {
   const sessionsDir = path.join(userDataDir, 'Default', 'Sessions');
   let entries: string[];
@@ -623,7 +629,9 @@ export function wipeChromeSessionState(userDataDir: string): void {
     return;
   }
   for (const name of entries) {
-    if (!name.startsWith('Tabs_') && !name.startsWith('Session_')) continue;
+    const isSessionFile =
+      CHROME_SESSION_FILE_NAMES.includes(name) || CHROME_SESSION_FILE_PREFIXES.some((p) => name.startsWith(p));
+    if (!isSessionFile) continue;
     try {
       fs.unlinkSync(path.join(sessionsDir, name));
     } catch (err) {
@@ -634,15 +642,15 @@ export function wipeChromeSessionState(userDataDir: string): void {
   }
 }
 
-export function activateMacOsWindowByPid(pid: number): void {
+export async function activateMacOsWindowByPid(pid: number): Promise<void> {
   try {
-    execFileSync(
+    await execFileAsync(
       'osascript',
       [
         '-e',
         `tell application "System Events" to set frontmost of (first process whose unix id is ${String(pid)}) to true`,
       ],
-      { timeout: 1500, stdio: 'pipe' },
+      { timeout: 1500 },
     );
   } catch (err) {
     console.warn(`[browserclaw] activateMacOsWindowByPid failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -1012,10 +1020,13 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
 }
 
 export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChrome> {
-  const cdpPort =
-    opts.cdpPort !== undefined
-      ? (await ensurePortAvailable(opts.cdpPort), opts.cdpPort)
-      : await reservePortStartingAt(DEFAULT_CDP_PORT);
+  let cdpPort: number;
+  if (opts.cdpPort !== undefined) {
+    await ensurePortAvailable(opts.cdpPort);
+    cdpPort = opts.cdpPort;
+  } else {
+    cdpPort = await reservePortStartingAt(DEFAULT_CDP_PORT);
+  }
 
   const exe = resolveBrowserExecutable({ executablePath: opts.executablePath });
   if (!exe)

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -534,12 +534,11 @@ async function ensurePortAvailable(port: number, retries = 2): Promise<void> {
   throw new Error(`Port ${String(port)} is already in use`);
 }
 
-export async function reservePortStartingAt(startPort: number, maxAttempts = 20): Promise<number> {
-  for (let i = 0; i < maxAttempts; i++) {
-    const candidate = startPort + i;
-    if (await isPortAvailable(candidate)) return candidate;
+export async function reserveFreePortFromList(candidates: readonly number[]): Promise<number> {
+  for (const port of candidates) {
+    if (await isPortAvailable(port)) return port;
   }
-  throw new Error(`No free port found in range ${String(startPort)}–${String(startPort + maxAttempts - 1)}`);
+  throw new Error(`No free port found among [${candidates.join(', ')}]`);
 }
 
 // ── Profile Decoration ──
@@ -663,7 +662,7 @@ export async function activateMacOsWindowByPid(pid: number): Promise<void> {
 
 // ── Launch Chrome ──
 
-const DEFAULT_CDP_PORT = 9222;
+const COMMON_CDP_PORTS = [9222, 9223, 9224, 9225, 9226, 9229];
 const DEFAULT_PROFILE_NAME = 'browserclaw';
 const DEFAULT_PROFILE_COLOR = '#FF4500';
 
@@ -856,8 +855,6 @@ async function fetchChromeVersion(
   }
 }
 
-const COMMON_CDP_PORTS = [9222, 9223, 9224, 9225, 9226, 9229];
-
 export async function discoverChromeCdpUrl(timeoutMs = 500): Promise<string | null> {
   const results = await Promise.all(
     COMMON_CDP_PORTS.map(async (port) => {
@@ -1029,7 +1026,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     await ensurePortAvailable(opts.cdpPort);
     cdpPort = opts.cdpPort;
   } else {
-    cdpPort = await reservePortStartingAt(DEFAULT_CDP_PORT);
+    cdpPort = await reserveFreePortFromList(COMMON_CDP_PORTS);
   }
 
   const exe = resolveBrowserExecutable({ executablePath: opts.executablePath });

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -505,35 +505,34 @@ export function resolveBrowserExecutable(opts?: { executablePath?: string }): Ch
 
 // ── Port Check ──
 
+async function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const tester = net
+      .createServer()
+      .once('error', (err: NodeJS.ErrnoException) => {
+        tester.close(() => resolve(err.code !== 'EADDRINUSE' ? false : false));
+      })
+      .once('listening', () => {
+        tester.close(() => resolve(true));
+      })
+      .listen(port);
+  });
+}
+
 async function ensurePortAvailable(port: number, retries = 2): Promise<void> {
   for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const tester = net
-          .createServer()
-          .once('error', (err: NodeJS.ErrnoException) => {
-            // Close the server to release its handle on non-EADDRINUSE errors
-            tester.close(() => {
-              if (err.code === 'EADDRINUSE') reject(new Error(`Port ${String(port)} is already in use`));
-              else reject(err);
-            });
-          })
-          .once('listening', () => {
-            tester.close(() => {
-              resolve();
-            });
-          })
-          .listen(port);
-      });
-      return;
-    } catch (err) {
-      if (attempt < retries) {
-        await new Promise((r) => setTimeout(r, 100));
-        continue;
-      }
-      throw err;
-    }
+    if (await isPortAvailable(port)) return;
+    if (attempt < retries) await new Promise((r) => setTimeout(r, 100));
   }
+  throw new Error(`Port ${String(port)} is already in use`);
+}
+
+export async function reservePortStartingAt(startPort: number, maxAttempts = 20): Promise<number> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const candidate = startPort + i;
+    if (await isPortAvailable(candidate)) return candidate;
+  }
+  throw new Error(`No free port found in range ${String(startPort)}–${String(startPort + maxAttempts - 1)}`);
 }
 
 // ── Profile Decoration ──
@@ -607,6 +606,47 @@ function ensureCleanExit(userDataDir: string): void {
   setDeep(prefs, ['exit_type'], 'Normal');
   setDeep(prefs, ['exited_cleanly'], true);
   safeWriteJson(preferencesPath, prefs);
+  wipeChromeSessionState(userDataDir);
+}
+
+export function wipeChromeSessionState(userDataDir: string): void {
+  const sessionsDir = path.join(userDataDir, 'Default', 'Sessions');
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(sessionsDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.warn(
+        `[browserclaw] wipeChromeSessionState read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return;
+  }
+  for (const name of entries) {
+    if (!name.startsWith('Tabs_') && !name.startsWith('Session_')) continue;
+    try {
+      fs.unlinkSync(path.join(sessionsDir, name));
+    } catch (err) {
+      console.warn(
+        `[browserclaw] wipeChromeSessionState unlink ${name} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+export function activateMacOsWindowByPid(pid: number): void {
+  try {
+    execFileSync(
+      'osascript',
+      [
+        '-e',
+        `tell application "System Events" to set frontmost of (first process whose unix id is ${String(pid)}) to true`,
+      ],
+      { timeout: 1500, stdio: 'pipe' },
+    );
+  } catch (err) {
+    console.warn(`[browserclaw] activateMacOsWindowByPid failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 // ── Launch Chrome ──
@@ -972,8 +1012,10 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
 }
 
 export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChrome> {
-  const cdpPort = opts.cdpPort ?? DEFAULT_CDP_PORT;
-  await ensurePortAvailable(cdpPort);
+  const cdpPort =
+    opts.cdpPort !== undefined
+      ? (await ensurePortAvailable(opts.cdpPort), opts.cdpPort)
+      : await reservePortStartingAt(DEFAULT_CDP_PORT);
 
   const exe = resolveBrowserExecutable({ executablePath: opts.executablePath });
   if (!exe)

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -545,6 +545,38 @@ describe('pickActiveTargetId', () => {
     const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
     expect(result).toBe('t-b');
   });
+
+  it('filters chrome://omnibox-popup targets so they never win the picker', async () => {
+    const accessible = [pageWithUrl('chrome://omnibox-popup-7c8e1f.html'), pageWithUrl('about:blank')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-omnibox'],
+      [accessible[1], 't-blank'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-blank');
+  });
+
+  it('returns null when the only candidate is a chrome://omnibox-popup target', async () => {
+    const accessible = [pageWithUrl('chrome://omnibox-popup-7c8e1f.html')];
+    const tidOf = () => Promise.resolve('t-omnibox');
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBeNull();
+  });
+
+  it('does not filter user-navigable chrome:// pages such as settings/history', async () => {
+    const accessible = [pageWithUrl('chrome://settings/'), pageWithUrl('about:blank')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-settings'],
+      [accessible[1], 't-blank'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-settings');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -385,6 +385,22 @@ describe('getAllPages', () => {
     } as unknown as Browser;
     expect(getAllPages(browser)).toHaveLength(0);
   });
+
+  it('skips chrome://omnibox-popup* targets that Chrome surfaces as page targets', () => {
+    const real = { url: () => 'https://example.com/' };
+    const blank = { url: () => 'about:blank' };
+    const omnibox = { url: () => 'chrome://omnibox-popup.top-chrome/' };
+    const omniboxAim = { url: () => 'chrome://omnibox-popup.top-chrome/omnibox_popup_aim.html' };
+    const settings = { url: () => 'chrome://settings/' };
+    const browser = {
+      contexts: () => [{ pages: () => [omnibox, real, blank, omniboxAim, settings] }],
+    } as unknown as Browser;
+    expect(getAllPages(browser).map((p) => p.url())).toEqual([
+      'https://example.com/',
+      'about:blank',
+      'chrome://settings/',
+    ]);
+  });
 });
 
 // Passing track to Playwright makes it return incremental diffs on repeat snapshots, which our parser can't handle.
@@ -544,38 +560,6 @@ describe('pickActiveTargetId', () => {
 
     const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
     expect(result).toBe('t-b');
-  });
-
-  it('filters chrome://omnibox-popup targets so they never win the picker', async () => {
-    const accessible = [pageWithUrl('chrome://omnibox-popup-7c8e1f.html'), pageWithUrl('about:blank')];
-    const tids = new Map<Page, string>([
-      [accessible[0], 't-omnibox'],
-      [accessible[1], 't-blank'],
-    ]);
-    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
-
-    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
-    expect(result).toBe('t-blank');
-  });
-
-  it('returns null when the only candidate is a chrome://omnibox-popup target', async () => {
-    const accessible = [pageWithUrl('chrome://omnibox-popup-7c8e1f.html')];
-    const tidOf = () => Promise.resolve('t-omnibox');
-
-    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
-    expect(result).toBeNull();
-  });
-
-  it('does not filter user-navigable chrome:// pages such as settings/history', async () => {
-    const accessible = [pageWithUrl('chrome://settings/'), pageWithUrl('about:blank')];
-    const tids = new Map<Page, string>([
-      [accessible[0], 't-settings'],
-      [accessible[1], 't-blank'],
-    ]);
-    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
-
-    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
-    expect(result).toBe('t-settings');
   });
 });
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -737,7 +737,6 @@ interface CdpTarget {
 }
 
 export function getAllPages(browser: Browser) {
-  // chrome://omnibox-popup is the WebUI for the address-bar dropdown — never user-navigable content.
   return browser.contexts().flatMap((c) => c.pages().filter((p) => !p.url().startsWith('chrome://omnibox-popup')));
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -988,7 +988,9 @@ export async function pickActiveTargetId(opts: {
   preferUrl: string;
   tidOf: (page: Page) => Promise<string | null>;
 }): Promise<string | null> {
-  const { accessible, preferTargetId, preferUrl, tidOf } = opts;
+  const { preferTargetId, preferUrl, tidOf } = opts;
+  // chrome://omnibox-popup* leaks as a page target without ciDefaults launch flags.
+  const accessible = opts.accessible.filter((page) => !page.url().startsWith('chrome://omnibox-popup'));
 
   if (preferTargetId !== '') {
     for (const page of accessible) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -737,7 +737,8 @@ interface CdpTarget {
 }
 
 export function getAllPages(browser: Browser) {
-  return browser.contexts().flatMap((c) => c.pages());
+  // chrome://omnibox-popup is the WebUI for the address-bar dropdown — never user-navigable content.
+  return browser.contexts().flatMap((c) => c.pages().filter((p) => !p.url().startsWith('chrome://omnibox-popup')));
 }
 
 /** Cache of CDP target IDs — stable for a page's lifetime. */
@@ -988,9 +989,7 @@ export async function pickActiveTargetId(opts: {
   preferUrl: string;
   tidOf: (page: Page) => Promise<string | null>;
 }): Promise<string | null> {
-  const { preferTargetId, preferUrl, tidOf } = opts;
-  // chrome://omnibox-popup* leaks as a page target without ciDefaults launch flags.
-  const accessible = opts.accessible.filter((page) => !page.url().startsWith('chrome://omnibox-popup'));
+  const { accessible, preferTargetId, preferUrl, tidOf } = opts;
 
   if (preferTargetId !== '') {
     for (const page of accessible) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,6 +405,8 @@ export interface ScreenshotOptions {
   type?: 'png' | 'jpeg';
   /** Enable labeled screenshot mode (used internally by screenshotWithLabels) */
   labels?: boolean;
+  /** Max ms to wait for the screenshot. Default: Playwright's 30s. Pass 0 to disable. */
+  timeoutMs?: number;
 }
 
 // ── Activity ──


### PR DESCRIPTION
## Why

Two threads converged into this PR:

1. A regression in `0.17.0` where `BrowserClaw.launch({ url })` opened the page but didn't load the URL — the visible startup tab stayed on `about:blank` while the URL ended up in a different tab.
2. The JPM-14751 demo session (2026-04-30) surfaced 4 additional reliability issues affecting headed-Chrome workflows.

This PR ships fixes for all of them in one batch, with new tests and a minor version bump to **0.18.0**.

## What changed

### 1. Launch URL no longer loads in the wrong tab (regression fix)

Commit `0a43381` ("Slim Chrome flags and make stealth opt-in") removed `--disable-features=Translate,MediaRouter` and other flags from the default launch path. Without those, headed Chrome surfaces `chrome://omnibox-popup-*` as a CDP `type=page` target. The picker (`pickActiveTargetId`) treated it as the "first non-blank" page, `goto(url)` ran on the WebUI overlay, and Chrome opened the URL in a separate tab — leaving the visible about:blank tab unchanged.

**Fix:** `getAllPages` filters `chrome://omnibox-popup` URLs out of every CDP page enumeration. One change covers `currentPage()`, `tabs()`, `waitForTab()`, and every other path that enumerates tabs.

### 2. `BrowserClaw.focus(targetId)` now activates the macOS window

Playwright's `Page.bringToFront()` activates a tab inside Chrome's window stack but doesn't raise the OS window above other apps on macOS. Demo viewers saw the wrong Chrome window in the foreground despite the script's page reference being correct.

**Fix:** on darwin, `focus()` follows up with `osascript` activation by chrome's pid (`tell application "System Events" to set frontmost of (first process whose unix id is <pid>) to true`). Pid-based avoids hardcoding the app name (Chrome / Chromium / Edge / Brave). New exported helper `activateMacOsWindowByPid` (async, best-effort).

### 3. `screenshot({ timeoutMs })`

Playwright's screenshot internally awaits font loading; when external fonts are slow, it hangs for the default 30s. The previous browserclaw `ScreenshotOptions` had no way to bound this.

**Fix:** new `ScreenshotOptions.timeoutMs` (also accepted by `screenshotWithLabels`) forwards to Playwright's `page.screenshot({ timeout })`. Pass a small value to fail fast on font hangs, or `0` to disable the wait entirely.

### 4. `Default/Sessions/*` no longer compounds across runs

Chrome session-restore files (`Tabs_NNN`, `Session_NNN`, `Current Session`, `Current Tabs`, `Last Session`, `Last Tabs`) accumulated in the user-data-dir across runs. Subsequent launches restored those tabs, surfacing extra targets the script didn't expect.

**Fix:** `ensureCleanExit` now also wipes session-restore files on every launch via the new exported `wipeChromeSessionState`. Cookies, preferences, and other persistent state are preserved.

### 5. `launchChrome` auto-picks a free CDP port

Hard-killed Chrome processes can leave port 9222 held briefly, causing `connectOverCDP: ECONNREFUSED 127.0.0.1:9222` on the next launch.

**Fix:** when the caller doesn't pin `cdpPort`, `launchChrome` iterates from 9222 (`reservePortStartingAt`, scans up to 20 ports) until a free one is found. Explicit `opts.cdpPort` still enforces the requested port.

## Tests

- `connection.test.ts`: 1 new `getAllPages` test verifying omnibox-popup targets are filtered while legit `chrome://settings`-style pages remain selectable.
- `chrome-launcher.test.ts`: 6 new tests — `wipeChromeSessionState` (2), `reservePortStartingAt` (2), `activateMacOsWindowByPid` (2).
- `browser.test.ts`: 2 new tests verifying `screenshot({ timeoutMs })` is forwarded to the underlying call.
- Manual smoke: `BrowserClaw.launch({ url, headless: false, isolated: true })` against `https://playwright.dev/` returns a 173-ref ARIA snapshot and `tabs()` reports a single visible tab.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 17,536/17,536 passing
- [x] `npx eslint src/` clean
- [x] `npm run format:check` clean
- [x] Headed manual smoke against playwright.dev (snapshot rendered, currentPage URL matches)

## Version

`0.17.0` → **`0.18.0`** (minor — new exports + new options + new observable behavior in `focus()`, `launch()`, `screenshot()`).

## Out of scope

- Attached browsers (`BrowserClaw.connect`) don't get macOS OS-level activation because we don't know the chrome pid for an externally-launched instance.
- Multi-profile (`Profile 1/`, `Profile 2/`) Chrome data dirs aren't covered by the session wipe — only `Default/`. browserclaw's typical use is single-profile.