### PR TITLE
Updates from OpenClaw 2026.6.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/snapshot/aria-snapshot.ts
+++ b/src/snapshot/aria-snapshot.ts
@@ -285,7 +285,9 @@ function buildAriaSnapshotRefs(nodes: AriaNode[], markedRefs: Set<string>): Role
     const key = `${role}:${name ?? ''}`;
     const nth = counts.get(key) ?? 0;
     counts.set(key, nth + 1);
-    refsByKey.set(key, [...(refsByKey.get(key) ?? []), node.ref]);
+    const refsForKey = refsByKey.get(key);
+    if (refsForKey) refsForKey.push(node.ref);
+    else refsByKey.set(key, [node.ref]);
     refs[node.ref] = {
       role,
       ...(name !== undefined ? { name } : {}),

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -135,31 +135,40 @@ function removeNthFromNonDuplicates(refs: RoleRefs, tracker: ReturnType<typeof c
   }
 }
 
+interface CompactTreeEntry {
+  line: string;
+  keep: boolean;
+  hasRef: boolean;
+  indent: number;
+}
+
 function compactTree(tree: string): string {
   const lines = tree.split('\n');
-  const result: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (line.includes('[ref=')) {
-      result.push(line);
-      continue;
-    }
-    if (line.includes(':') && !line.trimEnd().endsWith(':')) {
-      result.push(line);
-      continue;
-    }
-    const currentIndent = getIndentLevel(line);
-    let hasRelevantChildren = false;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (getIndentLevel(lines[j]) <= currentIndent) break;
-      if (lines[j]?.includes('[ref=')) {
-        hasRelevantChildren = true;
-        break;
-      }
-    }
-    if (hasRelevantChildren) result.push(line);
+  const entries: CompactTreeEntry[] = [];
+  const stack: { entry: CompactTreeEntry; indent: number }[] = [];
+  const finishEntry = (): void => {
+    const current = stack.pop();
+    if (!current) return;
+    current.entry.keep ||= current.entry.hasRef;
+    if (current.entry.hasRef && stack.length > 0) stack[stack.length - 1].entry.hasRef = true;
+  };
+  for (const line of lines) {
+    const indent = getIndentLevel(line);
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) finishEntry();
+    const entry: CompactTreeEntry = {
+      line,
+      keep: line.includes('[ref=') || (line.includes(':') && !line.trimEnd().endsWith(':')),
+      hasRef: line.includes('[ref='),
+      indent,
+    };
+    entries.push(entry);
+    stack.push({ entry, indent });
   }
-  return result.join('\n');
+  while (stack.length > 0) finishEntry();
+  return entries
+    .filter((entry) => entry.keep)
+    .map((entry) => entry.line)
+    .join('\n');
 }
 
 export interface SnapshotBuildOptions {


### PR DESCRIPTION
Syncs browserclaw with OpenClaw browser SDK changes across the **2026.6.8 → 2026.6.11** stable releases (walked 6.9, 6.10, 6.11). Version bump 0.19.4 → 0.19.5.

## Ported (both from PR #96072, "index role snapshot references", 6.11 — output-equivalent perf)

- **`compactTree` (ref-map.ts)** — rewrote the O(n²) child-scan as a single-pass stack walk. Proven output-identical to the previous implementation by two independent harnesses over 600k+ inputs (random trees + indent-anomaly / odd-indent / trailing-whitespace / blank-line cases), zero diffs. `getIndentLevel` unchanged.
- **`buildAriaSnapshotRefs` (aria-snapshot.ts)** — `refsByKey` accumulation changed from per-iteration array spread to push-or-set (one line). **`nth` handling deliberately preserved** — browserclaw's always-add-then-delete-for-singletons is a pre-existing divergence from OC, and 6.11 didn't touch that line.

## Not ported (registered)

- **Managed-Chrome stale-CDP-listener recovery** (6.9, PR #93670 — `ensureManagedChromePortAvailable` / `recoverOwnedStaleManagedChromeCdpListener` + ~22 `/proc`/`ps`/`lsof` identity helpers). OC server managed-profile fixed-port reclaim; browserclaw uses free-port selection + fail-fast on caller-pinned ports + dead-pid-only lock clearing + caller-owned proc cleanup, and omits `diagnoseChromeCdp` (KD #65) which the recovery trigger depends on. → **new KD #84**.
- **`cdp.helpers` magic-number→constant refactor** (6.9) — lives inside `resolveCdpReachabilityTimeouts`, which browserclaw doesn't ship (already covered by the OC-2026.6.1 note on KD #80 / KD #20/#21).
- **`buildCdpRoleSnapshot` `nodesByRef`** (6.11) — browserclaw has no tree-based CDP role-snapshot pipeline (`buildRoleTree`/`renderRoleTree`/`tree.find`-by-ref); only the `refsByKey` line mapped over.

6.9→6.10 was fully byte-identical across every mapped bundle (rebuild churn only). The `number-coercion` filename swap was chunk-inlining, content-identical.

## Verification

- `npm run typecheck`, `npm run build`, `npm run format:check` — all clean
- Full suite **952/952** green (snapshot suite 69/69)
- Method: deterministic `compare.ts` on all three hops + a 6-agent adversarial workflow to judge applicability and prove output-equivalence before porting