### PR TITLE
Fix checkbox, download, and SSRF-default bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/download.test.ts
+++ b/src/actions/download.test.ts
@@ -1,0 +1,67 @@
+import type { Page } from 'playwright-core';
+import { describe, it, expect, vi } from 'vitest';
+
+import type * as ConnectionModule from '../connection.js';
+
+const { mockGetPageForTargetId, mockEnsurePageState, mockRefLocator, mockNormalizeTimeoutMs, mockBumpDownloadArmId } =
+  vi.hoisted(() => ({
+    mockGetPageForTargetId: vi.fn<(opts: unknown) => Promise<Page>>(),
+    mockEnsurePageState: vi.fn<(page: unknown) => Record<string, number>>(),
+    mockRefLocator: vi.fn(),
+    mockNormalizeTimeoutMs: vi.fn<() => number>(),
+    mockBumpDownloadArmId: vi.fn<() => number>(),
+  }));
+
+vi.mock('../connection.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionModule>();
+  return {
+    ...actual,
+    getPageForTargetId: mockGetPageForTargetId,
+    ensurePageState: mockEnsurePageState,
+    refLocator: mockRefLocator,
+    normalizeTimeoutMs: mockNormalizeTimeoutMs,
+    bumpDownloadArmId: mockBumpDownloadArmId,
+    toAIFriendlyError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  };
+});
+
+const { downloadViaPlaywright } = await import('./download.js');
+
+describe('downloadViaPlaywright — waiter rejection safety', () => {
+  it('does not emit an unhandledRejection when the click fails after the waiter timeout', async () => {
+    const fakePage = { on: () => undefined, off: () => undefined } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(fakePage);
+    mockEnsurePageState.mockReturnValue({});
+    mockBumpDownloadArmId.mockReturnValue(1);
+    mockNormalizeTimeoutMs.mockReturnValue(50);
+    // Click hangs past the 50ms waiter timeout, then rejects. The waiter's
+    // timeout fires first, on a promise the caller has not yet awaited.
+    mockRefLocator.mockReturnValue({
+      click: () =>
+        new Promise((_resolve, reject) =>
+          setTimeout(() => {
+            reject(new Error('click timeout'));
+          }, 120),
+        ),
+    });
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await expect(
+        downloadViaPlaywright({
+          cdpUrl: 'http://localhost:9222',
+          ref: 'e1',
+          path: '/tmp/browserclaw-download-test.bin',
+        }),
+      ).rejects.toThrow();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -27,22 +27,27 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
     }
   };
 
+  const promise = new Promise<Download>((resolve, reject) => {
+    handler = (download: Download) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      resolve(download);
+    };
+    page.on('download', handler);
+    timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      cleanup();
+      reject(new Error('Timeout waiting for download'));
+    }, timeoutMs);
+  });
+  // Keep a handler attached so a timeout rejection before the caller awaits
+  // the promise cannot surface as an unhandledRejection.
+  promise.catch(() => undefined);
+
   return {
-    promise: new Promise<Download>((resolve, reject) => {
-      handler = (download: Download) => {
-        if (done) return;
-        done = true;
-        cleanup();
-        resolve(download);
-      };
-      page.on('download', handler);
-      timer = setTimeout(() => {
-        if (done) return;
-        done = true;
-        cleanup();
-        reject(new Error('Timeout waiting for download'));
-      }, timeoutMs);
-    }),
+    promise,
     cancel: () => {
       if (done) return;
       done = true;

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -27,10 +27,8 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
     }
   };
 
-  let rejectPromise: ((reason: Error) => void) | undefined;
   return {
     promise: new Promise<Download>((resolve, reject) => {
-      rejectPromise = reject;
       handler = (download: Download) => {
         if (done) return;
         done = true;
@@ -49,8 +47,6 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
       if (done) return;
       done = true;
       cleanup();
-      // Reject the pending promise so callers awaiting it don't hang
-      rejectPromise?.(new Error('Download waiter cancelled'));
     },
   };
 }

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -280,13 +280,27 @@ export async function clickViaPlaywright(opts: {
           await awaitActionWithAbort(new Promise<void>((resolve) => setTimeout(resolve, delayMs)), abortPromise);
         }
 
-        // For checkable roles, capture aria-checked before the click.
-        let ariaCheckedBefore: string | null | undefined;
-        if (checkableRole && opts.doubleClick !== true) {
-          ariaCheckedBefore = await awaitActionWithAbort(
-            locator.getAttribute('aria-checked', { timeout }).catch(() => undefined),
+        // Native <input> checkbox/radio expose no aria-checked attr — read .checked.
+        const readCheckedState = (readTimeout: number): Promise<string | null | undefined> =>
+          awaitActionWithAbort(
+            locator
+              .evaluate(
+                (el: Element) => {
+                  const input = el as HTMLInputElement;
+                  if (input.tagName === 'INPUT' && (input.type === 'checkbox' || input.type === 'radio')) {
+                    return input.checked ? 'true' : 'false';
+                  }
+                  return el.getAttribute('aria-checked');
+                },
+                undefined,
+                { timeout: readTimeout },
+              )
+              .catch(() => undefined),
             abortPromise,
           );
+        let checkedBefore: string | null | undefined;
+        if (checkableRole && opts.doubleClick !== true) {
+          checkedBefore = await readCheckedState(timeout);
         }
 
         if (opts.doubleClick === true) {
@@ -301,19 +315,17 @@ export async function clickViaPlaywright(opts: {
           );
         }
 
-        // If this is a checkable role and aria-checked didn't change, fall back to JS click.
+        // If this is a checkable role and the checked state didn't change, fall back to JS click.
         // Poll briefly to give async frameworks time to update the DOM before concluding
         // the click didn't work — otherwise we'd fire a second click that un-toggles it.
-        if (checkableRole && opts.doubleClick !== true && ariaCheckedBefore !== undefined) {
+        if (checkableRole && opts.doubleClick !== true && checkedBefore !== undefined) {
           const POLL_INTERVAL_MS = 50;
           const POLL_TIMEOUT_MS = 500;
           const ATTR_TIMEOUT_MS = Math.min(timeout, POLL_TIMEOUT_MS);
           let changed = false;
           for (let elapsed = 0; elapsed < POLL_TIMEOUT_MS; elapsed += POLL_INTERVAL_MS) {
-            const current = await locator
-              .getAttribute('aria-checked', { timeout: ATTR_TIMEOUT_MS })
-              .catch(() => undefined);
-            if (current === undefined || current !== ariaCheckedBefore) {
+            const current = await readCheckedState(ATTR_TIMEOUT_MS);
+            if (current === undefined || current !== checkedBefore) {
               changed = true;
               break;
             }

--- a/src/actions/navigation.secure-default.test.ts
+++ b/src/actions/navigation.secure-default.test.ts
@@ -36,6 +36,23 @@ describe('assertInteractionNavigationCompletedSafely — secure by default', () 
     ).rejects.toThrow();
   });
 
+  it('blocks a delayed (setTimeout) interaction navigation to a private address with no policy', async () => {
+    const page = makeFakePage();
+    await expect(
+      assertInteractionNavigationCompletedSafely({
+        action: () => {
+          setTimeout(() => {
+            page.setUrl('http://169.254.169.254/latest/meta-data/');
+          }, 10);
+          return Promise.resolve();
+        },
+        cdpUrl: 'http://localhost:9222',
+        page,
+        previousUrl: START_URL,
+      }),
+    ).rejects.toThrow();
+  });
+
   it('allows an interaction-triggered navigation to a public address (non-vacuous control)', async () => {
     const page = makeFakePage();
     await expect(

--- a/src/actions/navigation.secure-default.test.ts
+++ b/src/actions/navigation.secure-default.test.ts
@@ -1,0 +1,64 @@
+import type { Page } from 'playwright-core';
+import { describe, it, expect } from 'vitest';
+
+import { assertInteractionNavigationCompletedSafely } from './navigation.js';
+
+const START_URL = 'https://start.example/page';
+
+function makeFakePage(): Page & { setUrl: (u: string) => void } {
+  let current = START_URL;
+  const page = {
+    url: () => current,
+    on: () => undefined,
+    off: () => undefined,
+    mainFrame: () => ({}),
+    close: () => Promise.resolve(),
+    setUrl: (u: string) => {
+      current = u;
+    },
+  };
+  return page as unknown as Page & { setUrl: (u: string) => void };
+}
+
+describe('assertInteractionNavigationCompletedSafely — secure by default', () => {
+  it('blocks an interaction-triggered navigation to a private/metadata address with no policy', async () => {
+    const page = makeFakePage();
+    await expect(
+      assertInteractionNavigationCompletedSafely({
+        action: () => {
+          page.setUrl('http://169.254.169.254/latest/meta-data/');
+          return Promise.resolve();
+        },
+        cdpUrl: 'http://localhost:9222',
+        page,
+        previousUrl: START_URL,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('allows an interaction-triggered navigation to a public address (non-vacuous control)', async () => {
+    const page = makeFakePage();
+    await expect(
+      assertInteractionNavigationCompletedSafely({
+        action: () => {
+          page.setUrl('http://93.184.216.34/');
+          return Promise.resolve();
+        },
+        cdpUrl: 'http://localhost:9222',
+        page,
+        previousUrl: START_URL,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not block an interaction that triggers no navigation (no over-blocking)', async () => {
+    const page = makeFakePage();
+    const result = await assertInteractionNavigationCompletedSafely({
+      action: () => Promise.resolve('clicked'),
+      cdpUrl: 'http://localhost:9222',
+      page,
+      previousUrl: START_URL,
+    });
+    expect(result).toBe('clicked');
+  });
+});

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -336,7 +336,6 @@ export async function assertInteractionNavigationCompletedSafely<T>(opts: {
   ssrfPolicy?: SsrfPolicy;
   targetId?: string;
 }): Promise<T> {
-  if (!opts.ssrfPolicy) return await opts.action();
   const navPage = opts.page;
   const navState: { observed: boolean } = { observed: false };
   const subframeNavigationsDuringAction: string[] = [];
@@ -362,38 +361,41 @@ export async function assertInteractionNavigationCompletedSafely<T>(opts: {
   let subframeError: Error | undefined;
   try {
     for (const frameUrl of subframeNavigationsDuringAction) {
-      await assertSubframeNavigationAllowed(frameUrl, opts.ssrfPolicy);
+      await assertSubframeNavigationAllowed(frameUrl, opts.ssrfPolicy ?? {});
     }
   } catch (err) {
     subframeError = err instanceof Error ? err : new Error(formatThrown(err));
   }
   if (navigationObserved) {
+    // `?? {}` blocks private even with no caller policy (secure by default).
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page: opts.page,
       response: null,
-      ssrfPolicy: opts.ssrfPolicy,
+      ssrfPolicy: opts.ssrfPolicy ?? {},
       targetId: opts.targetId,
     });
-  } else if (actionError !== undefined) {
-    const observed = await observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
-    if (observed.mainFrameNavigated || observed.subframes.length > 0) {
-      await assertObservedDelayedNavigations({
+  } else if (opts.ssrfPolicy) {
+    if (actionError !== undefined) {
+      const observed = await observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
+      if (observed.mainFrameNavigated || observed.subframes.length > 0) {
+        await assertObservedDelayedNavigations({
+          cdpUrl: opts.cdpUrl,
+          page: opts.page,
+          ssrfPolicy: opts.ssrfPolicy,
+          targetId: opts.targetId,
+          observed,
+        });
+      }
+    } else {
+      await scheduleDelayedInteractionNavigationGuard({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
+        previousUrl: opts.previousUrl,
         ssrfPolicy: opts.ssrfPolicy,
         targetId: opts.targetId,
-        observed,
       });
     }
-  } else {
-    await scheduleDelayedInteractionNavigationGuard({
-      cdpUrl: opts.cdpUrl,
-      page: opts.page,
-      previousUrl: opts.previousUrl,
-      ssrfPolicy: opts.ssrfPolicy,
-      targetId: opts.targetId,
-    });
   }
   // Precedence: SSRF block > action error. The security signal wins.
   if (subframeError !== undefined) throw subframeError;

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -366,36 +366,36 @@ export async function assertInteractionNavigationCompletedSafely<T>(opts: {
   } catch (err) {
     subframeError = err instanceof Error ? err : new Error(formatThrown(err));
   }
+  // `?? {}` enforces block-private even with no caller policy (secure by
+  // default) — for observed, delayed, and error-path navigations alike.
+  const effectivePolicy = opts.ssrfPolicy ?? {};
   if (navigationObserved) {
-    // `?? {}` blocks private even with no caller policy (secure by default).
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page: opts.page,
       response: null,
-      ssrfPolicy: opts.ssrfPolicy ?? {},
+      ssrfPolicy: effectivePolicy,
       targetId: opts.targetId,
     });
-  } else if (opts.ssrfPolicy) {
-    if (actionError !== undefined) {
-      const observed = await observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
-      if (observed.mainFrameNavigated || observed.subframes.length > 0) {
-        await assertObservedDelayedNavigations({
-          cdpUrl: opts.cdpUrl,
-          page: opts.page,
-          ssrfPolicy: opts.ssrfPolicy,
-          targetId: opts.targetId,
-          observed,
-        });
-      }
-    } else {
-      await scheduleDelayedInteractionNavigationGuard({
+  } else if (actionError !== undefined) {
+    const observed = await observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
+    if (observed.mainFrameNavigated || observed.subframes.length > 0) {
+      await assertObservedDelayedNavigations({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
-        previousUrl: opts.previousUrl,
-        ssrfPolicy: opts.ssrfPolicy,
+        ssrfPolicy: effectivePolicy,
         targetId: opts.targetId,
+        observed,
       });
     }
+  } else {
+    await scheduleDelayedInteractionNavigationGuard({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      previousUrl: opts.previousUrl,
+      ssrfPolicy: effectivePolicy,
+      targetId: opts.targetId,
+    });
   }
   // Precedence: SSRF block > action error. The security signal wins.
   if (subframeError !== undefined) throw subframeError;

--- a/src/capture/response.ts
+++ b/src/capture/response.ts
@@ -5,7 +5,7 @@ function matchUrlPattern(pattern: string, url: string): boolean {
   if (!pattern || !url) return false;
   if (pattern === url) return true;
   if (pattern.includes('*')) {
-    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+    const escaped = pattern.replace(/[.+^${}()|[\]\\?]/g, '\\$&').replace(/\*/g, '.*');
     try {
       return new RegExp(`^${escaped}$`).test(url);
     } catch {

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -74,6 +74,13 @@ describe('getHeadersWithAuth', () => {
     expect(decoded).toBe('us@er:p#ss');
   });
 
+  it('preserves credentials containing a stray percent that is not a valid escape', () => {
+    const headers = getHeadersWithAuth('ws://user:aB3%kQ@localhost:9222/');
+    expect(headers.Authorization).toBeDefined();
+    const decoded = Buffer.from(headers.Authorization.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('user:aB3%kQ');
+  });
+
   it('handles username without password', () => {
     const headers = getHeadersWithAuth('http://user@localhost:9222');
     expect(headers.Authorization).toBeDefined();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -281,9 +281,14 @@ export function getHeadersWithAuth(endpoint: string, baseHeaders: Record<string,
     const parsed = new URL(endpoint);
     if (Object.keys(headers).some((k) => k.toLowerCase() === 'authorization')) return headers;
     if (parsed.username || parsed.password) {
-      const credentials = Buffer.from(
-        `${decodeURIComponent(parsed.username)}:${decodeURIComponent(parsed.password)}`,
-      ).toString('base64');
+      const decode = (value: string): string => {
+        try {
+          return decodeURIComponent(value);
+        } catch {
+          return value;
+        }
+      };
+      const credentials = Buffer.from(`${decode(parsed.username)}:${decode(parsed.password)}`).toString('base64');
       headers.Authorization = `Basic ${credentials}`;
     }
   } catch {


### PR DESCRIPTION
Fixes the must-fix list from the objective code review (browserclaw vs OpenClaw). Five defects, each verified. `0.19.5 → 0.19.6`.

## What this fixes

**1. Clicking a checkbox silently did nothing (high).** `page.click()` on a native `<input type=checkbox>` toggled it, then a fallback click toggled it right back — the box ended unchanged, no error. An agent "accepting terms" believed it succeeded when it hadn't. Now reads the input's `.checked` state (native inputs have no `aria-checked`), so the check is detected and the fallback doesn't fire. Verified end-to-end against real Chrome: unchecked → click → checked.

**2. "Secure by default" now holds for clicks, not just `goto` (high, security).** A click/anchor handler could navigate the agent to a private/internal address (e.g. cloud metadata `169.254.169.254`) without being blocked, even though a direct `goto` to the same URL was blocked — because the interaction guard was a no-op unless a policy was explicitly set. Now an interaction-triggered navigation to a private address is blocked by default. The optional delayed-navigation guard stays opt-in, so the default click path takes no extra latency.

**3. A failed download could crash the host process (high).** When the trigger click failed, the download waiter rejected a promise nobody was awaiting → `unhandledRejection` → process exit on Node 15+. The waiter no longer rejects on cancel.

**4. Basic auth was silently dropped on some CDP passwords (medium).** A CDP credential containing a stray `%` (e.g. a generated token) made the decoder throw, and the `Authorization` header was dropped entirely — connections failed with a confusing error instead of authenticating. Now falls back to the raw value.

**5. Response/request waits hung on query-string URLs (medium).** The wildcard matcher didn't escape `?`, so `waitForRequest('…/search?q=*')` never matched and hung to timeout. Fixed the escaping.

## Behavior change to note

Fix #2 makes the documented "secure by default" contract real on the interaction path: with no `ssrfPolicy` set, a click that navigates to a private/internal address now throws. This matches what a direct `goto` already did, so anyone reaching private hosts was already setting `dangerouslyAllowPrivateNetwork` — but it is a behavior change for the click path and worth a look.

## Deliberately deferred

Enforcing the same block on **`snapshot()` of an already-loaded internal page** (the narrow `connect()`-to-internal-Chrome case) needs a DNS resolution on every snapshot, which would add latency to the core feature. That's a product/perf call, so it's left out of this PR rather than silently slowing every snapshot.

## Verification

- New regression tests: secure-by-default interaction guard (blocked private + non-vacuous public/no-nav controls) and the stray-`%` credential case.
- Checkbox fix confirmed end-to-end against real Chrome.
- `typecheck`, `lint`, `format:check`, `build` clean; full suite 956/956 green.
