### PR TITLE
Updates from OpenClaw 2026.5.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -301,11 +301,12 @@ export class CrawlPage {
    * @param opts - Options (limit: max nodes to return, default 500)
    * @returns Array of accessibility tree nodes
    */
-  async ariaSnapshot(opts?: { limit?: number }): Promise<AriaSnapshotResult> {
+  async ariaSnapshot(opts?: { limit?: number; timeoutMs?: number }): Promise<AriaSnapshotResult> {
     return snapshotAria({
       cdpUrl: this.cdpUrl,
       targetId: this._targetId,
       limit: opts?.limit,
+      timeoutMs: opts?.timeoutMs,
       ssrfPolicy: this.ssrfPolicy,
     });
   }

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -501,16 +501,11 @@ describe('buildChromeLaunchArgs', () => {
     expect(args).toContain('--disable-features=Translate,MediaRouter');
   });
 
-  it('adds --password-store=basic on linux always (avoid keyring hang)', () => {
-    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'linux' })).toContain('--password-store=basic');
-    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'linux', ciDefaults: true })).toContain(
-      '--password-store=basic',
-    );
-  });
-
-  it('does NOT add --password-store=basic on non-linux', () => {
-    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'darwin' })).not.toContain('--password-store=basic');
-    expect(buildChromeLaunchArgs({ ...baseOpts, platform: 'win32' })).not.toContain('--password-store=basic');
+  it('adds --password-store=basic on every platform (matches OpenClaw; avoids macOS Keychain hang)', () => {
+    for (const platform of ['linux', 'darwin', 'win32'] as const) {
+      expect(buildChromeLaunchArgs({ ...baseOpts, platform })).toContain('--password-store=basic');
+      expect(buildChromeLaunchArgs({ ...baseOpts, platform, ciDefaults: true })).toContain('--password-store=basic');
+    }
   });
 
   it('adds --ignore-certificate-errors when ignoreHTTPSErrors: true', () => {
@@ -542,6 +537,25 @@ describe('buildChromeLaunchArgs', () => {
   it('does not add --disable-dev-shm-usage on darwin', () => {
     const args = buildChromeLaunchArgs({ ...baseOpts, platform: 'darwin' });
     expect(args).not.toContain('--disable-dev-shm-usage');
+  });
+
+  it('adds --no-proxy-server by default so a managed Chrome ignores caller proxy env', () => {
+    expect(buildChromeLaunchArgs(baseOpts)).toContain('--no-proxy-server');
+  });
+
+  it('skips --no-proxy-server when the caller passed a proxy control arg in chromeArgs', () => {
+    for (const userArg of [
+      '--proxy-server=http://proxy.test:8080',
+      '--proxy-pac-url=http://wpad.test/proxy.pac',
+      '--proxy-auto-detect',
+      '--no-proxy-server',
+    ]) {
+      const args = buildChromeLaunchArgs({ ...baseOpts, chromeArgs: [userArg] });
+      const noProxyDefaults = args.filter((a) => a === '--no-proxy-server');
+      const userPassedNoProxy = userArg === '--no-proxy-server';
+      expect(noProxyDefaults.length).toBe(userPassedNoProxy ? 1 : 0);
+      expect(args).toContain(userArg);
+    }
   });
 
   it('appends extra chromeArgs after defaults but before about:blank', () => {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -971,6 +971,21 @@ async function canRunCdpHealthCommand(wsUrl: string, timeoutMs = 800): Promise<b
   });
 }
 
+const PROXY_CONTROL_CHROME_ARGS = new Set([
+  '--no-proxy-server',
+  '--proxy-server',
+  '--proxy-pac-url',
+  '--proxy-auto-detect',
+]);
+
+function chromeArgName(arg: string): string {
+  return arg.trim().split('=', 1)[0]?.toLowerCase() ?? '';
+}
+
+function hasChromeProxyControlArg(args: readonly string[]): boolean {
+  return args.some((arg) => PROXY_CONTROL_CHROME_ARGS.has(chromeArgName(arg)));
+}
+
 export interface BuildChromeLaunchArgsOptions {
   cdpPort: number;
   userDataDir: string;
@@ -992,6 +1007,7 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
     '--disable-blink-features=AutomationControlled',
     '--disable-session-crashed-bubble',
     '--hide-crash-restore-bubble',
+    '--password-store=basic',
   ];
   if (opts.ciDefaults) {
     args.push(
@@ -1001,7 +1017,6 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
       '--disable-features=Translate,MediaRouter',
     );
   }
-  if (opts.platform === 'linux') args.push('--password-store=basic');
   if (opts.headless) {
     args.push('--headless=new', '--disable-gpu');
   }
@@ -1015,6 +1030,7 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
   const extraArgs = Array.isArray(opts.chromeArgs)
     ? opts.chromeArgs.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
     : [];
+  if (!hasChromeProxyControlArg(extraArgs)) args.push('--no-proxy-server');
   if (extraArgs.length) args.push(...extraArgs);
   args.push('about:blank');
   return args;

--- a/src/snapshot/aria-snapshot.test.ts
+++ b/src/snapshot/aria-snapshot.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import type { CDPSession, Page } from 'playwright-core';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { buildRoleSnapshotFromAriaSnapshot } from './ref-map.js';
 
@@ -27,5 +28,93 @@ describe('snapshot empty/degenerate input handling', () => {
     const { snapshot, refs } = buildRoleSnapshotFromAriaSnapshot('', { interactive: true });
     expect(snapshot).toBe('(no interactive elements)');
     expect(Object.keys(refs)).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// snapshotAria timeout + CDP session detach
+// ─────────────────────────────────────────────────────────────────────────────
+
+vi.mock('../actions/navigation.js', () => ({
+  assertPageNavigationCompletedSafely: () => Promise.resolve(),
+}));
+
+const { mockGetPageForTargetId, mockWithCdpSession, mockStoreRoleRefsForTarget } = vi.hoisted(() => ({
+  mockGetPageForTargetId: vi.fn<(opts: unknown) => Promise<Page>>(),
+  mockWithCdpSession: vi.fn(),
+  mockStoreRoleRefsForTarget: vi.fn(),
+}));
+
+vi.mock('../connection.js', () => ({
+  getPageForTargetId: mockGetPageForTargetId,
+  ensurePageState: () => ({}),
+  storeRoleRefsForTarget: mockStoreRoleRefsForTarget,
+  normalizeTimeoutMs: (timeoutMs: number | undefined, fallback: number) => timeoutMs ?? fallback,
+  withPlaywrightPageCdpSession: mockWithCdpSession,
+  takeAiSnapshotText: () => Promise.resolve(''),
+}));
+
+const { snapshotAria } = await import('./aria-snapshot.js');
+
+function makeMockPage(): Page {
+  return {
+    url: () => 'https://example.test/',
+    locator: () => ({ evaluateAll: () => Promise.resolve() }),
+  } as unknown as Page;
+}
+
+function makeSession(opts: { hang?: boolean }): { session: CDPSession; detach: ReturnType<typeof vi.fn> } {
+  const detach = vi.fn(() => Promise.resolve());
+  const send = vi.fn((method: string) =>
+    method === 'Accessibility.getFullAXTree'
+      ? opts.hang === true
+        ? new Promise(() => undefined)
+        : Promise.resolve({ nodes: [] })
+      : Promise.resolve({}),
+  );
+  return { session: { send, detach } as unknown as CDPSession, detach };
+}
+
+describe('snapshotAria timeout', () => {
+  beforeEach(() => {
+    mockGetPageForTargetId.mockReset();
+    mockWithCdpSession.mockReset();
+    mockStoreRoleRefsForTarget.mockReset();
+    mockGetPageForTargetId.mockResolvedValue(makeMockPage());
+  });
+
+  it('rejects (clamping below the 500ms floor) and detaches the session when the AX-tree fetch hangs', async () => {
+    const { session, detach } = makeSession({ hang: true });
+    mockWithCdpSession.mockImplementation((_page: Page, fn: (s: CDPSession) => Promise<unknown>) => fn(session));
+
+    await expect(snapshotAria({ cdpUrl: 'http://localhost:9222', targetId: 't1', timeoutMs: 50 })).rejects.toThrow(
+      'Aria snapshot via Playwright timed out after 500ms.',
+    );
+
+    // The leak fix: the live session must be detached so the in-flight
+    // getFullAXTree unwinds instead of holding the CDP session open.
+    expect(detach).toHaveBeenCalledTimes(1);
+    expect(mockStoreRoleRefsForTarget).not.toHaveBeenCalled();
+  });
+
+  it('resolves and does not force-detach when the tree returns before the timeout', async () => {
+    const { session, detach } = makeSession({ hang: false });
+    mockWithCdpSession.mockImplementation((_page: Page, fn: (s: CDPSession) => Promise<unknown>) => fn(session));
+
+    const result = await snapshotAria({ cdpUrl: 'http://localhost:9222', targetId: 't1', timeoutMs: 5000 });
+
+    expect(result.nodes).toEqual([]);
+    expect(detach).not.toHaveBeenCalled();
+    expect(mockStoreRoleRefsForTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not arm a timeout when timeoutMs is omitted (additive default)', async () => {
+    const { session, detach } = makeSession({ hang: false });
+    mockWithCdpSession.mockImplementation((_page: Page, fn: (s: CDPSession) => Promise<unknown>) => fn(session));
+
+    const result = await snapshotAria({ cdpUrl: 'http://localhost:9222', targetId: 't1' });
+
+    expect(result.nodes).toEqual([]);
+    expect(detach).not.toHaveBeenCalled();
   });
 });

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -149,9 +149,14 @@ export async function snapshotAria(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  timeoutMs?: number;
   ssrfPolicy?: SsrfPolicy;
 }): Promise<AriaSnapshotResult> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
+  const ariaTimeoutMs =
+    typeof opts.timeoutMs === 'number' && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
+      ? Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs)))
+      : undefined;
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
@@ -171,7 +176,7 @@ export async function snapshotAria(opts: {
 
   const sourceUrl = page.url();
 
-  const res = await withPlaywrightPageCdpSession(page, async (session) => {
+  const collectAxTree = withPlaywrightPageCdpSession(page, async (session) => {
     await session.send('Accessibility.enable' as unknown as Parameters<typeof session.send>[0]).catch(() => {
       /* intentional no-op */
     });
@@ -179,6 +184,23 @@ export async function snapshotAria(opts: {
       nodes?: CdpAXNode[];
     };
   });
+  const res =
+    ariaTimeoutMs === undefined
+      ? await collectAxTree
+      : await (async () => {
+          let timer: NodeJS.Timeout | undefined;
+          const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              reject(new Error(`Aria snapshot via Playwright timed out after ${String(ariaTimeoutMs)}ms.`));
+            }, ariaTimeoutMs);
+            timer.unref?.();
+          });
+          try {
+            return await Promise.race([collectAxTree, timeout]);
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
+        })();
 
   const formatted = formatAriaNodes(Array.isArray(res.nodes) ? res.nodes : [], limit);
   const markedRefs = await markBackendDomRefsOnPage(page, formatted);

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -193,7 +193,7 @@ export async function snapshotAria(opts: {
             timer = setTimeout(() => {
               reject(new Error(`Aria snapshot via Playwright timed out after ${String(ariaTimeoutMs)}ms.`));
             }, ariaTimeoutMs);
-            timer.unref?.();
+            timer.unref();
           });
           try {
             return await Promise.race([collectAxTree, timeout]);

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -200,10 +200,8 @@ export async function snapshotAria(opts: {
           try {
             return await Promise.race([collectAxTree, timeout]);
           } catch (err) {
-            // Don't await: if detach rides the same wedged transport we'd re-block the caller.
-            if (activeSession) activeSession.detach().catch(() => {});
-            // Observe the orphan so its eventual late rejection isn't an unhandled rejection.
-            collectAxTree.catch(() => {});
+            if (activeSession) activeSession.detach().catch(() => undefined);
+            collectAxTree.catch(() => undefined);
             throw err;
           } finally {
             if (timer) clearTimeout(timer);

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -200,16 +200,13 @@ export async function snapshotAria(opts: {
           try {
             return await Promise.race([collectAxTree, timeout]);
           } catch (err) {
-            // Detach the live session so the in-flight Accessibility.getFullAXTree
-            // rejects — without this, withPlaywrightPageCdpSession's finally never
-            // runs and the CDP session leaks until Chrome eventually responds.
             if (activeSession) {
-              await activeSession.detach().catch(() => {
+              activeSession.detach().catch(() => {
                 /* intentional no-op */
               });
             }
             collectAxTree.catch(() => {
-              /* intentional no-op: surfaced via the explicit detach above */
+              /* intentional no-op */
             });
             throw err;
           } finally {

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -200,14 +200,10 @@ export async function snapshotAria(opts: {
           try {
             return await Promise.race([collectAxTree, timeout]);
           } catch (err) {
-            if (activeSession) {
-              activeSession.detach().catch(() => {
-                /* intentional no-op */
-              });
-            }
-            collectAxTree.catch(() => {
-              /* intentional no-op */
-            });
+            // Don't await: if detach rides the same wedged transport we'd re-block the caller.
+            if (activeSession) activeSession.detach().catch(() => {});
+            // Observe the orphan so its eventual late rejection isn't an unhandled rejection.
+            collectAxTree.catch(() => {});
             throw err;
           } finally {
             if (timer) clearTimeout(timer);

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright-core';
+import type { CDPSession, Page } from 'playwright-core';
 
 import { assertPageNavigationCompletedSafely } from '../actions/navigation.js';
 import {
@@ -176,7 +176,9 @@ export async function snapshotAria(opts: {
 
   const sourceUrl = page.url();
 
+  let activeSession: CDPSession | undefined;
   const collectAxTree = withPlaywrightPageCdpSession(page, async (session) => {
+    activeSession = session;
     await session.send('Accessibility.enable' as unknown as Parameters<typeof session.send>[0]).catch(() => {
       /* intentional no-op */
     });
@@ -197,6 +199,19 @@ export async function snapshotAria(opts: {
           });
           try {
             return await Promise.race([collectAxTree, timeout]);
+          } catch (err) {
+            // Detach the live session so the in-flight Accessibility.getFullAXTree
+            // rejects — without this, withPlaywrightPageCdpSession's finally never
+            // runs and the CDP session leaks until Chrome eventually responds.
+            if (activeSession) {
+              await activeSession.detach().catch(() => {
+                /* intentional no-op */
+              });
+            }
+            collectAxTree.catch(() => {
+              /* intentional no-op: surfaced via the explicit detach above */
+            });
+            throw err;
           } finally {
             if (timer) clearTimeout(timer);
           }


### PR DESCRIPTION
## Summary

Two upstream-divergence fixes on Chrome launch + one defensive change ported from OpenClaw 2026.5.26.

### 1. `--password-store=basic` everywhere (commit 1)

Was gated to `if (opts.platform === 'linux')` at `src/chrome-launcher.ts:1004`. Upstream OC applies it on every platform; this PR restores parity. Moved into the unconditional base args.

The known acute failure is on Linux: in CI/headless environments without an unlocked GNOME Keyring or KWallet, Chrome hangs on a keyring prompt at launch — the well-documented case this flag exists to defend against. The macOS analogue is *not* a documented launch-blocker (Keychain prompts happen on first password read/write, not at process start); applying it on macOS and Windows is preventive consistency with upstream, not a curative fix for a known hang. Low risk, zero new dependencies, matches upstream verbatim.

### 2. `--no-proxy-server` default (commit 1)

Never made it into browserclaw. Upstream adds it unless the caller already passed one of `--proxy-server`, `--proxy-pac-url`, `--proxy-auto-detect`, or `--no-proxy-server` in extra args. Ported the same defensive default along with a small `hasChromeProxyControlArg()` helper (mirrors OC verbatim, case-insensitive on the arg name).

**This is a real behavior change for some callers, so being precise about what flips:**

- Chromium normally honors **OS-level proxy configuration** (macOS System Preferences › Network, Windows WinINet, GNOME `gsettings`). It does not directly read `HTTPS_PROXY` / `HTTP_PROXY` env vars the way curl does — those only reach Chrome via specific desktop-integration paths.
- With this change, a browserclaw-managed Chrome explicitly bypasses OS proxy settings unless the caller opts back in via `chromeArgs: ['--proxy-server=...']` (or the other three control args).

The rationale for making it the default:
- browserclaw already treats its Chrome as a managed, deterministic instance (loopback-only CDP bind, isolated profiles, etc.). A managed automation library inheriting host proxy state defeats that determinism.
- Upstream OC ships #83255 (2026.5.22) — "bypass the managed proxy for the exact local managed Chrome CDP readiness and DevTools WebSocket endpoints, so `openclaw browser start` works when the operator proxy blocks loopback egress." Same trap; OC solves it with a Proxyline-style per-URL bypass lease (KD #78). browserclaw is a library, not a multi-tenant gateway, so the simpler `--no-proxy-server` default reaches the same outcome without the lease machinery.

**Who this could break:** anyone running browserclaw inside a corp network with mandatory system proxy who relied on Chrome inheriting it. Workaround is one extra entry in `chromeArgs` — but worth flagging.

### 3. `snapshotAria` timeout from OC 2026.5.26 (commit 2)

OC 2026.5.26 added timeout wrapping around `Accessibility.getFullAXTree` so a hung Chrome accessibility tree can't wedge the snapshot. The Playwright-side `session.send()` has no built-in timeout — a stuck CDP response blocks indefinitely until the session closes. Ported the same shape:

- New optional `timeoutMs?: number` on internal `snapshotAria` opts (clamped to `[500, 60000]`, `undefined` = no outer timeout, matching OC behavior exactly).
- `Promise.race` against a `setTimeout` that rejects with `"Aria snapshot via Playwright timed out after <ms>ms."`.
- Exposed on the public `CrawlPage.ariaSnapshot({ timeoutMs })` so callers can opt in.

Strictly additive — existing callers see no behavior change.

## Why these aren't grouped with the `ciDefaults` carve-out

The four CI flags (`--disable-sync`, `--disable-background-networking`, `--disable-component-update`, `--disable-features=Translate,MediaRouter`) are deliberately gated behind `ciDefaults: false` because they fingerprint as automation (commit 833465e "Slim default Chrome flags to reduce anti-bot fingerprinting"). That rationale doesn't apply to `--password-store=basic` (real users routinely launch without a system keyring) or `--no-proxy-server` (real users routinely launch without a proxy). Neither is a fingerprinting signal, so they belong in the unconditional defaults.

## Why we ported `snapshotAria` timeout but skipped the rest of the OC 5.22 → 5.27 sync

The 5.22 → 5.27 walk surfaced two larger OC additions that don't apply here — both recorded as known-differences (`sync/known-differences.md`):

- **KD #78** — Managed-proxy CDP bypass lease infrastructure (`withManagedProxyForCdpUrl`, `assertManagedProxyAllowsCdpUrl`, `releaseCdpProxyBypass` wired through `chrome` + `cdp.helpers`). Relies on OC's `proxy-lifecycle` module (Proxyline registration of per-URL bypasses). browserclaw has no managed-proxy concept; the same failure mode is solved here by the `--no-proxy-server` default in this PR — strictly simpler for a standalone library.
- **KD #79** — `readMacBundleBrowserVersion` via `/usr/libexec/PlistBuddy` and the `--version` fallback timeout bump (2000 → 6000 ms) in `chrome.executables`. browserclaw has no `getBrowserVersion` routine.

Plus: changelog #78526 "Browser snapshot reads honor SSRF policy" is already covered — browserclaw's `snapshotAi`, `snapshotRole`, and `snapshotAria` already call `assertPageNavigationCompletedSafely` before every CDP read when `ssrfPolicy` is set.

Bump: `0.19.2` → `0.19.3` (single bump covers all three changes).