### PR TITLE
Fix path validation under symlinked roots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browserclaw",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserclaw",
-      "version": "0.19.7",
+      "version": "0.19.8",
       "license": "MIT",
       "dependencies": {
         "ipaddr.js": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile, symlink, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { resolve, join } from 'node:path';
+import { basename, dirname, resolve, join } from 'node:path';
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
@@ -1543,6 +1543,24 @@ describe('security.ts', () => {
       });
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.paths[0]).toBe(filePath);
+    });
+
+    it('should accept files under a symlinked root', async () => {
+      const linkedRoot = join(dirname(tempRoot), `link-root-${basename(tempRoot)}`);
+      await symlink(tempRoot, linkedRoot);
+      try {
+        const filePath = join(tempRoot, 'file.txt');
+        await writeFile(filePath, 'data');
+        const result = await resolveStrictExistingPathsWithinRoot({
+          rootDir: linkedRoot,
+          requestedPaths: ['file.txt'],
+          scopeLabel: 'test',
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.paths[0]).toBe(filePath);
+      } finally {
+        await rm(linkedRoot, { force: true });
+      }
     });
 
     it('should reject missing files', async () => {

--- a/src/security.ts
+++ b/src/security.ts
@@ -900,11 +900,7 @@ export async function resolveExistingPathsWithinRoot(params: {
   return { ok: true, paths: resolved };
 }
 
-/**
- * The escape checks compare realpath'd files against the root, so the root itself
- * must be realpath'd too — otherwise a symlinked temp dir (macOS /tmp ->
- * /private/tmp) rejects every legitimate path inside it.
- */
+/** Escape checks compare realpath'd files, so the root must be realpath'd too (macOS /tmp -> /private/tmp). */
 async function realRootOf(rootDir: string): Promise<string> {
   const lexical = resolve(rootDir);
   try {

--- a/src/security.ts
+++ b/src/security.ts
@@ -863,7 +863,7 @@ export async function resolveExistingPathsWithinRoot(params: {
   requestedPaths: string[];
   scopeLabel: string;
 }): Promise<PathsResult> {
-  const root = resolve(params.rootDir);
+  const root = await realRootOf(params.rootDir);
   const resolved: string[] = [];
 
   for (const raw of params.requestedPaths) {
@@ -901,6 +901,20 @@ export async function resolveExistingPathsWithinRoot(params: {
 }
 
 /**
+ * The escape checks compare realpath'd files against the root, so the root itself
+ * must be realpath'd too — otherwise a symlinked temp dir (macOS /tmp ->
+ * /private/tmp) rejects every legitimate path inside it.
+ */
+async function realRootOf(rootDir: string): Promise<string> {
+  const lexical = resolve(rootDir);
+  try {
+    return await realpath(lexical);
+  } catch {
+    return lexical;
+  }
+}
+
+/**
  * Same as resolveExistingPathsWithinRoot but missing files are NOT allowed.
  */
 export async function resolveStrictExistingPathsWithinRoot(params: {
@@ -908,7 +922,7 @@ export async function resolveStrictExistingPathsWithinRoot(params: {
   requestedPaths: string[];
   scopeLabel: string;
 }): Promise<PathsResult> {
-  const root = resolve(params.rootDir);
+  const root = await realRootOf(params.rootDir);
   const resolved: string[] = [];
 
   for (const raw of params.requestedPaths) {


### PR DESCRIPTION
`resolveStrictExistingPathsWithinRoot` / `resolveExistingPathsWithinRoot` realpath each candidate file but compared it against a lexically resolved root. On macOS `/tmp` is a symlink to `/private/tmp`, so the default uploads root (`/tmp/browserclaw/uploads`) could never contain a "non-escaping" file — `armFileUpload` rejected every upload on macOS with *Path escapes uploads directory via symlink*.

Both helpers now resolve the root through symlinks (falling back to the lexical root when it doesn't exist yet, in which case no file can exist under it either). Regression test stages a file under a root reached via a symlink.

Full suite green; found while running GreenhouseAI's e2e suite (its order-wizard photo upload) on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)