### PR TITLE
[codex] Add OpenAI support review repro note

### DIFF
--- a/docs/openai-support-case-09704586.md
+++ b/docs/openai-support-case-09704586.md
@@ -1,0 +1,7 @@
+# OpenAI Support Case 09704586
+
+This temporary note exists only to create a harmless pull request for reproducing
+the Codex GitHub PR review integration issue requested by OpenAI Support.
+
+The support case asks for a screen recording that shows a fresh `@codex review`
+comment and the resulting Codex bot response.


### PR DESCRIPTION
This draft PR exists only to reproduce the Codex GitHub PR review integration issue for OpenAI Support case 09704586.

It adds a harmless documentation note so there is a real pull request for a fresh `@codex review` attempt.

No product behavior changes are intended.

Validation: not run; documentation-only support reproduction note.
