### PR TITLE
Keep version at unpublished 0.19.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.8",
+  "version": "0.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.8",
+      "version": "0.19.7",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.8",
+  "version": "0.19.7",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
npm latest is 0.19.6 and 0.19.7 was never published (no v0.19.7 tag), so main bumping to 0.19.8 would leave 0.19.7 a phantom version. Next publish ships everything as 0.19.7.