### PR TITLE
Fix inverted SSRF default doc comments

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,13 +5,13 @@ import type { lookup as dnsLookup } from 'node:dns';
 
 /**
  * Policy for controlling which URLs browser navigation is allowed to reach.
- * Defaults to trusted-network mode (private/internal addresses allowed).
- * Set `dangerouslyAllowPrivateNetwork: false` to enforce strict public-only checks.
+ * Secure by default: private/internal/loopback addresses are blocked.
+ * Set `dangerouslyAllowPrivateNetwork: true` to allow them.
  */
 export interface SsrfPolicy {
   /**
    * Allow navigation to private/internal network addresses.
-   * Default: `true` (trusted-network mode). Set to `false` for strict public-only enforcement.
+   * Default: `false` — private/internal/loopback addresses are blocked. Set to `true` to allow them.
    */
   dangerouslyAllowPrivateNetwork?: boolean;
   /**
@@ -131,8 +131,8 @@ export interface LaunchOptions {
   isolated?: boolean | string;
   /**
    * SSRF policy controlling which URLs navigation is allowed to reach.
-   * Defaults to trusted-network mode (private/internal addresses allowed).
-   * Set `dangerouslyAllowPrivateNetwork: false` to enforce strict public-only checks.
+   * Secure by default: private/internal/loopback addresses are blocked.
+   * Set `dangerouslyAllowPrivateNetwork: true` to allow them.
    */
   ssrfPolicy?: SsrfPolicy;
   /**
@@ -151,8 +151,8 @@ export interface LaunchOptions {
 export interface ConnectOptions {
   /**
    * SSRF policy controlling which URLs navigation is allowed to reach.
-   * Defaults to trusted-network mode (private/internal addresses allowed).
-   * Set `dangerouslyAllowPrivateNetwork: false` to enforce strict public-only checks.
+   * Secure by default: private/internal/loopback addresses are blocked.
+   * Set `dangerouslyAllowPrivateNetwork: true` to allow them.
    */
   ssrfPolicy?: SsrfPolicy;
   /**


### PR DESCRIPTION
The JSDoc on `SsrfPolicy`, `LaunchOptions.ssrfPolicy`, and `ConnectOptions.ssrfPolicy` described the SSRF default backwards.

**Comments said:** defaults to "trusted-network mode (private/internal addresses allowed)"; opt into strict with `dangerouslyAllowPrivateNetwork: false`. One even claimed `Default: \`true\``.

**Code actually does the opposite — secure by default:** with no policy, navigation to private/loopback/metadata addresses is blocked. `isPrivateNetworkAllowedByPolicy` (security.ts) returns true only when `dangerouslyAllowPrivateNetwork === true`, and `launch()` injects no permissive default. Reproduced: `launch({})` → `open('http://127.0.0.1')` throws `... strict mode`. This behavior has been in place since 2026-03-10 with no later flip — the comments were simply wrong.

Comment-only change, no behavior change. Companion to the README correction in the merged README pass.