### PR TITLE
Updates from OpenClaw 2026.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/navigation.test.ts
+++ b/src/actions/navigation.test.ts
@@ -250,6 +250,29 @@ describe('listPagesViaPlaywright browser-internal filter', () => {
     expect(tabs[0]?.url).toBe('https://example.test/');
   });
 
+  it('keeps default new-tab pages in the listing', async () => {
+    const newtab = pageWithUrl('chrome://newtab/');
+    const newTabPage = pageWithUrl('chrome://new-tab-page/');
+    const settings = pageWithUrl('chrome://settings/');
+    const real = pageWithUrl('https://example.test/');
+    const context = { pages: () => [newtab, newTabPage, settings, real] };
+    const browser = { contexts: () => [context] };
+    mockConnectBrowser.mockResolvedValue({
+      browser: browser as unknown as Browser,
+      cdpUrl: 'http://localhost:9222',
+    });
+    const calls = new Map<FakePage, string>([
+      [newtab, 't-newtab'],
+      [newTabPage, 't-ntp'],
+      [settings, 't-settings'],
+      [real, 't-real'],
+    ]);
+    mockPageTargetId.mockImplementation((p: FakePage) => Promise.resolve(calls.get(p) ?? ''));
+
+    const tabs = await listPagesViaPlaywright({ cdpUrl: 'http://localhost:9222' });
+    expect(tabs.map((t) => t.targetId)).toEqual(['t-newtab', 't-ntp', 't-real']);
+  });
+
   it('matches prefixes case-insensitively and after trimming', async () => {
     const upperChrome = pageWithUrl('  CHROME://VERSION  ');
     const realPage = pageWithUrl('https://example.test/');

--- a/src/actions/navigation.test.ts
+++ b/src/actions/navigation.test.ts
@@ -52,7 +52,8 @@ vi.mock('../security.js', async (importOriginal) => {
   };
 });
 
-const { createPageViaPlaywright } = await import('./navigation.js');
+const { createPageViaPlaywright, assertPageNavigationCompletedSafely, listPagesViaPlaywright } =
+  await import('./navigation.js');
 const { InvalidBrowserNavigationUrlError } = await import('../security.js');
 
 interface FakePage {
@@ -184,5 +185,87 @@ describe('createPageViaPlaywright leak prevention', () => {
 
     expect(tab.targetId).toBe('t-new');
     expect(page.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertPageNavigationCompletedSafely policy denial', () => {
+  beforeEach(() => {
+    mockAssertBrowserNavigationResultAllowed.mockReset();
+    mockAssertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    mockAssertBrowserNavigationRedirectChainAllowed.mockReset();
+    mockAssertBrowserNavigationRedirectChainAllowed.mockResolvedValue(undefined);
+  });
+
+  it('does not close the page on policy denial (read-only assertion)', async () => {
+    const page = buildFakePage({ url: () => 'https://blocked.example/' });
+    mockAssertBrowserNavigationResultAllowed.mockRejectedValue(
+      new InvalidBrowserNavigationUrlError('Navigation blocked: example denial'),
+    );
+
+    await expect(
+      assertPageNavigationCompletedSafely({
+        cdpUrl: 'http://localhost:9222',
+        page: page as never,
+        response: null,
+      }),
+    ).rejects.toThrow(/example denial/);
+
+    expect(page.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('listPagesViaPlaywright browser-internal filter', () => {
+  beforeEach(() => {
+    mockConnectBrowser.mockReset();
+    mockPageTargetId.mockReset();
+  });
+
+  function pageWithUrl(url: string): FakePage {
+    return buildFakePage({ url: () => url });
+  }
+
+  it('filters out chrome:// and devtools:// pages from listings', async () => {
+    const realPage = pageWithUrl('https://example.test/');
+    const chromePage = pageWithUrl('chrome://settings/');
+    const devtoolsPage = pageWithUrl('devtools://devtools/bundled/inspector.html');
+    const edgePage = pageWithUrl('edge://flags/');
+    const context = { pages: () => [realPage, chromePage, devtoolsPage, edgePage] };
+    const browser = { contexts: () => [context] };
+    mockConnectBrowser.mockResolvedValue({
+      browser: browser as unknown as Browser,
+      cdpUrl: 'http://localhost:9222',
+    });
+
+    const calls = new Map<FakePage, string>([
+      [realPage, 't-real'],
+      [chromePage, 't-chrome'],
+      [devtoolsPage, 't-devtools'],
+      [edgePage, 't-edge'],
+    ]);
+    mockPageTargetId.mockImplementation((p: FakePage) => Promise.resolve(calls.get(p) ?? ''));
+
+    const tabs = await listPagesViaPlaywright({ cdpUrl: 'http://localhost:9222' });
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.targetId).toBe('t-real');
+    expect(tabs[0]?.url).toBe('https://example.test/');
+  });
+
+  it('matches prefixes case-insensitively and after trimming', async () => {
+    const upperChrome = pageWithUrl('  CHROME://VERSION  ');
+    const realPage = pageWithUrl('https://example.test/');
+    const context = { pages: () => [upperChrome, realPage] };
+    const browser = { contexts: () => [context] };
+    mockConnectBrowser.mockResolvedValue({
+      browser: browser as unknown as Browser,
+      cdpUrl: 'http://localhost:9222',
+    });
+    const calls = new Map<FakePage, string>([
+      [upperChrome, 't-up'],
+      [realPage, 't-real'],
+    ]);
+    mockPageTargetId.mockImplementation((p: FakePage) => Promise.resolve(calls.get(p) ?? ''));
+
+    const tabs = await listPagesViaPlaywright({ cdpUrl: 'http://localhost:9222' });
+    expect(tabs.map((t) => t.targetId)).toEqual(['t-real']);
   });
 });

--- a/src/actions/navigation.test.ts
+++ b/src/actions/navigation.test.ts
@@ -250,27 +250,31 @@ describe('listPagesViaPlaywright browser-internal filter', () => {
     expect(tabs[0]?.url).toBe('https://example.test/');
   });
 
-  it('keeps default new-tab pages in the listing', async () => {
-    const newtab = pageWithUrl('chrome://newtab/');
-    const newTabPage = pageWithUrl('chrome://new-tab-page/');
+  it('keeps default new-tab pages in the listing across vendors', async () => {
+    const chromeNewtab = pageWithUrl('chrome://newtab/');
+    const chromeNtp = pageWithUrl('chrome://new-tab-page/');
+    const edgeNewtab = pageWithUrl('edge://newtab/');
+    const braveNewtab = pageWithUrl('brave://newtab/');
     const settings = pageWithUrl('chrome://settings/');
     const real = pageWithUrl('https://example.test/');
-    const context = { pages: () => [newtab, newTabPage, settings, real] };
+    const context = { pages: () => [chromeNewtab, chromeNtp, edgeNewtab, braveNewtab, settings, real] };
     const browser = { contexts: () => [context] };
     mockConnectBrowser.mockResolvedValue({
       browser: browser as unknown as Browser,
       cdpUrl: 'http://localhost:9222',
     });
     const calls = new Map<FakePage, string>([
-      [newtab, 't-newtab'],
-      [newTabPage, 't-ntp'],
+      [chromeNewtab, 't-cnt'],
+      [chromeNtp, 't-cntp'],
+      [edgeNewtab, 't-enewtab'],
+      [braveNewtab, 't-bnewtab'],
       [settings, 't-settings'],
       [real, 't-real'],
     ]);
     mockPageTargetId.mockImplementation((p: FakePage) => Promise.resolve(calls.get(p) ?? ''));
 
     const tabs = await listPagesViaPlaywright({ cdpUrl: 'http://localhost:9222' });
-    expect(tabs.map((t) => t.targetId)).toEqual(['t-newtab', 't-ntp', 't-real']);
+    expect(tabs.map((t) => t.targetId)).toEqual(['t-cnt', 't-cntp', 't-enewtab', 't-bnewtab', 't-real']);
   });
 
   it('matches prefixes case-insensitively and after trimming', async () => {

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -17,6 +17,7 @@ import {
   withPageScopedCdpClient,
   isBlockedTarget,
   isBlockedPageRef,
+  isBrowserInternalTargetUrl,
   markTargetBlocked,
   markPageRefBlocked,
   clearBlockedPageRef,
@@ -543,21 +544,6 @@ export async function navigateViaPlaywright(opts: {
     throw err;
   }
   return { url: page.url() };
-}
-
-const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
-  'chrome://',
-  'chrome-untrusted://',
-  'devtools://',
-  'edge://',
-  'brave://',
-  'vivaldi://',
-  'opera://',
-];
-
-function isBrowserInternalTargetUrl(url: string): boolean {
-  const normalized = url.trim().toLowerCase();
-  return BROWSER_INTERNAL_TARGET_URL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 async function listPagesViaPlaywrightOnce(cdpUrl: string): Promise<BrowserTab[]> {

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -99,12 +99,16 @@ function isSubframeDocumentNavigationRequest(page: Page, request: Request): bool
   }
 }
 
-async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page; targetId?: string }): Promise<void> {
+async function quarantineBlockedTarget(opts: { cdpUrl: string; page: Page; targetId?: string }): Promise<void> {
   markPageRefBlocked(opts.cdpUrl, opts.page);
   const resolvedTargetId = await pageTargetId(opts.page).catch(() => null);
   const fallbackTargetId = opts.targetId?.trim() ?? '';
   const targetIdToBlock = resolvedTargetId ?? fallbackTargetId;
   if (targetIdToBlock) markTargetBlocked(opts.cdpUrl, targetIdToBlock);
+}
+
+async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page; targetId?: string }): Promise<void> {
+  await quarantineBlockedTarget(opts);
   await opts.page.close().catch((e: unknown) => {
     console.warn('[browserclaw] failed to close blocked page', e);
   });
@@ -123,7 +127,7 @@ export async function assertPageNavigationCompletedSafely(opts: {
     await assertBrowserNavigationResultAllowed({ url: opts.page.url(), ...navigationPolicy });
   } catch (err) {
     if (isPolicyDenyNavigationError(err))
-      await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page: opts.page, targetId: opts.targetId });
+      await quarantineBlockedTarget({ cdpUrl: opts.cdpUrl, page: opts.page, targetId: opts.targetId });
     throw err;
   }
 }
@@ -525,14 +529,35 @@ export async function navigateViaPlaywright(opts: {
     response = await navigate();
   }
 
-  await assertPageNavigationCompletedSafely({
-    cdpUrl: opts.cdpUrl,
-    page,
-    response,
-    ssrfPolicy: policy,
-    targetId: opts.targetId,
-  });
+  try {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response,
+      ssrfPolicy: policy,
+      targetId: opts.targetId,
+    });
+  } catch (err) {
+    if (isPolicyDenyNavigationError(err))
+      await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page, targetId: opts.targetId });
+    throw err;
+  }
   return { url: page.url() };
+}
+
+const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
+  'chrome://',
+  'chrome-untrusted://',
+  'devtools://',
+  'edge://',
+  'brave://',
+  'vivaldi://',
+  'opera://',
+];
+
+function isBrowserInternalTargetUrl(url: string): boolean {
+  const normalized = url.trim().toLowerCase();
+  return BROWSER_INTERNAL_TARGET_URL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 async function listPagesViaPlaywrightOnce(cdpUrl: string): Promise<BrowserTab[]> {
@@ -542,13 +567,15 @@ async function listPagesViaPlaywrightOnce(cdpUrl: string): Promise<BrowserTab[]>
   for (const page of pages) {
     if (isBlockedPageRef(cdpUrl, page)) continue;
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid !== null && tid !== '' && !isBlockedTarget(cdpUrl, tid))
-      results.push({
-        targetId: tid,
-        title: await page.title().catch(() => ''),
-        url: page.url(),
-        type: 'page',
-      });
+    if (tid === null || tid === '' || isBlockedTarget(cdpUrl, tid)) continue;
+    const url = page.url();
+    if (isBrowserInternalTargetUrl(url)) continue;
+    results.push({
+      targetId: tid,
+      title: await page.title().catch(() => ''),
+      url,
+      type: 'page',
+    });
   }
   return results;
 }
@@ -593,8 +620,6 @@ export async function createPageViaPlaywright(opts: {
   await observeContext(context, { stealth: opts.stealth ?? getStealthEnabledForCdpUrl(opts.cdpUrl) });
   const page = await context.newPage();
 
-  // From here on, anything that throws would leave a tab dangling. Wrap and
-  // close the page on any failure so callers don't accumulate junk tabs.
   try {
     ensurePageState(page);
     clearBlockedPageRef(opts.cdpUrl, page);
@@ -628,12 +653,7 @@ export async function createPageViaPlaywright(opts: {
       type: 'page',
     };
   } catch (err) {
-    // closeBlockedNavigationTarget (called by the post-nav safety check for
-    // policy denials) may have already closed the page — page.close() is
-    // idempotent in Playwright and the .catch() swallows the no-op error.
-    await page.close().catch(() => {
-      /* best-effort cleanup */
-    });
+    await page.close().catch(() => undefined);
     throw err;
   }
 }

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -625,6 +625,21 @@ describe('pickActiveTargetId', () => {
     const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
     expect(result).toBe('t-newtab');
   });
+
+  it('keeps vendor new-tab pages eligible (edge, brave, vivaldi, opera)', async () => {
+    const cases: { url: string; expected: string }[] = [
+      { url: 'edge://newtab/', expected: 't-edge' },
+      { url: 'brave://newtab/', expected: 't-brave' },
+      { url: 'vivaldi://newtab', expected: 't-vivaldi' },
+      { url: 'opera://newtab/', expected: 't-opera' },
+    ];
+    for (const { url, expected } of cases) {
+      const accessible = [pageWithUrl(url)];
+      const tidOf = (page: Page) => Promise.resolve(page === accessible[0] ? expected : null);
+      const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+      expect(result).toBe(expected);
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -609,6 +609,22 @@ describe('pickActiveTargetId', () => {
     const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
     expect(result).toBeNull();
   });
+
+  it('keeps the default new-tab page eligible in the final fallback', async () => {
+    const accessible = [pageWithUrl('chrome://newtab/')];
+    const tidOf = (page: Page) => Promise.resolve(page === accessible[0] ? 't-newtab' : null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-newtab');
+  });
+
+  it('keeps chrome://new-tab-page eligible in the final fallback', async () => {
+    const accessible = [pageWithUrl('chrome://new-tab-page/')];
+    const tidOf = (page: Page) => Promise.resolve(page === accessible[0] ? 't-newtab' : null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-newtab');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -585,6 +585,30 @@ describe('pickActiveTargetId', () => {
     const result = await pickActiveTargetId({ accessible, preferTargetId: 't-chrome', preferUrl: '', tidOf });
     expect(result).toBe('t-chrome');
   });
+
+  it('prefers a blank tab over a browser-internal page in the final fallback', async () => {
+    const accessible = [pageWithUrl('chrome://settings/'), pageWithUrl('about:blank')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-chrome'],
+      [accessible[1], 't-blank'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-blank');
+  });
+
+  it('returns null when every accessible page is browser-internal', async () => {
+    const accessible = [pageWithUrl('chrome://settings/'), pageWithUrl('devtools://devtools/')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-chrome'],
+      [accessible[1], 't-devtools'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBeNull();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -561,6 +561,30 @@ describe('pickActiveTargetId', () => {
     const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
     expect(result).toBe('t-b');
   });
+
+  it('skips browser-internal URLs in the non-blank pass so it matches the tabs filter', async () => {
+    const accessible = [pageWithUrl('chrome://settings/'), pageWithUrl('https://a.test/')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-chrome'],
+      [accessible[1], 't-real'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: '', preferUrl: '', tidOf });
+    expect(result).toBe('t-real');
+  });
+
+  it('still honors preferTargetId for browser-internal URLs when explicitly requested', async () => {
+    const accessible = [pageWithUrl('chrome://settings/'), pageWithUrl('https://a.test/')];
+    const tids = new Map<Page, string>([
+      [accessible[0], 't-chrome'],
+      [accessible[1], 't-real'],
+    ]);
+    const tidOf = (page: Page) => Promise.resolve(tids.get(page) ?? null);
+
+    const result = await pickActiveTargetId({ accessible, preferTargetId: 't-chrome', preferUrl: '', tidOf });
+    expect(result).toBe('t-chrome');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1030,7 +1030,8 @@ export async function pickActiveTargetId(opts: {
   }
 
   for (const page of accessible) {
-    if (isBrowserInternalTargetUrl(page.url())) continue;
+    const url = page.url();
+    if (isBrowserInternalTargetUrl(url) && !isBlankUrl(url)) continue;
     const tid = await tidOf(page);
     if (tid !== null && tid !== '') return tid;
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -939,6 +939,21 @@ function isBlankUrl(url: string): boolean {
   return url === '' || url === 'about:blank' || url.startsWith('chrome://new-tab-page') || url === 'chrome://newtab/';
 }
 
+const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
+  'chrome://',
+  'chrome-untrusted://',
+  'devtools://',
+  'edge://',
+  'brave://',
+  'vivaldi://',
+  'opera://',
+];
+
+export function isBrowserInternalTargetUrl(url: string): boolean {
+  const normalized = url.trim().toLowerCase();
+  return BROWSER_INTERNAL_TARGET_URL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
 /**
  * Best-effort heuristic resolver for a usable page targetId.
  *
@@ -1007,7 +1022,8 @@ export async function pickActiveTargetId(opts: {
   }
 
   for (const page of accessible) {
-    if (!isBlankUrl(page.url())) {
+    const url = page.url();
+    if (!isBlankUrl(url) && !isBrowserInternalTargetUrl(url)) {
       const tid = await tidOf(page);
       if (tid !== null && tid !== '') return tid;
     }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -951,6 +951,7 @@ const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
 
 export function isBrowserInternalTargetUrl(url: string): boolean {
   const normalized = url.trim().toLowerCase();
+  if (isBlankUrl(normalized)) return false;
   return BROWSER_INTERNAL_TARGET_URL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
@@ -1030,8 +1031,7 @@ export async function pickActiveTargetId(opts: {
   }
 
   for (const page of accessible) {
-    const url = page.url();
-    if (isBrowserInternalTargetUrl(url) && !isBlankUrl(url)) continue;
+    if (isBrowserInternalTargetUrl(page.url())) continue;
     const tid = await tidOf(page);
     if (tid !== null && tid !== '') return tid;
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1029,10 +1029,8 @@ export async function pickActiveTargetId(opts: {
     }
   }
 
-  // Final fallback: any accessible page whose targetId resolves. We iterate
-  // rather than only asking `accessible[0]` because a transient pageTargetId
-  // failure on the first page must not mask a usable later page.
   for (const page of accessible) {
+    if (isBrowserInternalTargetUrl(page.url())) continue;
     const tid = await tidOf(page);
     if (tid !== null && tid !== '') return tid;
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -935,10 +935,6 @@ export async function getRestoredPageForTarget(opts: {
   return page;
 }
 
-function isBlankUrl(url: string): boolean {
-  return url === '' || url === 'about:blank' || url.startsWith('chrome://new-tab-page') || url === 'chrome://newtab/';
-}
-
 const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
   'chrome://',
   'chrome-untrusted://',
@@ -949,9 +945,24 @@ const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
   'opera://',
 ];
 
+function isVendorNewTabUrl(normalized: string): boolean {
+  for (const prefix of BROWSER_INTERNAL_TARGET_URL_PREFIXES) {
+    if (!normalized.startsWith(prefix)) continue;
+    const rest = normalized.slice(prefix.length);
+    if (rest === 'newtab' || rest === 'newtab/' || rest.startsWith('new-tab-page')) return true;
+  }
+  return false;
+}
+
+function isBlankUrl(url: string): boolean {
+  if (url === '' || url === 'about:blank') return true;
+  return isVendorNewTabUrl(url.trim().toLowerCase());
+}
+
 export function isBrowserInternalTargetUrl(url: string): boolean {
   const normalized = url.trim().toLowerCase();
-  if (isBlankUrl(normalized)) return false;
+  if (normalized === '' || normalized === 'about:blank') return false;
+  if (isVendorNewTabUrl(normalized)) return false;
   return BROWSER_INTERNAL_TARGET_URL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -864,15 +864,35 @@ describe('security.ts', () => {
       expect(result.family).toBe(4);
     });
 
-    it('should return all addresses when opts.all is true', async () => {
+    it('should prefer IPv4 when no family is requested and IPv4 addresses exist', async () => {
       const lookup = createPinnedLookup({
         hostname: 'test.com',
         addresses: ['1.2.3.4', '2001:db8::1'],
       });
       const results = await callPinnedAll(lookup, 'test.com');
-      expect(results).toHaveLength(2);
+      expect(results).toHaveLength(1);
       expect(results[0]).toEqual({ address: '1.2.3.4', family: 4 });
-      expect(results[1]).toEqual({ address: '2001:db8::1', family: 6 });
+    });
+
+    it('should return IPv6 addresses when no IPv4 records exist', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['2001:db8::1', '2001:db8::2'],
+      });
+      const results = await callPinnedAll(lookup, 'test.com');
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({ address: '2001:db8::1', family: 6 });
+      expect(results[1]).toEqual({ address: '2001:db8::2', family: 6 });
+    });
+
+    it('should return both families when family: 0 is explicitly requested but fallback hits IPv4-first', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.2.3.4', '5.6.7.8', '2001:db8::1'],
+      });
+      const results = await callPinnedAll(lookup, 'test.com');
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.address).sort()).toEqual(['1.2.3.4', '5.6.7.8']);
     });
 
     it('should filter by requested family', async () => {

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -885,7 +885,17 @@ describe('security.ts', () => {
       expect(results[1]).toEqual({ address: '2001:db8::2', family: 6 });
     });
 
-    it('should return both families when family: 0 is explicitly requested but fallback hits IPv4-first', async () => {
+    it('should return both families when family: 0 is explicitly requested', async () => {
+      const lookup = createPinnedLookup({
+        hostname: 'test.com',
+        addresses: ['1.2.3.4', '5.6.7.8', '2001:db8::1'],
+      });
+      const results = await callPinnedAll(lookup, 'test.com', { family: 0 });
+      expect(results).toHaveLength(3);
+      expect(results.map((r) => r.address).sort()).toEqual(['1.2.3.4', '2001:db8::1', '5.6.7.8']);
+    });
+
+    it('should prefer IPv4 only when no family option is provided at all', async () => {
       const lookup = createPinnedLookup({
         hostname: 'test.com',
         addresses: ['1.2.3.4', '5.6.7.8', '2001:db8::1'],

--- a/src/security.ts
+++ b/src/security.ts
@@ -470,12 +470,14 @@ export function createPinnedLookup(params: {
 
     const opts: { all?: boolean; family?: number } =
       typeof second === 'object' ? (second as { all?: boolean; family?: number }) : {};
-    const requestedFamily = typeof second === 'number' ? second : typeof opts.family === 'number' ? opts.family : 0;
+    const requestedFamily: number | undefined =
+      typeof second === 'number' ? second : typeof opts.family === 'number' ? opts.family : undefined;
+    const fallbackPool = requestedFamily === undefined ? automaticRecords : records;
     const candidates =
       requestedFamily === 4 || requestedFamily === 6
         ? records.filter((entry) => entry.family === requestedFamily)
-        : automaticRecords;
-    const usable = candidates.length > 0 ? candidates : automaticRecords;
+        : fallbackPool;
+    const usable = candidates.length > 0 ? candidates : fallbackPool;
 
     if (opts.all === true) {
       cb(null, usable);

--- a/src/security.ts
+++ b/src/security.ts
@@ -445,6 +445,8 @@ export function createPinnedLookup(params: {
     address,
     family: address.includes(':') ? (6 as const) : (4 as const),
   }));
+  const ipv4Records = records.filter((entry) => entry.family === 4);
+  const automaticRecords = ipv4Records.length > 0 ? ipv4Records : records;
   let index = 0;
 
   // dns.lookup has complex overloads; we use a loosely-typed inner signature
@@ -472,8 +474,8 @@ export function createPinnedLookup(params: {
     const candidates =
       requestedFamily === 4 || requestedFamily === 6
         ? records.filter((entry) => entry.family === requestedFamily)
-        : records;
-    const usable = candidates.length > 0 ? candidates : records;
+        : automaticRecords;
+    const usable = candidates.length > 0 ? candidates : automaticRecords;
 
     if (opts.all === true) {
       cb(null, usable);


### PR DESCRIPTION
Three browser-SDK ports from OpenClaw 2026.5.12 (5.8–5.11 were never published as stable; 5.12 is the first new release since 5.7).

## Ported

- **Read-only SSRF reject no longer auto-closes the user's tab.** Extracted `quarantineBlockedTarget` (mark-blocked only) from `closeBlockedNavigationTarget` (mark + close). `assertPageNavigationCompletedSafely` — called by snapshot, screenshot, PDF, and interaction-time navigation guards — now quarantines on policy denial instead of closing. `navigateViaPlaywright` wraps the post-nav assertion and closes on policy denial since that path is browserclaw-initiated. `createPageViaPlaywright` already closes via its outer catch.
- **`listPagesViaPlaywright` filters browser-internal targets.** Added `BROWSER_INTERNAL_TARGET_URL_PREFIXES` covering `chrome://`, `chrome-untrusted://`, `devtools://`, `edge://`, `brave://`, `vivaldi://`, `opera://`. Trims and lowercases before prefix match. (Upstream: filter browser-internal targets from raw CDP and persistent Playwright tab selection so navigation opens real page tabs.)
- **`createPinnedLookup` prefers IPv4 when no family is requested.** When the pinned address set contains any IPv4 entries, the auto-resolution fallback returns IPv4 only — extends the 5.4 undici IPv4/IPv6 policy work so SDK callers on broken-IPv6 hosts recover instead of dialing unreachable v6.

## Not ports

- `writeViaSiblingTempPath` refactor (OC delegates to fs-safe `writeExternalFileWithinRoot`): browserclaw's atomic-rename approach is registered as a known difference and stays.
- `ensureOutputDirectory`, `resolveSystemDirectoryAlias`, XDG_CONFIG_HOME env, managed download path: not in browserclaw's surface.
- `wildcardPatternToRegExp`: browserclaw uses Playwright's native URL matcher, not OC's `matchBrowserUrlPattern`.

## Tests

Three new navigation tests (quarantine-only on read-only SSRF, chrome:// filter applied, prefix match is case-insensitive). Two new security tests for IPv4-first auto-resolution; one existing test updated to reflect new semantics. 19258 tests pass; lint, typecheck, prettier all clean.

## Version

0.19.0 → 0.19.1 — all three upstream items are framed as fixes (stop closing, filter internal targets, IPv4 reachability).