### PR TITLE
Updates from OpenClaw 2026.4.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.0",
+  "version": "0.18.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -366,6 +366,18 @@ describe('security.ts', () => {
         expect(isInternalUrl('http://[fe80::1]', { allowIpv6UniqueLocalRange: true })).toBe(true);
         expect(isInternalUrl('http://[fec0::1]', { allowIpv6UniqueLocalRange: true })).toBe(true);
       });
+
+      it('treats allowIpv6UniqueLocalRange as orthogonal to dangerouslyAllowPrivateNetwork', () => {
+        // dangerouslyAllowPrivateNetwork alone does not unblock ULA at the isInternalUrl layer.
+        expect(isInternalUrl('http://[fc00::1]', { dangerouslyAllowPrivateNetwork: true })).toBe(true);
+        // Both flags together: ULA flag does the work, DAPN doesn't interfere.
+        expect(
+          isInternalUrl('http://[fc00::1]', {
+            dangerouslyAllowPrivateNetwork: true,
+            allowIpv6UniqueLocalRange: true,
+          }),
+        ).toBe(false);
+      });
     });
 
     describe('IPv6 multicast (ff00::/8)', () => {
@@ -752,6 +764,22 @@ describe('security.ts', () => {
         policy: STRICT_POLICY,
       });
       expect(result.addresses).toHaveLength(1);
+    });
+
+    it('does not serve a permissive-ULA cached result to a strict-ULA caller', async () => {
+      const ulaLookup = (() => Promise.resolve([{ address: 'fc00::1', family: 6 }])) as unknown as LookupFn;
+      const hostname = `cache-iso-${randomUUID().slice(0, 8)}.test`;
+      const permissive = await resolvePinnedHostnameWithPolicy(hostname, {
+        lookupFn: ulaLookup,
+        policy: { allowIpv6UniqueLocalRange: true },
+      });
+      expect(permissive.addresses).toContain('fc00::1');
+      await expect(
+        resolvePinnedHostnameWithPolicy(hostname, {
+          lookupFn: ulaLookup,
+          policy: STRICT_POLICY,
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
     });
 
     it('should honor hostnameAllowlist restriction', async () => {

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -348,6 +348,24 @@ describe('security.ts', () => {
       it('should block fd00::1', () => {
         expect(isInternalUrl('http://[fd00::1]')).toBe(true);
       });
+
+      it('should allow fc00::1 when allowIpv6UniqueLocalRange is true', () => {
+        expect(isInternalUrl('http://[fc00::1]', { allowIpv6UniqueLocalRange: true })).toBe(false);
+      });
+
+      it('should allow fd00::1 when allowIpv6UniqueLocalRange is true', () => {
+        expect(isInternalUrl('http://[fd00::1]', { allowIpv6UniqueLocalRange: true })).toBe(false);
+      });
+
+      it('should NOT allow fc00::1 when policy does not explicitly allow it', () => {
+        expect(isInternalUrl('http://[fc00::1]', {})).toBe(true);
+      });
+
+      it('should still block other IPv6 ranges when only allowIpv6UniqueLocalRange is set', () => {
+        expect(isInternalUrl('http://[::1]', { allowIpv6UniqueLocalRange: true })).toBe(true);
+        expect(isInternalUrl('http://[fe80::1]', { allowIpv6UniqueLocalRange: true })).toBe(true);
+        expect(isInternalUrl('http://[fec0::1]', { allowIpv6UniqueLocalRange: true })).toBe(true);
+      });
     });
 
     describe('IPv6 multicast (ff00::/8)', () => {
@@ -1590,6 +1608,11 @@ describe('security.ts', () => {
     it('should respect allowRfc2544BenchmarkRange in policy', () => {
       expect(isInternalUrl('http://198.18.0.1', { allowRfc2544BenchmarkRange: true })).toBe(false);
       expect(isInternalUrl('http://198.18.0.1', { allowRfc2544BenchmarkRange: false })).toBe(true);
+    });
+
+    it('should respect allowIpv6UniqueLocalRange in policy', () => {
+      expect(isInternalUrl('http://[fc00::1]', { allowIpv6UniqueLocalRange: true })).toBe(false);
+      expect(isInternalUrl('http://[fc00::1]', { allowIpv6UniqueLocalRange: false })).toBe(true);
     });
   });
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -180,8 +180,12 @@ const BLOCKED_IPV6_RANGES = new Set([
 
 const RFC2544_BENCHMARK_PREFIX: [ipaddr.IPv4, number] = [ipaddr.IPv4.parse('198.18.0.0'), 15];
 
-interface IsPrivateIpOpts {
+interface IsPrivateIpv4Opts {
   allowRfc2544BenchmarkRange?: boolean;
+}
+
+interface IsPrivateIpv6Opts {
+  allowUniqueLocalRange?: boolean;
 }
 
 const EMBEDDED_IPV4_SENTINEL_RULES: {
@@ -290,14 +294,16 @@ function looksLikeUnsupportedIpv4Literal(address: string): boolean {
   return parts.every((part) => /^[0-9]+$/.test(part) || /^0x/i.test(part));
 }
 
-function isBlockedSpecialUseIpv4Address(address: ipaddr.IPv4, opts?: IsPrivateIpOpts): boolean {
+function isBlockedSpecialUseIpv4Address(address: ipaddr.IPv4, opts?: IsPrivateIpv4Opts): boolean {
   const inRfc2544 = address.match(RFC2544_BENCHMARK_PREFIX);
   if (inRfc2544 && opts?.allowRfc2544BenchmarkRange === true) return false;
   return BLOCKED_IPV4_RANGES.has(address.range()) || inRfc2544;
 }
 
-function isBlockedSpecialUseIpv6Address(address: ipaddr.IPv6): boolean {
-  if (BLOCKED_IPV6_RANGES.has(address.range())) return true;
+function isBlockedSpecialUseIpv6Address(address: ipaddr.IPv6, opts?: IsPrivateIpv6Opts): boolean {
+  const range = address.range();
+  if (range === 'uniqueLocal' && opts?.allowUniqueLocalRange === true) return false;
+  if (BLOCKED_IPV6_RANGES.has(range)) return true;
   return (address.parts[0] & 0xffc0) === 0xfec0;
 }
 
@@ -317,8 +323,12 @@ function extractEmbeddedIpv4FromIpv6(address: ipaddr.IPv6): ipaddr.IPv4 | undefi
   }
 }
 
-function resolveIpv4SpecialUseBlockOptions(policy?: SsrfPolicy): IsPrivateIpOpts {
+function resolveIpv4SpecialUseBlockOptions(policy?: SsrfPolicy): IsPrivateIpv4Opts {
   return { allowRfc2544BenchmarkRange: policy?.allowRfc2544BenchmarkRange === true };
+}
+
+function resolveIpv6SpecialUseBlockOptions(policy?: SsrfPolicy): IsPrivateIpv6Opts {
+  return { allowUniqueLocalRange: policy?.allowIpv6UniqueLocalRange === true };
 }
 
 function isBlockedHostnameOrIp(hostname: string, policy?: SsrfPolicy): boolean {
@@ -334,12 +344,13 @@ function isPrivateIpAddress(address: string, policy?: SsrfPolicy): boolean {
   if (!normalized) return true;
 
   const blockOptions = resolveIpv4SpecialUseBlockOptions(policy);
+  const ipv6BlockOptions = resolveIpv6SpecialUseBlockOptions(policy);
 
   const strictIp = parseCanonicalIpAddress(normalized);
   if (strictIp) {
     if (strictIp.kind() === 'ipv4') return isBlockedSpecialUseIpv4Address(strictIp as ipaddr.IPv4, blockOptions);
     const v6 = strictIp as ipaddr.IPv6;
-    if (isBlockedSpecialUseIpv6Address(v6)) return true;
+    if (isBlockedSpecialUseIpv6Address(v6, ipv6BlockOptions)) return true;
     const embeddedIpv4 = extractEmbeddedIpv4FromIpv6(v6);
     if (embeddedIpv4) return isBlockedSpecialUseIpv4Address(embeddedIpv4, blockOptions);
     return false;
@@ -490,9 +501,10 @@ function dnsPolicyFingerprint(policy: SsrfPolicy | undefined): string {
   const allowed = normalizeHostnameSet(policy?.allowedHostnames);
   const allowlist = normalizeHostnameAllowlist(policy?.hostnameAllowlist);
   const allowRfc2544 = policy?.allowRfc2544BenchmarkRange === true;
+  const allowIpv6Ula = policy?.allowIpv6UniqueLocalRange === true;
   const allowedKey = [...allowed].sort().join(',');
   const allowlistKey = allowlist.sort().join(',');
-  return `${allowPrivate ? '1' : '0'}|${allowRfc2544 ? '1' : '0'}|${allowedKey}|${allowlistKey}`;
+  return `${allowPrivate ? '1' : '0'}|${allowRfc2544 ? '1' : '0'}|${allowIpv6Ula ? '1' : '0'}|${allowedKey}|${allowlistKey}`;
 }
 
 function dnsCacheKey(hostname: string, policy: SsrfPolicy | undefined): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,12 @@ export interface SsrfPolicy {
    * environments where this range is used for legitimate routing.
    */
   allowRfc2544BenchmarkRange?: boolean;
+  /**
+   * Allow navigation to the IPv6 unique local address range (fc00::/7).
+   * This range is blocked by default. Enable only in trusted fake-IP proxy
+   * stacks that use ULA addresses for legitimate routing.
+   */
+  allowIpv6UniqueLocalRange?: boolean;
 }
 
 // ── Chrome Launcher ──


### PR DESCRIPTION
## Summary

Sync with OpenClaw 2026.4.29.

### Ported

**SSRF policy: opt-in IPv6 unique local address (`fc00::/7`) range** ([OC #74351](https://github.com/openclaw/openclaw/issues/74351))

- `SsrfPolicy.allowIpv6UniqueLocalRange?: boolean` — new opt-in field. Default behavior unchanged (ULA blocked).
- `isBlockedSpecialUseIpv6Address` accepts an `IsPrivateIpv6Opts` options bag and returns `false` for `uniqueLocal` when `allowUniqueLocalRange` is set.
- New helper `resolveIpv6SpecialUseBlockOptions(policy)` mirrors the existing `resolveIpv4SpecialUseBlockOptions`.
- `isPrivateIpAddress` threads the IPv6 block options through to `isBlockedSpecialUseIpv6Address`.
- `dnsPolicyFingerprint` includes the new flag in the cache key so a permissive-policy result cannot be served to a stricter-policy caller.

Use case: trusted fake-IP proxy stacks that use ULA addresses for legitimate routing, without having to enable the broader `dangerouslyAllowPrivateNetwork`.

### Not applicable

- **Playwright `Page.handleJavaScriptDialog` race fix** (OC #40067): OC registers a process-level `unhandledRejection` handler that swallows specific dialog-race errors. browserclaw is a library, not a server runtime — host applications manage their own process-level handlers. browserclaw already handles dialog dismissal failures at the page level (`page-utils.ts:141+`).

### Version bump

`0.18.0` → `0.18.1` (patch — additive opt-in option, default behavior unchanged).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (17,550 tests pass; new tests cover ULA opt-in via `isInternalUrl` policy parameter)