### PR TITLE
Updates from OpenClaw 2026.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -188,7 +188,7 @@ export async function evaluateViaPlaywright(opts: {
       const targetId = opts.targetId?.trim() ?? '';
       if (targetId !== '') {
         // Targeted: only terminate execution on this target, preserving the shared connection
-        tryTerminateExecutionViaCdp(opts.cdpUrl, targetId).catch(() => {
+        tryTerminateExecutionViaCdp(opts.cdpUrl, targetId, opts.ssrfPolicy).catch(() => {
           /* intentional no-op */
         });
       } else {
@@ -197,6 +197,7 @@ export async function evaluateViaPlaywright(opts: {
         forceDisconnectPlaywrightConnection({
           cdpUrl: opts.cdpUrl,
           reason: 'evaluate aborted (no targetId)',
+          ssrfPolicy: opts.ssrfPolicy,
         }).catch(() => {
           /* intentional no-op */
         });

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -244,6 +244,7 @@ export async function clickViaPlaywright(opts: {
         cdpUrl: opts.cdpUrl,
         targetId: opts.targetId,
         reason: 'click aborted',
+        ssrfPolicy: opts.ssrfPolicy,
       }).catch(() => {
         /* best-effort disconnect */
       });

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -522,6 +522,7 @@ export async function navigateViaPlaywright(opts: {
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       reason: 'retry navigate after detached frame',
+      ssrfPolicy: policy,
     }).catch(() => {
       /* intentional no-op */
     });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -626,7 +626,8 @@ function cdpSocketNeedsAttach(wsUrl: string): boolean {
  * Bypasses Playwright entirely — important because Playwright may be stuck.
  * If the wsUrl is a browser-level endpoint, attaches to the target first.
  */
-async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string): Promise<void> {
+async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string, ssrfPolicy?: SsrfPolicy): Promise<void> {
+  await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
   const httpBase = normalizeCdpHttpBaseForJsonEndpoints(cdpUrl);
   const listUrl = `${httpBase}/json/list`;
   const headers = getHeadersWithAuth(listUrl);
@@ -655,6 +656,7 @@ async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string): Pr
   if (wsUrlRaw === '') return;
 
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, httpBase);
+  await assertCdpEndpointAllowed(wsUrl, ssrfPolicy);
   const needsAttach = cdpSocketNeedsAttach(wsUrl);
 
   await new Promise<void>((resolve) => {
@@ -730,6 +732,7 @@ export async function forceDisconnectPlaywrightConnection(opts: {
   cdpUrl: string;
   targetId?: string;
   reason?: string;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const normalized = normalizeCdpUrl(opts.cdpUrl);
   const cur = cachedByCdpUrl.get(normalized);
@@ -744,7 +747,7 @@ export async function forceDisconnectPlaywrightConnection(opts: {
 
   const targetId = opts.targetId?.trim() ?? '';
   if (targetId !== '') {
-    await tryTerminateExecutionViaCdp(normalized, targetId).catch(() => {
+    await tryTerminateExecutionViaCdp(normalized, targetId, opts.ssrfPolicy).catch(() => {
       /* noop */
     });
   }


### PR DESCRIPTION
Sync with OpenClaw 2026.6.6 (single hop from verified baseline 2026.6.5).

## Ported

**SSRF validation of discovered CDP WebSocket URLs** (OC "discovered WebSocket validation", #91736):

- `tryTerminateExecutionViaCdp` now takes an optional `ssrfPolicy`, asserts the CDP endpoint at entry, and asserts the WebSocket URL discovered from `/json/list` before opening the raw socket — a crafted `webSocketDebuggerUrl` in the `/json/list` response can no longer point the socket at a policy-blocked host.
- `forceDisconnectPlaywrightConnection` accepts `ssrfPolicy` and threads it through.
- The three disconnect paths now pass the caller's policy: navigate retry after detached frame, click abort, evaluate abort.

All additions are backwards-compatible (optional params; no policy = no-op per the existing `assertCdpEndpointAllowed` contract).

## Not ported (registered)

- **Evaluate source normalization** — OC moved statement-form handling server-side (`normalizeBrowserEvaluateFunctionSource` via `node:vm`, `fnBody`→`fnSource`, strict must-produce-a-function in-page eval). browserclaw keeps its in-page two-stage eval fallback with browser-side promise timeout (KD #35, extended).
- **`fetchJson` ssrfPolicy pass-through** — browserclaw has no `fetchCdpChecked` dispatcher stack; equivalent semantics via direct `assertCdpEndpointAllowed` calls (new KD #82).

## Verified N/A

`chrome` bundle comments-only; `cdp.helpers` import-hash only; `ssrf`/`ssrf-policy`/`ip`/`fs-safe` and all chunk bundles byte-identical. Changelog items #91422 (browser-output boundaries), #89851 (existing-session CDP), #91747 (default-profile cdpUrl) live in OC's browser-cli/config server layer, outside mapped bundles. Canonical-function dist sweep confirms no browser code migrated.

Typecheck, build, 20,443 tests, and format:check all pass.