### PR TITLE
Harden singleton lock recovery and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ Pass `isolated: true` (or `isolated: 'some-label'`) to launch in a dedicated per
 
 For a stable, shared profile across runs (persistent login state, preserved history), omit `isolated` and use `profileName` / `userDataDir` instead.
 
+#### Stale-lock recovery (persistent profiles)
+
+When a launch fails because Chrome reports the profile is in use by another process, browserclaw removes the `Singleton*` lock files and retries once — unless the lock is held by a live process on the same machine, in which case the launch fails so the running browser is left alone. A lock recorded under a different hostname is treated as stale: that's the normal state after a container restart with a persisted profile volume, where each run gets a fresh hostname and the old lock would otherwise block launches forever. The trade-off is deliberate and worth knowing: sharing one **live** profile directory across machines or containers (e.g. over a network filesystem) is unsupported — cross-host liveness can't be verified, so recovery will usurp the other session's lock. A warning is logged whenever locks are removed.
+
 #### SSRF policy (navigating agent-supplied URLs)
 
 **Secure by default.** browserclaw blocks navigation to private and loopback addresses — `127.0.0.1`, `10.0.0.0/8` and the rest of RFC 1918, link-local, the RFC 2544 range, IPv6 ULA, and cloud metadata endpoints like `169.254.169.254`. Public addresses resolve normally; internal ones are refused. Because an agent's target URLs often come from untrusted sources (LLM output, user input, an external API), blocking internal targets is the right default — and DNS is resolved and pinned up front, so a hostname can't pass the check as a public IP and then be fetched as a private one.

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -38,6 +38,7 @@ const {
   processExists,
   clearChromeSingletonArtifacts,
   clearStaleChromeSingletonLocks,
+  CHROME_SINGLETON_IN_USE_PATTERN,
   buildChromeLaunchArgs,
   wipeChromeSessionState,
   reserveFreePortFromList,
@@ -423,8 +424,9 @@ describe('clearStaleChromeSingletonLocks', () => {
     }
   });
 
-  itUnix('clears artifacts when lock pid is dead', () => {
+  itUnix('clears artifacts when lock pid is dead and warns', () => {
     const dir = makeTempDir();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     try {
       const target = `${os.hostname()}-2147483646`;
       fs.symlinkSync(target, path.join(dir, 'SingletonLock'));
@@ -432,13 +434,16 @@ describe('clearStaleChromeSingletonLocks', () => {
       expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(true);
       expect(() => fs.lstatSync(path.join(dir, 'SingletonLock'))).toThrow();
       expect(fs.existsSync(path.join(dir, 'SingletonSocket'))).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('process no longer running'));
     } finally {
+      warnSpy.mockRestore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  itUnix('clears a foreign-host lock (cross-host liveness cannot be verified)', () => {
+  itUnix('clears a foreign-host lock (cross-host liveness cannot be verified) and warns', () => {
     const dir = makeTempDir();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     try {
       const target = `some-other-host-${String(process.pid)}`;
       fs.symlinkSync(target, path.join(dir, 'SingletonLock'));
@@ -446,7 +451,9 @@ describe('clearStaleChromeSingletonLocks', () => {
       expect(clearStaleChromeSingletonLocks(dir, os.hostname())).toBe(true);
       expect(() => fs.lstatSync(path.join(dir, 'SingletonLock'))).toThrow();
       expect(fs.existsSync(path.join(dir, 'SingletonSocket'))).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('lock is from another host'));
     } finally {
+      warnSpy.mockRestore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -459,6 +466,38 @@ describe('clearStaleChromeSingletonLocks', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('CHROME_SINGLETON_IN_USE_PATTERN', () => {
+  it('matches the Chromium-branded message', () => {
+    expect(
+      CHROME_SINGLETON_IN_USE_PATTERN.test(
+        'The profile appears to be in use by another Chromium process (123) on another computer (abc).',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the Google-Chrome-branded message', () => {
+    expect(
+      CHROME_SINGLETON_IN_USE_PATTERN.test(
+        'The profile appears to be in use by another Google Chrome process (123) on another computer (abc).',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the Microsoft-Edge-branded message', () => {
+    expect(
+      CHROME_SINGLETON_IN_USE_PATTERN.test(
+        'The profile appears to be in use by another Microsoft Edge process (123) on another computer (abc).',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated stderr output', () => {
+    expect(
+      CHROME_SINGLETON_IN_USE_PATTERN.test('Failed to create a ProcessSingleton for your profile directory.'),
+    ).toBe(false);
   });
 });
 

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -13,7 +13,8 @@ import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome, SsrfPo
 // ── Singleton Lock Recovery ──
 
 const CHROME_SINGLETON_LOCK_PATHS = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
-const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another chromium process/i;
+// Brand-agnostic: stderr says "Chromium", "Google Chrome", "Microsoft Edge", ... per build; localized (non-English) messages won't match.
+export const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another .{1,40} process/i;
 
 export function processExists(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
@@ -49,6 +50,12 @@ export function clearStaleChromeSingletonLocks(userDataDir: string, hostname: st
   const lockHost = match.groups.lockHost;
   const pid = Number.parseInt(match.groups.pid, 10);
   if (lockHost === hostname && processExists(pid)) return false;
+  console.warn(
+    `[browserclaw] Removing Chrome Singleton* locks in ${userDataDir} held by "${lockHost}" (pid ${String(pid)})` +
+      (lockHost === hostname
+        ? ' — process no longer running.'
+        : ' — lock is from another host; if this profile is live on another machine or container, that session may be disrupted.'),
+  );
   clearChromeSingletonArtifacts(userDataDir);
   return true;
 }


### PR DESCRIPTION
Non-blocking hardening from the singleton-lock review discussion. No version bump.

## The concrete fix
`CHROME_SINGLETON_IN_USE_PATTERN` only matched "another **chromium** process", but branded builds emit different wording (`google_chrome_strings.grd`: "another **Google Chrome** process"; Edge/Brave likewise) — so the #123 stale-lock recovery silently never activated on branded Chrome. The pattern is now brand-agnostic (`another .{1,40} process`), verified against Chromium source strings. Localized (non-English) messages still won't match; noted in a code comment.

## Hardening (from the withdrawn P2 cross-host finding)
- `clearStaleChromeSingletonLocks` now `console.warn`s before clearing, distinguishing dead-pid from foreign-host locks (foreign-host warns the other session may be disrupted). No double-warn on the retry path — the second call returns early on ENOENT.
- README documents the recovery behavior and the deliberate trade-off: sharing a live profile directory across machines/containers is unsupported and may be usurped during recovery.

Tests: 4 new pattern tests (Chromium/Google Chrome/Edge wording + negative), warn assertions on both clearing tests. Gate green: typecheck, lint, format:check, build, 971/971.