### PR TITLE
Updates from OpenClaw 2026.5.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -8,6 +8,7 @@ import {
   BrowserTabNotFoundError,
   BlockedBrowserTargetError,
   getHeadersWithAuth,
+  stripUrlCredentials,
   getDirectAgentForCdp,
   isBlockedTarget,
   markTargetBlocked,
@@ -109,6 +110,32 @@ describe('getHeadersWithAuth', () => {
     const result = getHeadersWithAuth('http://user:pass@localhost:9222', base);
     expect(base).toEqual({ 'X-Foo': 'bar' });
     expect(result).not.toBe(base);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stripUrlCredentials
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('stripUrlCredentials', () => {
+  it('removes userinfo from URL', () => {
+    expect(stripUrlCredentials('http://user:pass@localhost:9222/json/list')).toBe('http://localhost:9222/json/list');
+  });
+
+  it('returns URL unchanged when no credentials present', () => {
+    expect(stripUrlCredentials('http://localhost:9222/json/list')).toBe('http://localhost:9222/json/list');
+  });
+
+  it('strips username-only', () => {
+    expect(stripUrlCredentials('http://user@localhost:9222/')).toBe('http://localhost:9222/');
+  });
+
+  it('returns input unchanged when not a valid URL', () => {
+    expect(stripUrlCredentials('not-a-url')).toBe('not-a-url');
+  });
+
+  it('preserves query string and fragment', () => {
+    expect(stripUrlCredentials('https://u:p@host/path?q=1#frag')).toBe('https://host/path?q=1#frag');
   });
 });
 
@@ -300,9 +327,10 @@ describe('withNoProxyForCdpUrl', () => {
     expect(noProxyDuringFn).toContain('localhost');
   });
 
-  it('skips mutation when NO_PROXY already covers localhost', async () => {
+  it('skips mutation when both NO_PROXY casings already cover localhost', async () => {
     process.env.HTTP_PROXY = 'http://proxy:8080';
     process.env.NO_PROXY = 'foo,localhost,127.0.0.1,[::1],bar';
+    process.env.no_proxy = 'localhost,127.0.0.1,[::1]';
 
     let noProxyDuringFn: string | undefined;
     await withNoProxyForCdpUrl('ws://localhost:9222', () => {
@@ -310,6 +338,53 @@ describe('withNoProxyForCdpUrl', () => {
       return Promise.resolve();
     });
     expect(noProxyDuringFn).toBe('foo,localhost,127.0.0.1,[::1],bar');
+  });
+
+  it('mutates when only one NO_PROXY casing covers localhost', async () => {
+    process.env.HTTP_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'localhost,127.0.0.1,[::1]';
+    delete process.env.no_proxy;
+
+    let noProxyLowerDuringFn: string | undefined;
+    await withNoProxyForCdpUrl('ws://localhost:9222', () => {
+      noProxyLowerDuringFn = process.env.no_proxy;
+      return Promise.resolve();
+    });
+    expect(noProxyLowerDuringFn).toContain('localhost');
+    expect(noProxyLowerDuringFn).toContain('127.0.0.1');
+    expect(noProxyLowerDuringFn).toContain('[::1]');
+  });
+
+  it('does not treat substring matches like "mylocalhost.com" as covering localhost', async () => {
+    process.env.HTTP_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'mylocalhost.com,my127.0.0.1.com,[::1]';
+    process.env.no_proxy = 'mylocalhost.com,my127.0.0.1.com,[::1]';
+
+    let noProxyDuringFn: string | undefined;
+    await withNoProxyForCdpUrl('ws://localhost:9222', () => {
+      noProxyDuringFn = process.env.NO_PROXY;
+      return Promise.resolve();
+    });
+    expect(noProxyDuringFn).toContain('mylocalhost.com');
+    expect(noProxyDuringFn).toContain(',localhost,127.0.0.1,[::1]');
+  });
+
+  it('preserves distinct NO_PROXY and no_proxy base values when appending', async () => {
+    process.env.HTTP_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'corp.example';
+    process.env.no_proxy = 'lowercase.example';
+
+    let upper: string | undefined;
+    let lower: string | undefined;
+    await withNoProxyForCdpUrl('ws://localhost:9222', () => {
+      upper = process.env.NO_PROXY;
+      lower = process.env.no_proxy;
+      return Promise.resolve();
+    });
+    expect(upper).toBe('corp.example,localhost,127.0.0.1,[::1]');
+    expect(lower).toBe('lowercase.example,localhost,127.0.0.1,[::1]');
+    expect(process.env.NO_PROXY).toBe('corp.example');
+    expect(process.env.no_proxy).toBe('lowercase.example');
   });
 
   it('deletes NO_PROXY if it was originally undefined', async () => {

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -387,6 +387,42 @@ describe('withNoProxyForCdpUrl', () => {
     expect(process.env.no_proxy).toBe('lowercase.example');
   });
 
+  it('copies upper-case base into lower-case casing when no_proxy is unset', async () => {
+    process.env.HTTP_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'internal.corp';
+    delete process.env.no_proxy;
+
+    let upper: string | undefined;
+    let lower: string | undefined;
+    await withNoProxyForCdpUrl('ws://localhost:9222', () => {
+      upper = process.env.NO_PROXY;
+      lower = process.env.no_proxy;
+      return Promise.resolve();
+    });
+    expect(upper).toBe('internal.corp,localhost,127.0.0.1,[::1]');
+    expect(lower).toBe('internal.corp,localhost,127.0.0.1,[::1]');
+    expect(process.env.NO_PROXY).toBe('internal.corp');
+    expect(process.env.no_proxy).toBeUndefined();
+  });
+
+  it('copies lower-case base into upper-case casing when NO_PROXY is unset', async () => {
+    process.env.HTTP_PROXY = 'http://proxy:8080';
+    delete process.env.NO_PROXY;
+    process.env.no_proxy = 'internal.corp';
+
+    let upper: string | undefined;
+    let lower: string | undefined;
+    await withNoProxyForCdpUrl('ws://localhost:9222', () => {
+      upper = process.env.NO_PROXY;
+      lower = process.env.no_proxy;
+      return Promise.resolve();
+    });
+    expect(upper).toBe('internal.corp,localhost,127.0.0.1,[::1]');
+    expect(lower).toBe('internal.corp,localhost,127.0.0.1,[::1]');
+    expect(process.env.NO_PROXY).toBeUndefined();
+    expect(process.env.no_proxy).toBe('internal.corp');
+  });
+
   it('deletes NO_PROXY if it was originally undefined', async () => {
     process.env.HTTP_PROXY = 'http://proxy:8080';
     delete process.env.NO_PROXY;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -626,13 +626,16 @@ function cdpSocketNeedsAttach(wsUrl: string): boolean {
  */
 async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string): Promise<void> {
   const httpBase = normalizeCdpHttpBaseForJsonEndpoints(cdpUrl);
+  const listUrl = `${httpBase}/json/list`;
+  const headers = getHeadersWithAuth(listUrl);
+  const fetchUrl = stripUrlCredentials(listUrl);
   const ctrl = new AbortController();
   const t = setTimeout(() => {
     ctrl.abort();
   }, 2000);
   let targets: unknown;
   try {
-    const res = await fetch(`${httpBase}/json/list`, { signal: ctrl.signal });
+    const res = await fetch(fetchUrl, { signal: ctrl.signal, headers });
     if (!res.ok) return;
     targets = await res.json();
   } catch {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -84,13 +84,17 @@ async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<unknown>
   const t = setTimeout(() => {
     ctrl.abort();
   }, timeoutMs);
+  const headers = getHeadersWithAuth(url);
+  const fetchUrl = stripUrlCredentials(url);
   try {
-    const res = await fetch(url, { signal: ctrl.signal });
+    const res = await fetch(fetchUrl, { signal: ctrl.signal, headers });
     if (!res.ok) return null;
     return await res.json();
   } catch (err) {
     if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
-      console.warn(`[browserclaw] fetchJsonForCdp ${url} failed: ${err instanceof Error ? err.message : String(err)}`);
+      console.warn(
+        `[browserclaw] fetchJsonForCdp ${fetchUrl} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     return null;
   } finally {
     clearTimeout(t);
@@ -151,9 +155,22 @@ export async function withPageScopedCdpClient<T>(opts: {
 
 const LOOPBACK_ENTRIES = 'localhost,127.0.0.1,[::1]';
 
+function noProxyValueCoversLocalhost(value: string | undefined): boolean {
+  const entries = new Set(
+    (value ?? '')
+      .split(',')
+      .map((entry) => entry.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  return entries.has('localhost') && entries.has('127.0.0.1') && entries.has('[::1]');
+}
+
 function noProxyAlreadyCoversLocalhost(): boolean {
-  const current = process.env.NO_PROXY ?? process.env.no_proxy ?? '';
-  return current.includes('localhost') && current.includes('127.0.0.1') && current.includes('[::1]');
+  return noProxyValueCoversLocalhost(process.env.NO_PROXY) && noProxyValueCoversLocalhost(process.env.no_proxy);
+}
+
+function appendLoopbackEntries(value: string | undefined): string {
+  return value !== undefined && value !== '' ? `${value},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
 }
 
 function isLoopbackCdpUrl(url: string): boolean {
@@ -209,20 +226,20 @@ export async function withNoProxyForCdpUrl<T>(url: string, fn: () => Promise<T>)
 
   const savedNoProxy = process.env.NO_PROXY;
   const savedNoProxyLower = process.env.no_proxy;
-  const current = savedNoProxy ?? savedNoProxyLower ?? '';
-  const applied = current ? `${current},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
-  process.env.NO_PROXY = applied;
-  process.env.no_proxy = applied;
+  const appliedNoProxy = appendLoopbackEntries(savedNoProxy);
+  const appliedNoProxyLower = appendLoopbackEntries(savedNoProxyLower);
+  process.env.NO_PROXY = appliedNoProxy;
+  process.env.no_proxy = appliedNoProxyLower;
   envMutexDepth += 1;
   try {
     return await fn();
   } finally {
     envMutexDepth -= 1;
-    if (process.env.NO_PROXY === applied) {
+    if (process.env.NO_PROXY === appliedNoProxy) {
       if (savedNoProxy !== undefined) process.env.NO_PROXY = savedNoProxy;
       else delete process.env.NO_PROXY;
     }
-    if (process.env.no_proxy === applied) {
+    if (process.env.no_proxy === appliedNoProxyLower) {
       if (savedNoProxyLower !== undefined) process.env.no_proxy = savedNoProxyLower;
       else delete process.env.no_proxy;
     }
@@ -271,6 +288,23 @@ export function getHeadersWithAuth(endpoint: string, baseHeaders: Record<string,
     // endpoint is not a valid URL (e.g. a raw WebSocket path) — skip auth header injection
   }
   return headers;
+}
+
+/**
+ * Strip URL userinfo (user:pass@) so the URL can be safely logged or passed to
+ * fetch without leaking credentials. Pair with `getHeadersWithAuth` to move
+ * credentials into an Authorization header before issuing the request.
+ */
+export function stripUrlCredentials(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.username && !parsed.password) return url;
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
 }
 
 // ── Persistent Connection Cache ──

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -226,8 +226,10 @@ export async function withNoProxyForCdpUrl<T>(url: string, fn: () => Promise<T>)
 
   const savedNoProxy = process.env.NO_PROXY;
   const savedNoProxyLower = process.env.no_proxy;
-  const appliedNoProxy = appendLoopbackEntries(savedNoProxy);
-  const appliedNoProxyLower = appendLoopbackEntries(savedNoProxyLower);
+  const baseUpper = savedNoProxy ?? savedNoProxyLower;
+  const baseLower = savedNoProxyLower ?? savedNoProxy;
+  const appliedNoProxy = appendLoopbackEntries(baseUpper);
+  const appliedNoProxyLower = appendLoopbackEntries(baseLower);
   process.env.NO_PROXY = appliedNoProxy;
   process.env.no_proxy = appliedNoProxyLower;
   envMutexDepth += 1;


### PR DESCRIPTION
## Summary

Sync browserclaw with OpenClaw 2026.5.18 (last synced: 2026.5.12). Two real fixes ported in `connection.ts`; two larger upstream additions documented as known divergences. Version 0.19.1 → 0.19.2 (patch — both ports are bug fixes).

## Ported

**1. NO_PROXY loopback bypass — dual-casing + exact-entry matching**
Upstream changelog: *"Browser/CDP: keep loopback proxy bypass active across both `NO_PROXY` casings"* and *"require exact loopback entries before treating `NO_PROXY` as already covering local CDP proxy bypasses"*.
- `noProxyAlreadyCoversLocalhost` now requires BOTH `process.env.NO_PROXY` and `process.env.no_proxy` to cover localhost (previously only checked one casing via `??`).
- New `noProxyValueCoversLocalhost(value)` helper splits on comma, trims, lowercases, and uses Set membership — no more substring false positives like `mylocalhost.com`.
- New `appendLoopbackEntries(value)` helper; the apply path builds `appliedNoProxy` and `appliedNoProxyLower` independently so each casing's base value is preserved on restore.

**2. Credential redaction in `fetchJsonForCdp`**
Upstream changelog: *"Browser/CDP: redact credential-bearing Chrome MCP and managed Chrome launch diagnostics"*.
- New exported `stripUrlCredentials(url)` helper.
- `fetchJsonForCdp` now extracts URL credentials into an Authorization header via `getHeadersWithAuth`, then passes the stripped URL to `fetch`. The error log path also uses the stripped URL.

## Not ported (documented in `sync/known-differences.md`)

**KD 73 — Observed-dialog state system (the big upstream addition).** OC 2026.5.18 added `pendingDialogs`/`recentDialogs` state, `BrowserObservedDialogBlockedError`, `respondToObservedDialog*`, `getObservedBrowserState*`, `armObservedDialogResponseOnPage`, and abort signals threaded through every `*ViaPlaywright` action. Incompatible with browserclaw's existing dialog model (auto-dismiss + `armDialog` + `onDialog`) — porting would either replace browserclaw's API (breaking change) or layer a parallel one.

**KD 74 — `diagnosticShowsChromeHttpDiscovery`.** OC uses it in `launchOpenClawChrome` to recover from `isChromeReachable` racing cold-start. browserclaw polls with `isChromeCdpReady` (KD #55) which doesn't have that race.

Other upstream changes (SSRF policy origin helpers, `mergeSsrFPolicies` bundle move, `toBrowserErrorResponse` bundle move, Chrome MCP/CLI changes) are either already covered by existing KDs (#19a, #65) or are non-SDK server concerns.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm test` — 589 passed (8 new: `stripUrlCredentials` ×5, NO_PROXY dual-casing ×3)
- [x] `npm run build` — ESM + CJS + DTS bundles build