### PR TITLE
Resolve code review quality findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.5",
+  "version": "0.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.5",
+      "version": "0.19.7",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/anti-bot.test.ts
+++ b/src/anti-bot.test.ts
@@ -1,0 +1,48 @@
+import type { Page } from 'playwright-core';
+import { describe, it, expect, vi } from 'vitest';
+
+import type * as ConnectionModule from './connection.js';
+
+const { mockGetPageForTargetId, mockEnsurePageState, mockNormalizeTimeoutMs } = vi.hoisted(() => ({
+  mockGetPageForTargetId: vi.fn<(opts: unknown) => Promise<Page>>(),
+  mockEnsurePageState: vi.fn<(page: unknown) => Record<string, unknown>>(),
+  mockNormalizeTimeoutMs: vi.fn<() => number>(),
+}));
+
+vi.mock('./connection.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionModule>();
+  return {
+    ...actual,
+    getPageForTargetId: mockGetPageForTargetId,
+    ensurePageState: mockEnsurePageState,
+    normalizeTimeoutMs: mockNormalizeTimeoutMs,
+  };
+});
+
+const { waitForChallengeViaPlaywright } = await import('./anti-bot.js');
+
+describe('waitForChallengeViaPlaywright — evaluate error handling', () => {
+  it('propagates a non-navigation evaluate error instead of reporting the challenge cleared', async () => {
+    const evaluate = vi.fn().mockRejectedValue(new Error('Target page, context or browser has been closed'));
+    const page = { evaluate, waitForLoadState: vi.fn().mockResolvedValue(undefined) } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(page);
+    mockEnsurePageState.mockReturnValue({});
+    mockNormalizeTimeoutMs.mockReturnValue(15000);
+
+    await expect(waitForChallengeViaPlaywright({ cdpUrl: 'http://localhost:9222' })).rejects.toThrow(/closed/i);
+  });
+
+  it('treats a navigation-race context-destroyed error as the challenge clearing', async () => {
+    const evaluate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Execution context was destroyed, most likely because of a navigation.'))
+      .mockResolvedValueOnce(null);
+    const page = { evaluate, waitForLoadState: vi.fn().mockResolvedValue(undefined) } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(page);
+    mockEnsurePageState.mockReturnValue({});
+    mockNormalizeTimeoutMs.mockReturnValue(15000);
+
+    const result = await waitForChallengeViaPlaywright({ cdpUrl: 'http://localhost:9222' });
+    expect(result).toEqual({ resolved: true, challenge: null });
+  });
+});

--- a/src/anti-bot.ts
+++ b/src/anti-bot.ts
@@ -92,12 +92,26 @@ export async function waitForChallengeViaPlaywright(opts: {
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 15000);
   const poll = Math.max(250, Math.min(5000, opts.pollMs ?? 500));
 
+  const isNavigationRaceError = (err: unknown): boolean =>
+    err instanceof Error &&
+    /execution context was destroyed|because of a navigation|frame was detached/i.test(err.message);
+
   const detect = async (): Promise<ChallengeInfo | null> => {
     try {
       return parseChallengeResult(await page.evaluate(DETECT_CHALLENGE_SCRIPT));
-    } catch {
-      // execution context destroyed mid-navigation — the challenge usually cleared via redirect
-      return null;
+    } catch (err) {
+      // Only a navigation race (context destroyed by a redirect) is treated as
+      // "re-check"; a closed tab, crash, or CDP disconnect must propagate.
+      if (!isNavigationRaceError(err)) throw err;
+      await page.waitForLoadState('domcontentloaded', { timeout: 5000 }).catch(() => {
+        /* best-effort settle */
+      });
+      try {
+        return parseChallengeResult(await page.evaluate(DETECT_CHALLENGE_SCRIPT));
+      } catch (retryErr) {
+        if (isNavigationRaceError(retryErr)) return null;
+        throw retryErr;
+      }
     }
   };
 

--- a/src/anti-bot.ts
+++ b/src/anti-bot.ts
@@ -92,7 +92,14 @@ export async function waitForChallengeViaPlaywright(opts: {
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 15000);
   const poll = Math.max(250, Math.min(5000, opts.pollMs ?? 500));
 
-  const detect = async () => parseChallengeResult(await page.evaluate(DETECT_CHALLENGE_SCRIPT));
+  const detect = async (): Promise<ChallengeInfo | null> => {
+    try {
+      return parseChallengeResult(await page.evaluate(DETECT_CHALLENGE_SCRIPT));
+    } catch {
+      // execution context destroyed mid-navigation — the challenge usually cleared via redirect
+      return null;
+    }
+  };
 
   // Check if there's actually a challenge present
   const initial = await detect();

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1669,7 +1669,7 @@ export class CrawlPage {
             fn: rule.fn,
             ssrfPolicy: this.ssrfPolicy,
           });
-          const passed = result !== null && result !== undefined && result !== false && result !== 0 && result !== '';
+          const passed = Boolean(result);
           checks.push({
             rule: 'fn',
             passed,

--- a/src/capture/response.ts
+++ b/src/capture/response.ts
@@ -30,7 +30,14 @@ export async function responseBodyViaPlaywright(opts: {
   if (!pattern) throw new Error('url is required');
 
   const response = await page.waitForResponse((resp) => matchUrlPattern(pattern, resp.url()), { timeout });
-  let body = await response.text();
+  let body: string;
+  try {
+    body = await response.text();
+  } catch (err) {
+    throw new Error(
+      `Failed to read response body for "${pattern}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   let truncated = false;
 
   const maxChars =

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -172,7 +172,8 @@ export function refLocator(page: Page, ref: string) {
     // Warn if refs are stale
     if (state?.roleRefsStoredAt !== undefined) {
       const ageMs = Date.now() - state.roleRefsStoredAt;
-      if (ageMs > REFS_STALENESS_THRESHOLD_MS) {
+      if (ageMs > REFS_STALENESS_THRESHOLD_MS && state.roleRefsStaleWarned !== state.roleRefsStoredAt) {
+        state.roleRefsStaleWarned = state.roleRefsStoredAt;
         console.warn(
           `[browserclaw] refs are ${String(Math.round(ageMs / 1000))}s old — consider re-snapshotting for fresh refs`,
         );

--- a/src/snapshot/ref-map.test.ts
+++ b/src/snapshot/ref-map.test.ts
@@ -164,5 +164,24 @@ describe('buildRoleSnapshotFromAiSnapshot', () => {
       expect(refs.e11).toBeDefined();
       expect(refs.e11.name).toBe('B');
     });
+
+    it('does not store an undefined name for a ref line with no accessible name', () => {
+      const { refs } = buildRoleSnapshotFromAiSnapshot('- button [ref=e5]');
+      expect(refs.e5).toBeDefined();
+      expect('name' in refs.e5).toBe(false);
+    });
+  });
+});
+
+describe('unnamed content/landmark roles do not get refs', () => {
+  it('assigns no ref to an unnamed landmark role', () => {
+    const { snapshot, refs } = buildRoleSnapshotFromAriaSnapshot('- navigation');
+    expect(snapshot).not.toContain('[ref=');
+    expect(Object.keys(refs)).toHaveLength(0);
+  });
+
+  it('assigns a ref to a named landmark role', () => {
+    const { refs } = buildRoleSnapshotFromAriaSnapshot('- navigation "Primary"');
+    expect(Object.values(refs).some((r) => r.role === 'navigation' && r.name === 'Primary')).toBe(true);
   });
 });

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -241,7 +241,7 @@ export function buildRoleSnapshotFromAriaSnapshot(
     const isContent = CONTENT_ROLES.has(role);
     const isStructural = STRUCTURAL_ROLES.has(role);
     if (options.compact === true && isStructural && !name) continue;
-    if (!(isInteractive || (isContent && name !== ''))) {
+    if (!(isInteractive || (isContent && name))) {
       result.push(line);
       continue;
     }
@@ -353,7 +353,7 @@ export function buildRoleSnapshotFromAiSnapshot(
     const ref = parseAiSnapshotRef(suffix);
     const state = parseStateFromSuffix(suffix);
     if (ref !== null) {
-      refs[ref] = { role, ...(name !== '' ? { name } : {}), ...state };
+      refs[ref] = { role, ...(name ? { name } : {}), ...state };
       out.push(line);
     } else if (INTERACTIVE_ROLES.has(role)) {
       const generatedRef = nextGeneratedRef();

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,7 +275,7 @@ export interface SnapshotOptions {
    * - `'role'` — uses Playwright's `ariaSnapshot()` + `getByRole()` resolution
    */
   mode?: 'role' | 'aria';
-  /** Timeout in milliseconds for the snapshot operation (role mode only, default: 5000) */
+  /** Timeout in milliseconds for the snapshot operation (default: 5000) */
   timeoutMs?: number;
   /**
    * How refs are stored for role-mode snapshots.
@@ -618,9 +618,8 @@ export interface HttpCredentials {
   clear?: boolean;
 }
 
-// ── Context State (internal) ──
+// ── Context State ──
 
-/** @internal */
 export interface ContextState {
   traceActive: boolean;
 }
@@ -638,6 +637,7 @@ export interface PageState {
   roleRefsFrameSelector?: string;
   roleRefsMode?: 'role' | 'aria';
   roleRefsStoredAt?: number;
+  roleRefsStaleWarned?: number;
   armIdUpload: number;
   armIdDialog: number;
   armIdDownload: number;


### PR DESCRIPTION
Wave 1 of driving the review findings to zero: the low/info correctness fixes. `0.19.6 → 0.19.7` (package.json + package-lock.json, which was stale at 0.19.5).

## Fixes
- **Auth check no longer passes on `NaN`** — `isAuthenticated` `fn` rule used explicit inequalities that let `NaN` through; now uses real truthiness. Closes #132
- **AI snapshot no longer stores `name: undefined`** — ref'd lines with no accessible name omit the key (matches the interactive-ref path). Closes #134
- **Role-mode snapshot no longer refs unnamed landmarks** — unnamed content/landmark roles (nav, main, article, listitem) get no ref; named ones still do. Closes #126
- **`waitForChallenge` resolves instead of rejecting when a challenge clears via navigation** — the detect `evaluate` is guarded against context-destroyed-mid-redirect. Closes #130
- **`responseBody` wraps an unreadable-body error** with context instead of leaking the raw Playwright error. Closes #128
- **Stale-ref warning throttled** to once per snapshot batch instead of every ref resolution. Closes #122
- **`SnapshotOptions.timeoutMs` doc** no longer says "role mode only" (aria mode honors it too). Closes #135
- **`ContextState` `@internal` tag removed** — it's publicly re-exported via `index.ts` (needed by `ensureContextState`), so the tag was inconsistent. Closes #136

New regression tests for the two ref-map fixes. Full gate green: typecheck, lint, format:check, build, 961/961 tests.

The SSRF security mediums (#116–#120) and the remaining investigation-needed items (#123–#125, #127, #129, #131, #133) follow in separate focused PRs. #121 (write-only role-ref cache) is closed separately as by-design (intentional KD-#46 divergence).
