### PR TITLE
Harden SSRF across allowlist and action paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.5",
+  "version": "0.19.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.5",
+      "version": "0.19.8",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.6",
+  "version": "0.19.8",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -180,6 +180,7 @@ export async function executeSingleAction(
         targetId: effectiveTargetId,
         fields: action.fields,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case 'resize':

--- a/src/actions/evaluate.frames.test.ts
+++ b/src/actions/evaluate.frames.test.ts
@@ -1,0 +1,46 @@
+import type { Page } from 'playwright-core';
+import { describe, it, expect, vi } from 'vitest';
+
+import type * as ConnectionModule from '../connection.js';
+
+const { mockGetPageForTargetId } = vi.hoisted(() => ({
+  mockGetPageForTargetId: vi.fn<(opts: unknown) => Promise<Page>>(),
+}));
+
+vi.mock('../connection.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionModule>();
+  return { ...actual, getPageForTargetId: mockGetPageForTargetId };
+});
+
+const { evaluateInAllFramesViaPlaywright } = await import('./evaluate.js');
+
+describe('evaluateInAllFramesViaPlaywright — per-frame SSRF validation', () => {
+  it('skips an SSRF-blocked frame and evaluates only allowed frames', async () => {
+    const publicFrame = {
+      url: () => 'http://93.184.216.34/',
+      name: () => 'main',
+      evaluate: vi.fn().mockResolvedValue(1),
+    };
+    const metadataFrame = {
+      url: () => 'http://169.254.169.254/',
+      name: () => 'meta',
+      evaluate: vi.fn().mockResolvedValue('secret'),
+    };
+    const page = {
+      url: () => 'http://93.184.216.34/',
+      frames: () => [publicFrame, metadataFrame],
+    } as unknown as Page;
+    mockGetPageForTargetId.mockResolvedValue(page);
+
+    const results = await evaluateInAllFramesViaPlaywright({
+      cdpUrl: 'http://localhost:9222',
+      fn: '() => 1',
+      ssrfPolicy: {},
+    });
+
+    expect(publicFrame.evaluate).toHaveBeenCalledTimes(1);
+    expect(metadataFrame.evaluate).not.toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0].frameUrl).toBe('http://93.184.216.34/');
+  });
+});

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -8,7 +8,7 @@ import {
 } from '../connection.js';
 import type { SsrfPolicy } from '../types.js';
 
-import { assertInteractionNavigationCompletedSafely } from './navigation.js';
+import { assertInteractionNavigationCompletedSafely, assertPageNavigationCompletedSafely } from './navigation.js';
 
 export interface FrameEvalResult {
   frameUrl: string;
@@ -35,6 +35,15 @@ export async function evaluateInAllFramesViaPlaywright(opts: {
     targetId: opts.targetId,
     ssrfPolicy: opts.ssrfPolicy,
   });
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
   const frames = page.frames();
   const results: FrameEvalResult[] = [];
 
@@ -163,6 +172,16 @@ export async function evaluateViaPlaywright(opts: {
     ssrfPolicy: opts.ssrfPolicy,
   });
   ensurePageState(page);
+
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   const outerTimeout = normalizeTimeoutMs(opts.timeoutMs, 20000);
   // Browser-side timeout must be strictly less than outer timeout so Playwright

--- a/src/actions/evaluate.ts
+++ b/src/actions/evaluate.ts
@@ -6,6 +6,7 @@ import {
   forceDisconnectPlaywrightConnection,
   tryTerminateExecutionViaCdp,
 } from '../connection.js';
+import { assertBrowserNavigationResultAllowed } from '../security.js';
 import type { SsrfPolicy } from '../types.js';
 
 import { assertInteractionNavigationCompletedSafely, assertPageNavigationCompletedSafely } from './navigation.js';
@@ -48,6 +49,14 @@ export async function evaluateInAllFramesViaPlaywright(opts: {
   const results: FrameEvalResult[] = [];
 
   for (const frame of frames) {
+    if (opts.ssrfPolicy) {
+      try {
+        await assertBrowserNavigationResultAllowed({ url: frame.url(), ssrfPolicy: opts.ssrfPolicy });
+      } catch {
+        console.warn(`[browserclaw] skipping SSRF-blocked frame: ${frame.url()}`);
+        continue;
+      }
+    }
     try {
       // Runs in the frame's browser context (sandboxed), not in Node.js
       const result: unknown = await frame.evaluate((fnBody: string) => {

--- a/src/actions/interaction.fill.test.ts
+++ b/src/actions/interaction.fill.test.ts
@@ -1,0 +1,57 @@
+import type { Page, Locator } from 'playwright-core';
+import { describe, it, expect, vi } from 'vitest';
+
+import type * as ConnectionModule from '../connection.js';
+import { NavigationRaceError } from '../errors.js';
+
+const { mockGetRestoredPageForTarget, mockRefLocator, mockResolveTimeout } = vi.hoisted(() => ({
+  mockGetRestoredPageForTarget: vi.fn<(opts: unknown) => Promise<Page>>(),
+  mockRefLocator: vi.fn(),
+  mockResolveTimeout: vi.fn<() => number>(() => 5000),
+}));
+
+vi.mock('../connection.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionModule>();
+  return {
+    ...actual,
+    getRestoredPageForTarget: mockGetRestoredPageForTarget,
+    refLocator: mockRefLocator,
+    resolveInteractionTimeoutMs: mockResolveTimeout,
+  };
+});
+
+const { fillFormViaPlaywright } = await import('./interaction.js');
+
+describe('fillFormViaPlaywright — mid-fill navigation', () => {
+  it('throws NavigationRaceError instead of silently returning after a benign mid-fill navigation', async () => {
+    let url = 'http://93.184.216.34/form';
+    const page = {
+      url: () => url,
+      on: () => undefined,
+      off: () => undefined,
+      mainFrame: () => ({}),
+    } as unknown as Page;
+    mockGetRestoredPageForTarget.mockResolvedValue(page);
+
+    let fillCalls = 0;
+    const locator = {
+      fill: vi.fn(() => {
+        fillCalls += 1;
+        if (fillCalls === 1) url = 'http://93.184.216.34/done';
+        return Promise.resolve();
+      }),
+      setChecked: vi.fn(() => Promise.resolve()),
+    } as unknown as Locator;
+    mockRefLocator.mockReturnValue(locator);
+
+    await expect(
+      fillFormViaPlaywright({
+        cdpUrl: 'http://localhost:9222',
+        fields: [
+          { ref: 'e1', value: 'a' },
+          { ref: 'e2', value: 'b' },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(NavigationRaceError);
+  });
+});

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -491,56 +491,67 @@ export async function fillFormViaPlaywright(opts: {
   targetId?: string;
   fields: FormField[];
   timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  const previousUrl = page.url();
 
-  let filledCount = 0;
-  for (const field of opts.fields) {
-    const ref = field.ref.trim();
-    const type = (typeof field.type === 'string' ? field.type.trim() : '') || 'text';
-    const rawValue = field.value;
-    const value =
-      typeof rawValue === 'string'
-        ? rawValue
-        : typeof rawValue === 'number' || typeof rawValue === 'boolean'
-          ? String(rawValue)
-          : '';
+  await assertInteractionNavigationCompletedSafely({
+    action: async () => {
+      let filledCount = 0;
+      for (const field of opts.fields) {
+        const ref = field.ref.trim();
+        const type = (typeof field.type === 'string' ? field.type.trim() : '') || 'text';
+        const rawValue = field.value;
+        const value =
+          typeof rawValue === 'string'
+            ? rawValue
+            : typeof rawValue === 'number' || typeof rawValue === 'boolean'
+              ? String(rawValue)
+              : '';
 
-    if (!ref) continue;
-    const locator = refLocator(page, ref);
+        if (!ref) continue;
+        const locator = refLocator(page, ref);
 
-    if (type === 'checkbox' || type === 'radio') {
-      const checked = rawValue === true || rawValue === 1 || rawValue === '1' || rawValue === 'true';
-      try {
-        await locator.setChecked(checked, { timeout, force: true });
-      } catch (setCheckedErr) {
-        console.warn(
-          `[browserclaw] setChecked fallback for ref "${ref}": ${setCheckedErr instanceof Error ? setCheckedErr.message : String(setCheckedErr)}`,
-        );
+        if (type === 'checkbox' || type === 'radio') {
+          const checked = rawValue === true || rawValue === 1 || rawValue === '1' || rawValue === 'true';
+          try {
+            await locator.setChecked(checked, { timeout, force: true });
+          } catch (setCheckedErr) {
+            console.warn(
+              `[browserclaw] setChecked fallback for ref "${ref}": ${setCheckedErr instanceof Error ? setCheckedErr.message : String(setCheckedErr)}`,
+            );
+            try {
+              await setCheckedViaEvaluate(locator, checked);
+            } catch (err) {
+              const friendly = toAIFriendlyError(err, ref);
+              throw new Error(
+                `Failed at field "${ref}" (${String(filledCount)}/${String(opts.fields.length)} filled): ${friendly.message}`,
+              );
+            }
+          }
+          filledCount += 1;
+          continue;
+        }
+
         try {
-          await setCheckedViaEvaluate(locator, checked);
+          await locator.fill(value, { timeout });
         } catch (err) {
           const friendly = toAIFriendlyError(err, ref);
           throw new Error(
             `Failed at field "${ref}" (${String(filledCount)}/${String(opts.fields.length)} filled): ${friendly.message}`,
           );
         }
+        filledCount += 1;
       }
-      filledCount += 1;
-      continue;
-    }
-
-    try {
-      await locator.fill(value, { timeout });
-    } catch (err) {
-      const friendly = toAIFriendlyError(err, ref);
-      throw new Error(
-        `Failed at field "${ref}" (${String(filledCount)}/${String(opts.fields.length)} filled): ${friendly.message}`,
-      );
-    }
-    filledCount += 1;
-  }
+    },
+    cdpUrl: opts.cdpUrl,
+    page,
+    previousUrl,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
 }
 
 export async function scrollIntoViewViaPlaywright(opts: {

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -17,6 +17,7 @@ import {
   withPageScopedCdpClient,
   forceDisconnectPlaywrightConnection,
 } from '../connection.js';
+import { NavigationRaceError } from '../errors.js';
 import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
 import type { FormField, SsrfPolicy } from '../types.js';
 
@@ -500,8 +501,12 @@ export async function fillFormViaPlaywright(opts: {
   await assertInteractionNavigationCompletedSafely({
     action: async () => {
       let filledCount = 0;
+      let navigated = false;
       for (const field of opts.fields) {
-        if (didCrossDocumentUrlChange(page, previousUrl)) break;
+        if (didCrossDocumentUrlChange(page, previousUrl)) {
+          navigated = true;
+          break;
+        }
         const ref = field.ref.trim();
         const type = (typeof field.type === 'string' ? field.type.trim() : '') || 'text';
         const rawValue = field.value;
@@ -546,6 +551,7 @@ export async function fillFormViaPlaywright(opts: {
         }
         filledCount += 1;
       }
+      if (navigated) throw new NavigationRaceError({ fromUrl: previousUrl, toUrl: page.url() });
     },
     cdpUrl: opts.cdpUrl,
     page,

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -20,7 +20,7 @@ import {
 import { resolveStrictExistingPathsWithinRoot, DEFAULT_UPLOAD_DIR } from '../security.js';
 import type { FormField, SsrfPolicy } from '../types.js';
 
-import { assertInteractionNavigationCompletedSafely } from './navigation.js';
+import { assertInteractionNavigationCompletedSafely, didCrossDocumentUrlChange } from './navigation.js';
 
 type MouseButton = 'left' | 'right' | 'middle';
 type KeyModifier = 'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift';
@@ -501,6 +501,7 @@ export async function fillFormViaPlaywright(opts: {
     action: async () => {
       let filledCount = 0;
       for (const field of opts.fields) {
+        if (didCrossDocumentUrlChange(page, previousUrl)) break;
         const ref = field.ref.trim();
         const type = (typeof field.type === 'string' ? field.type.trim() : '') || 'text';
         const rawValue = field.value;

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -440,13 +440,6 @@ async function gotoPageWithNavigationGuard(opts: {
       await safeContinue(route);
       return;
     }
-    if (isTopLevel) {
-      const isRedirect = request.redirectedFrom() !== null;
-      if (!isRedirect && request.url() !== opts.url) {
-        await safeContinue(route);
-        return;
-      }
-    }
     try {
       await assertBrowserNavigationAllowed({ url: request.url(), ...navigationPolicy });
     } catch (err) {

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -138,7 +138,7 @@ export async function assertPageNavigationCompletedSafely(opts: {
 const INTERACTION_NAVIGATION_GRACE_MS = 250;
 const pendingInteractionNavigationGuardCleanup = new WeakMap<Page, () => void>();
 
-function didCrossDocumentUrlChange(page: Page, previousUrl: string): boolean {
+export function didCrossDocumentUrlChange(page: Page, previousUrl: string): boolean {
   const currentUrl = page.url();
   if (currentUrl === previousUrl) return false;
   try {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -614,6 +614,7 @@ export class CrawlPage {
       cdpUrl: this.cdpUrl,
       targetId: this._targetId,
       fields,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -710,6 +710,26 @@ describe('security.ts', () => {
       ).rejects.toThrow(InvalidBrowserNavigationUrlError);
     });
 
+    it('blocks an allow-listed hostname that resolves to a cloud-metadata/link-local address', async () => {
+      const metadataLookup = (() =>
+        Promise.resolve([{ address: '169.254.169.254', family: 4 }])) as unknown as LookupFn;
+      await expect(
+        resolvePinnedHostnameWithPolicy('bastion.example', {
+          lookupFn: metadataLookup,
+          policy: { allowedHostnames: ['bastion.example'] },
+        }),
+      ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    it('still allows an allow-listed hostname that resolves to a normal private IP', async () => {
+      const rfc1918Lookup = (() => Promise.resolve([{ address: '10.0.0.5', family: 4 }])) as unknown as LookupFn;
+      const result = await resolvePinnedHostnameWithPolicy('bastion.example', {
+        lookupFn: rfc1918Lookup,
+        policy: { allowedHostnames: ['bastion.example'] },
+      });
+      expect(result.addresses).toContain('10.0.0.5');
+    });
+
     it('should allow localhost with permissive policy', async () => {
       const result = await resolvePinnedHostnameWithPolicy('localhost', {
         lookupFn: mockLoopbackLookup(),

--- a/src/security.ts
+++ b/src/security.ts
@@ -362,6 +362,26 @@ function isPrivateIpAddress(address: string, policy?: SsrfPolicy): boolean {
   return false;
 }
 
+// Addresses that are never a legitimate target even for an explicitly
+// allow-listed hostname (DNS-rebinding defense): link-local ranges and known
+// cloud-metadata endpoints (AWS/GCP 169.254.169.254, AWS IPv6 fd00:ec2::254,
+// Alibaba 100.100.100.200).
+const CLOUD_METADATA_IPV4 = ['169.254.169.254', '100.100.100.200'];
+const CLOUD_METADATA_IPV6 = ['fd00:ec2::254'];
+
+function isCloudMetadataOrLinkLocalAddress(address: string): boolean {
+  const parsed = parseCanonicalIpAddress(address);
+  if (!parsed) return false;
+  if (parsed.kind() === 'ipv4') {
+    const v4 = parsed as ipaddr.IPv4;
+    if (v4.range() === 'linkLocal') return true;
+    return CLOUD_METADATA_IPV4.some((m) => v4.toNormalizedString() === ipaddr.IPv4.parse(m).toNormalizedString());
+  }
+  const v6 = parsed as ipaddr.IPv6;
+  if (v6.range() === 'linkLocal') return true;
+  return CLOUD_METADATA_IPV6.some((m) => v6.toNormalizedString() === ipaddr.IPv6.parse(m).toNormalizedString());
+}
+
 // ── URL-level checks ──
 
 /**
@@ -596,6 +616,15 @@ export async function resolvePinnedHostnameWithPolicy(
       if (isBlockedHostnameOrIp(r.address, params.policy)) {
         throw new InvalidBrowserNavigationUrlError(
           `Navigation to internal/loopback address blocked: "${hostname}" resolves to "${r.address}". ssrfPolicy.dangerouslyAllowPrivateNetwork is false (strict mode).`,
+        );
+      }
+    }
+  } else if (isExplicitlyAllowed && !allowPrivateNetwork) {
+    // An allow-listed host may resolve to a private IP on purpose, but never to a metadata/link-local one.
+    for (const r of results) {
+      if (isCloudMetadataOrLinkLocalAddress(r.address)) {
+        throw new InvalidBrowserNavigationUrlError(
+          `Navigation blocked: allow-listed hostname "${hostname}" resolves to a cloud-metadata/link-local address "${r.address}".`,
         );
       }
     }


### PR DESCRIPTION
Wave 2 of driving the review findings to zero: the SSRF security cluster. `0.19.8` (assumes PR #137's 0.19.7 merges first).

## Fixes
- **Allow-listed host → cloud-metadata/link-local now blocked** — an `allowedHostnames` carve-out no longer skips the resolved-address check wholesale; an allow-listed hostname may resolve to a normal private IP on purpose (bastion), but a resolve to `169.254.169.254` / `fd00:ec2::254` / `100.100.100.200` / any link-local address is refused (DNS-rebinding defense). Also closes the same gap in the CDP loopback carve-out. Closes #116
- **`evaluate()` / `evaluateInAllFrames()` now SSRF-check the page URL** before running, when a policy is set — matching `screenshot()`/`pdf()`. Closes #120
- **`fillForm()` now enforces the interaction navigation guard** — a fill/`setChecked` that triggers a navigation to a private address is blocked (it previously took no policy at all). Threaded `ssrfPolicy` through `browser.fill()` and the batch `fill` action. Closes #119
- **`goto` route handler no longer skips client-side top-level navigations** — removed the `url !== opts.url` bypass so every top-level/subframe-document request is validated while the guard is active. Closes #118

## #117 — resolved as a documented decision (closed separately)
OC refuses *all* hostname navigation in explicit strict mode (IP-literals or allow-listed only), because a browser's own DNS can't be pinned. Adopting that verbatim would break every strict-mode user navigating to a public site by hostname — a UX regression. BC keeps hostname navigation usable in strict mode via check-time DNS pinning, now backstopped by the #116 metadata/link-local guard. Full IP-literal-only rebinding-proofing remains available as a future opt-in if wanted.

## Verification
New security regression tests: allow-listed host → metadata is blocked, plus a non-vacuous control proving an allow-listed host → normal RFC1918 is still allowed. Gate green: typecheck, lint, format:check, build, 960/960 tests.
