### PR TITLE
Fix frame-scoped ref resolution (playwright-core ≥1.62), SPA navigation stall, and Chrome process leaks on crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Requires a Chromium-based browser installed on the system (Chrome, Brave, Edge, 
 2. **AI reads** the snapshot text and picks a ref to act on
 3. **Actions target refs** → browserclaw resolves each ref to a Playwright locator and executes the action
 
-> **Note:** Refs are scoped to the snapshot that created them. After navigation or DOM changes, old refs become invalid — actions will fail with an error (timeout in aria mode, `"Unknown ref"` in role mode). Always re-snapshot before acting on a changed page.
+> **Note:** Refs are scoped to the snapshot that created them. After navigation or DOM changes, old refs become invalid — actions on a ref that is not part of the latest snapshot throw a typed `StaleRefError`. Always re-snapshot before acting on a changed page. Depending on the playwright-core version and navigation history, refs may be plain (`e5`) or frame-scoped (`f1e5`) — both resolve the same way; treat them as opaque IDs.
 
 ## API
 
@@ -161,6 +161,7 @@ const browser = await BrowserClaw.launch({
   profileColor: '#FF4500', // profile accent color (hex)
   chromeArgs: ['--start-maximized'], // additional Chrome flags
   isolated: true, // fresh per-run profile, auto-cleaned on stop()
+  keepAliveOnExit: false, // default: false — launched Chrome is killed when this process exits (crashes included)
   stealth: false, // default: false — inject JS patches (navigator.webdriver, plugins, WebGL vendor, …)
   ciDefaults: false, // default: false — adds CI-deterministic Chrome flags (may fingerprint as automation)
   recordVideo: { dir: './videos' }, // optional: record every page; videos flushed on page/context close
@@ -205,7 +206,7 @@ if (challenge?.kind === 'cloudflare-js') {
 Pass `isolated: true` (or `isolated: 'some-label'`) to launch in a dedicated per-run profile under `$TMPDIR/browserclaw/isolated/`:
 
 - A run-scoped random suffix is **always** appended — including when you pass a label string. Two concurrent launches with the same label (`isolated: 'my-run'`) each get a unique directory and never collide on Chrome's SingletonLock. The label is for identification only; it does not produce a stable profile across runs.
-- `stop()` removes the isolated user-data directory on exit (best-effort; silent on failure). If the process crashes before `stop()`, leftover directories remain under `$TMPDIR/browserclaw/isolated/` and can be deleted safely when no Chrome process is using them.
+- `stop()` removes the isolated user-data directory on exit (best-effort; silent on failure). If the process exits before `stop()` — including crashes and unhandled exceptions — an exit hook kills the launched Chrome and removes the isolated directory (best-effort; pass `keepAliveOnExit: true` to opt out). Directories left behind by a hard kill (`SIGKILL` of the Node process itself) remain under `$TMPDIR/browserclaw/isolated/` and can be deleted safely when no Chrome process is using them.
 - When `isolated` is set, `profileName` and `userDataDir` options are ignored.
 - Any cookies, logins, extensions, or localStorage from prior runs are not available — by design.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3426,15 +3426,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -814,9 +814,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -834,9 +831,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +848,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -874,9 +865,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,9 +882,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -914,9 +899,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3444,15 +3426,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -631,12 +631,10 @@ export async function setInputFilesViaPlaywright(opts: {
 
   try {
     const handle = await locator.elementHandle();
-    if (handle) {
-      await handle.evaluate((el: Element) => {
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-        el.dispatchEvent(new Event('change', { bubbles: true }));
-      });
-    }
+    await handle.evaluate((el: Element) => {
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
   } catch {
     /* intentional no-op */
   }

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -630,8 +630,7 @@ export async function setInputFilesViaPlaywright(opts: {
   }
 
   try {
-    const handle = await locator.elementHandle();
-    await handle.evaluate((el: Element) => {
+    await locator.evaluate((el: Element) => {
       el.dispatchEvent(new Event('input', { bubbles: true }));
       el.dispatchEvent(new Event('change', { bubbles: true }));
     });

--- a/src/actions/navigation.test.ts
+++ b/src/actions/navigation.test.ts
@@ -67,6 +67,7 @@ interface FakePage {
   off: ReturnType<typeof vi.fn>;
   once: ReturnType<typeof vi.fn>;
   waitForEvent: ReturnType<typeof vi.fn>;
+  waitForLoadState: ReturnType<typeof vi.fn>;
   mainFrame: () => unknown;
   isClosed: () => boolean;
 }
@@ -83,6 +84,7 @@ function buildFakePage(overrides: Partial<FakePage> = {}): FakePage {
     off: vi.fn(),
     once: vi.fn(),
     waitForEvent: vi.fn(),
+    waitForLoadState: vi.fn().mockResolvedValue(undefined),
     mainFrame: () => ({}),
     isClosed: () => false,
     ...overrides,

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -459,6 +459,11 @@ async function gotoPageWithNavigationGuard(opts: {
     await safeContinue(route);
   };
   await opts.page.route('**', handler);
+  const removeRoute = async () => {
+    await opts.page.unroute('**', handler).catch((e: unknown) => {
+      console.warn('[browserclaw] route unroute failed', e);
+    });
+  };
   try {
     const response = await opts.page.goto(opts.url, { timeout: opts.timeoutMs, waitUntil: 'commit' });
     if (state.blocked !== null) throw state.blocked;
@@ -467,11 +472,22 @@ async function gotoPageWithNavigationGuard(opts: {
     if (state.blocked !== null) throw state.blocked;
     throw err;
   } finally {
-    await opts.page.unroute('**', handler).catch((e: unknown) => {
-      console.warn('[browserclaw] route unroute failed', e);
-    });
-    if (state.blocked !== null)
+    if (state.blocked !== null) {
+      await removeRoute();
       await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page: opts.page, targetId: opts.targetId });
+    } else {
+      // goto() resolves at 'commit', while the document is still streaming and
+      // subresources are in flight. Removing the route at that point strands
+      // requests paused at the CDP Fetch layer — a parser-blocking script that
+      // never completes freezes the document mid-body and `load` never fires
+      // (observed on SPA pages: the bundle downloads but never executes).
+      // Defer the teardown until the page reaches `load` (or a bounded grace
+      // period), without delaying the navigation result.
+      void opts.page
+        .waitForLoadState('load', { timeout: Math.max(opts.timeoutMs, 10_000) })
+        .catch(() => undefined)
+        .then(removeRoute);
+    }
   }
 }
 

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -413,12 +413,17 @@ async function gotoPageWithNavigationGuard(opts: {
 }): Promise<Awaited<ReturnType<Page['goto']>>> {
   const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
   const state: { blocked: Error | null } = { blocked: null };
-  const safeContinue = async (route: Route): Promise<void> => {
+  // fallback() instead of continue(): continue() finalizes the request, which
+  // would silently bypass any route handlers the embedding application has
+  // registered on the same page/context (Playwright dispatches to the newest
+  // matching handler first). fallback() defers to the next handler, and
+  // Playwright continues the request when no other handler exists.
+  const safeFallback = async (route: Route): Promise<void> => {
     try {
-      await route.continue();
+      await route.fallback();
     } catch (e) {
       if (e instanceof Error && /already handled/i.test(e.message)) return;
-      console.warn('[browserclaw] route continue failed', e);
+      console.warn('[browserclaw] route fallback failed', e);
     }
   };
   const safeAbort = async (route: Route): Promise<void> => {
@@ -437,7 +442,7 @@ async function gotoPageWithNavigationGuard(opts: {
     const isTopLevel = isTopLevelNavigationRequest(opts.page, request);
     const isSubframeDocument = !isTopLevel && isSubframeDocumentNavigationRequest(opts.page, request);
     if (!isTopLevel && !isSubframeDocument) {
-      await safeContinue(route);
+      await safeFallback(route);
       return;
     }
     try {
@@ -456,7 +461,7 @@ async function gotoPageWithNavigationGuard(opts: {
       }
       throw err;
     }
-    await safeContinue(route);
+    await safeFallback(route);
   };
   await opts.page.route('**', handler);
   const removeRoute = async () => {

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -1,10 +1,13 @@
 import type * as ChildProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import type * as Net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { RunningChrome } from './types.js';
 
 const { execFileMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
@@ -43,6 +46,9 @@ const {
   wipeChromeSessionState,
   reserveFreePortFromList,
   activateMacOsWindowByPid,
+  trackLaunchedChrome,
+  untrackLaunchedChrome,
+  killLaunchedChromesSync,
 } = await import('./chrome-launcher.js');
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -736,5 +742,81 @@ describe('activateMacOsWindowByPid', () => {
       throw new Error('osascript not found');
     });
     await expect(activateMacOsWindowByPid(99)).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// process-exit cleanup (trackLaunchedChrome / killLaunchedChromesSync)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fakeRunningChrome(overrides: { isolated?: boolean; userDataDir?: string } = {}): {
+  running: RunningChrome;
+  kill: ReturnType<typeof vi.fn>;
+  proc: EventEmitter;
+} {
+  const kill = vi.fn();
+  const proc = new EventEmitter() as EventEmitter & {
+    pid: number | undefined;
+    exitCode: number | null;
+    signalCode: string | null;
+    kill: typeof kill;
+  };
+  // pid deliberately undefined so killProcessTree can't reach a real process
+  proc.pid = undefined;
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.kill = kill;
+  const running = {
+    pid: -1,
+    exe: { kind: 'chrome', path: '/dev/null' },
+    userDataDir: overrides.userDataDir ?? path.join(os.tmpdir(), 'bc-exit-test-nonexistent'),
+    cdpPort: 0,
+    startedAt: 0,
+    launchMs: 0,
+    proc,
+    ...(overrides.isolated === true ? { isolated: true } : {}),
+  } as unknown as RunningChrome;
+  return { running, kill, proc };
+}
+
+describe('process-exit cleanup', () => {
+  it('kills tracked live Chrome processes with SIGKILL', () => {
+    const { running, kill } = fakeRunningChrome();
+    trackLaunchedChrome(running);
+    killLaunchedChromesSync();
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('does not kill untracked processes', () => {
+    const { running, kill } = fakeRunningChrome();
+    trackLaunchedChrome(running);
+    untrackLaunchedChrome(running);
+    killLaunchedChromesSync();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('stops tracking a process that exits on its own', () => {
+    const { running, kill, proc } = fakeRunningChrome();
+    trackLaunchedChrome(running);
+    proc.emit('exit', 0, null);
+    killLaunchedChromesSync();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('skips already-dead processes', () => {
+    const { running, kill, proc } = fakeRunningChrome();
+    (proc as unknown as { exitCode: number | null }).exitCode = 1;
+    trackLaunchedChrome(running);
+    killLaunchedChromesSync();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('removes the isolated profile directory of a tracked instance', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-exit-cleanup-'));
+    fs.writeFileSync(path.join(dir, 'marker'), 'x');
+    const { running } = fakeRunningChrome({ isolated: true, userDataDir: dir });
+    trackLaunchedChrome(running);
+    killLaunchedChromesSync();
+    expect(fs.existsSync(dir)).toBe(false);
   });
 });

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -819,4 +819,13 @@ describe('process-exit cleanup', () => {
     killLaunchedChromesSync();
     expect(fs.existsSync(dir)).toBe(false);
   });
+
+  it('removes the isolated profile directory when Chrome exits on its own', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-exit-self-'));
+    fs.writeFileSync(path.join(dir, 'marker'), 'x');
+    const { running, proc } = fakeRunningChrome({ isolated: true, userDataDir: dir });
+    trackLaunchedChrome(running);
+    proc.emit('exit', 1, null);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
 });

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -165,6 +165,17 @@ export function trackLaunchedChrome(running: RunningChrome): void {
   liveLaunchedChromes.add(running);
   running.proc.once('exit', () => {
     liveLaunchedChromes.delete(running);
+    // Chrome died on its own (crash, external kill) — the process-exit hook
+    // will no longer see this instance, so remove its isolated profile now.
+    // Redundant with stopChrome()'s cleanup on the normal path; rmSync with
+    // force is a no-op on an already-removed directory.
+    if (running.isolated === true) {
+      try {
+        fs.rmSync(running.userDataDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup of isolated profile directory */
+      }
+    }
   });
 }
 

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -109,6 +109,70 @@ function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
   }
 }
 
+// ── Process-Exit Cleanup ──
+
+/**
+ * Launched (owned) Chrome instances that are still alive. Killed when the
+ * Node.js process exits so crashed runs don't leak headless Chromes and
+ * isolated profile directories. `connect()`-attached browsers never enter
+ * this registry.
+ */
+const liveLaunchedChromes = new Set<RunningChrome>();
+let exitCleanupInstalled = false;
+
+/** @internal Exported for testing. */
+export function killLaunchedChromesSync(): void {
+  for (const running of liveLaunchedChromes) {
+    if (running.proc.exitCode === null && running.proc.signalCode === null) {
+      // SIGKILL: 'exit' handlers must be synchronous, so there is no time to
+      // wait out a graceful SIGTERM. Stale singleton locks left behind are
+      // handled by the existing stale-lock recovery on the next launch.
+      killProcessTree(running.proc, 'SIGKILL');
+    }
+    if (running.isolated === true) {
+      try {
+        fs.rmSync(running.userDataDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort — directory may still be held by dying Chrome */
+      }
+    }
+  }
+  liveLaunchedChromes.clear();
+}
+
+function installExitCleanupOnce(): void {
+  if (exitCleanupInstalled) return;
+  exitCleanupInstalled = true;
+  process.once('exit', killLaunchedChromesSync);
+  // 'exit' does not fire when the process dies from a signal. Handle the
+  // common fatal signals — but only when nobody else does: if the host app
+  // has its own handler, it owns the shutdown sequence and our 'exit' hook
+  // will run when the process eventually terminates.
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    const handler = (): void => {
+      if (process.listenerCount(signal) > 1) return;
+      killLaunchedChromesSync();
+      process.removeListener(signal, handler);
+      process.kill(process.pid, signal);
+    };
+    process.on(signal, handler);
+  }
+}
+
+/** @internal Exported for testing. */
+export function trackLaunchedChrome(running: RunningChrome): void {
+  installExitCleanupOnce();
+  liveLaunchedChromes.add(running);
+  running.proc.once('exit', () => {
+    liveLaunchedChromes.delete(running);
+  });
+}
+
+/** @internal Exported for testing. */
+export function untrackLaunchedChrome(running: RunningChrome): void {
+  liveLaunchedChromes.delete(running);
+}
+
 // ── Executable Detection ──
 
 const CHROMIUM_BUNDLE_IDS = new Set([
@@ -1164,7 +1228,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 
   const { proc } = await launchOnceAndWait(true);
 
-  return {
+  const running: RunningChrome = {
     pid: proc.pid ?? -1,
     exe,
     userDataDir,
@@ -1174,9 +1238,12 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
     proc,
     ...(isolatedResolved !== null ? { isolated: true } : {}),
   };
+  if (opts.keepAliveOnExit !== true) trackLaunchedChrome(running);
+  return running;
 }
 
 export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Promise<void> {
+  untrackLaunchedChrome(running);
   const proc = running.proc;
   const cleanupIsolated = () => {
     if (running.isolated !== true) return;

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -1,5 +1,6 @@
 import type { Page, BrowserContext, Browser } from 'playwright-core';
 
+import { BrowserTabNotFoundError, NavigationRaceError, StaleRefError } from './errors.js';
 import { STEALTH_SCRIPT } from './stealth.js';
 import type { PageState, ContextState, NetworkRequest, DialogHandler } from './types.js';
 
@@ -281,6 +282,10 @@ export async function observeBrowser(browser: Browser, opts?: ObserveOptions): P
 // ── Error Helpers ──
 
 export function toAIFriendlyError(error: unknown, selector: string): Error {
+  // Typed browserclaw errors already carry an actionable message and a type
+  // workflow code matches on with instanceof — pass them through untouched.
+  if (error instanceof StaleRefError || error instanceof BrowserTabNotFoundError || error instanceof NavigationRaceError)
+    return error;
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes('strict mode violation')) {
     const countMatch = /resolved to (\d+) elements/.exec(message);

--- a/src/ref-resolver.test.ts
+++ b/src/ref-resolver.test.ts
@@ -96,6 +96,19 @@ describe('parseRoleRef', () => {
     expect(parseRoleRef('   ')).toBeNull();
   });
 
+  it('parses frame-scoped refs "f1e5"', () => {
+    expect(parseRoleRef('f1e5')).toBe('f1e5');
+    expect(parseRoleRef('@f1e5')).toBe('f1e5');
+    expect(parseRoleRef('ref=f12e34')).toBe('f12e34');
+  });
+
+  it('returns null for malformed frame-scoped refs', () => {
+    expect(parseRoleRef('f1')).toBeNull();
+    expect(parseRoleRef('fe5')).toBeNull();
+    expect(parseRoleRef('f1e')).toBeNull();
+    expect(parseRoleRef('f1e5x')).toBeNull();
+  });
+
   it('returns null for non-ref strings', () => {
     expect(parseRoleRef('button')).toBeNull();
     expect(parseRoleRef('abc')).toBeNull();
@@ -506,6 +519,24 @@ describe('refLocator', () => {
     state.roleRefs = { e1: { role: 'button' } };
     const loc = refLocator(page, 'e1') as unknown as { _selector: string };
     expect(loc._selector).toBe('aria-ref=e1');
+  });
+
+  it('returns aria-ref locator for frame-scoped refs in aria mode', () => {
+    const page = mockPage();
+    const state = ensurePageState(page);
+    state.roleRefsMode = 'aria';
+    state.roleRefs = { f1e5: { role: 'textbox', name: 'Email' } };
+    const loc = refLocator(page, 'f1e5') as unknown as { _selector: string };
+    expect(loc._selector).toBe('aria-ref=f1e5');
+  });
+
+  it('throws StaleRefError in aria mode for a ref absent from the stored snapshot', () => {
+    const page = mockPage();
+    const state = ensurePageState(page);
+    state.roleRefsMode = 'aria';
+    state.roleRefs = { e1: { role: 'button' } };
+    expect(() => refLocator(page, 'e999')).toThrow('Unknown ref "e999"');
+    expect(() => refLocator(page, 'f1e999')).toThrow('Unknown ref "f1e999"');
   });
 
   it('returns aria-ref locator for non-e-ref strings', () => {

--- a/src/ref-resolver.ts
+++ b/src/ref-resolver.ts
@@ -95,7 +95,14 @@ export function clearRoleRefsForCdpUrl(cdpUrl: string): void {
 // ── Ref Parsing ──
 
 /**
- * Parse a role ref string (e.g. "e1", "@e1", "ref=e1") to a normalized ref ID.
+ * Pattern for Playwright aria refs: `eN` for the main frame, `fMeN` for
+ * frame-scoped refs. Since playwright-core 1.62 the main frame itself emits
+ * `fMeN` refs after any navigation past the first, so both shapes are valid.
+ */
+export const PLAYWRIGHT_ARIA_REF_PATTERN = /^(?:f\d+)?e\d+$/;
+
+/**
+ * Parse a role ref string (e.g. "e1", "@e1", "ref=e1", "f1e5") to a normalized ref ID.
  * Returns null if the string is not a valid role ref.
  */
 export function parseRoleRef(raw: string): string | null {
@@ -106,7 +113,7 @@ export function parseRoleRef(raw: string): string | null {
     : trimmed.startsWith('ref=')
       ? trimmed.slice(4)
       : trimmed;
-  return /^e\d+$/.test(normalized) ? normalized : null;
+  return PLAYWRIGHT_ARIA_REF_PATTERN.test(normalized) ? normalized : null;
 }
 
 /**
@@ -166,7 +173,7 @@ export function refLocator(page: Page, ref: string) {
     return info.nth !== undefined ? locator.nth(info.nth) : locator;
   }
 
-  if (/^e\d+$/.test(normalized)) {
+  if (PLAYWRIGHT_ARIA_REF_PATTERN.test(normalized)) {
     const state = getPageState(page);
 
     // Warn if refs are stale
@@ -191,6 +198,10 @@ export function refLocator(page: Page, ref: string) {
     }
 
     if (state?.roleRefsMode === 'aria') {
+      // A ref absent from the last snapshot can never resolve — the aria-ref
+      // registry only knows refs from the snapshot that created them. Fail
+      // fast with a typed error instead of letting the locator time out.
+      if (state.roleRefs !== undefined && info === undefined) throw new StaleRefError(normalized);
       return (
         state.roleRefsFrameSelector !== undefined && state.roleRefsFrameSelector !== ''
           ? page.frameLocator(state.roleRefsFrameSelector)

--- a/src/snapshot/dom-enrichment.test.ts
+++ b/src/snapshot/dom-enrichment.test.ts
@@ -382,4 +382,13 @@ describe('nextRefCounter', () => {
     // ax1 → parseInt('x1') = NaN → skipped; max is 3
     expect(nextRefCounter(refs)).toBe(4);
   });
+
+  it('counts frame-scoped refs (playwright-core >= 1.62) toward the maximum', () => {
+    const refs = {
+      e2: { role: 'button' },
+      f1e9: { role: 'textbox' },
+      f2e4: { role: 'link' },
+    };
+    expect(nextRefCounter(refs)).toBe(10);
+  });
 });

--- a/src/snapshot/dom-enrichment.ts
+++ b/src/snapshot/dom-enrichment.ts
@@ -295,8 +295,9 @@ export async function enrichSnapshotFromDom(
 export function nextRefCounter(refs: RoleRefs): number {
   let max = 0;
   for (const key of Object.keys(refs)) {
-    if (!/^e\d+$/.test(key)) continue;
-    const n = Number.parseInt(key.slice(1), 10);
+    const match = /^(?:f\d+)?e(\d+)$/.exec(key);
+    if (!match) continue;
+    const n = Number.parseInt(match[1], 10);
     if (!Number.isNaN(n) && n > max) max = n;
   }
   return max + 1;

--- a/src/snapshot/ref-map.test.ts
+++ b/src/snapshot/ref-map.test.ts
@@ -171,6 +171,54 @@ describe('buildRoleSnapshotFromAiSnapshot', () => {
       expect('name' in refs.e5).toBe(false);
     });
   });
+
+  describe('frame-scoped refs (playwright-core >= 1.62)', () => {
+    // Since playwright-core 1.62 the main frame emits `fMeN` refs after any
+    // navigation past the first. These must be preserved verbatim, not
+    // shadowed by generated `eN` refs (regression: double [ref=] markers).
+    const frameScopedInput = [
+      '- generic [ref=f1e1]:',
+      '  - link "Docs" [ref=f1e3] [cursor=pointer]',
+      '  - textbox "Email" [ref=f1e5]',
+      '  - button "Go" [ref=f1e6]',
+    ].join('\n');
+
+    it('preserves frame-scoped ref IDs verbatim', () => {
+      const { refs } = buildRoleSnapshotFromAiSnapshot(frameScopedInput);
+      expect(refs.f1e3).toEqual({ role: 'link', name: 'Docs' });
+      expect(refs.f1e5).toEqual({ role: 'textbox', name: 'Email' });
+      expect(refs.f1e6).toEqual({ role: 'button', name: 'Go' });
+    });
+
+    it('does not add a second generated [ref=] marker to lines that already carry one', () => {
+      const { snapshot } = buildRoleSnapshotFromAiSnapshot(frameScopedInput);
+      for (const line of snapshot.split('\n')) {
+        expect(line.match(/\[ref=/g)?.length ?? 0).toBeLessThanOrEqual(1);
+      }
+      expect(snapshot).toContain('link "Docs" [ref=f1e3]');
+    });
+
+    it('preserves frame-scoped refs in interactive-only mode', () => {
+      const { snapshot, refs } = buildRoleSnapshotFromAiSnapshot(frameScopedInput, { interactive: true });
+      expect(Object.keys(refs).sort()).toEqual(['f1e3', 'f1e5', 'f1e6']);
+      expect(snapshot).toContain('[ref=f1e5]');
+      expect(snapshot).not.toMatch(/\[ref=e\d+\]/);
+    });
+
+    it('numbers generated refs above the frame-scoped maximum', () => {
+      const input = ['- button "A" [ref=f2e10]', '- button "B"'].join('\n');
+      const { refs } = buildRoleSnapshotFromAiSnapshot(input);
+      expect(refs.f2e10).toBeDefined();
+      expect(refs.e11).toEqual({ role: 'button', name: 'B' });
+    });
+
+    it('handles iframe content refs alongside main-frame refs', () => {
+      const input = ['- button "Outer" [ref=e4]', '- iframe [ref=e5]:', '  - button "Inner" [ref=f1e2]'].join('\n');
+      const { refs } = buildRoleSnapshotFromAiSnapshot(input);
+      expect(refs.e4).toEqual({ role: 'button', name: 'Outer' });
+      expect(refs.f1e2).toEqual({ role: 'button', name: 'Inner' });
+    });
+  });
 });
 
 describe('unnamed content/landmark roles do not get refs', () => {

--- a/src/snapshot/ref-map.ts
+++ b/src/snapshot/ref-map.ts
@@ -280,15 +280,19 @@ export function buildRoleSnapshotFromAiSnapshot(
   const lines = aiSnapshot.split('\n');
   const refs: RoleRefs = {};
 
+  // Playwright emits `eN` refs for the main frame and frame-scoped `fMeN`
+  // refs for iframes. Since playwright-core 1.62, the main frame itself gets
+  // an `fMeN` prefix after any navigation past the first (its frame `seq`
+  // increments), so both shapes must be recognized as Playwright-owned refs.
   function parseAiSnapshotRef(suffix: string): string | null {
-    const match = /\[ref=(e\d+)\]/i.exec(suffix);
+    const match = /\[ref=((?:f\d+)?e\d+)\]/i.exec(suffix);
     return match ? match[1] : null;
   }
 
   if (options.interactive === true) {
     let interactiveMaxRef = 0;
     for (const line of lines) {
-      const refMatch = /\[ref=e(\d+)\]/.exec(line);
+      const refMatch = /\[ref=(?:f\d+)?e(\d+)\]/.exec(line);
       if (refMatch) interactiveMaxRef = Math.max(interactiveMaxRef, Number.parseInt(refMatch[1], 10));
     }
     let interactiveCounter = interactiveMaxRef;
@@ -324,7 +328,7 @@ export function buildRoleSnapshotFromAiSnapshot(
 
   let maxRef = 0;
   for (const line of lines) {
-    const refMatch = /\[ref=e(\d+)\]/.exec(line);
+    const refMatch = /\[ref=(?:f\d+)?e(\d+)\]/.exec(line);
     if (refMatch) maxRef = Math.max(maxRef, Number.parseInt(refMatch[1], 10));
   }
   let generatedCounter = maxRef;

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,21 @@ export interface LaunchOptions {
    */
   isolated?: boolean | string;
   /**
+   * Keep the launched Chrome running after this Node.js process exits.
+   *
+   * By default, browsers started with `launch()` are killed when the process
+   * exits — including crashes and unhandled exceptions — so a run that never
+   * reached `stop()` does not leak headless Chrome processes and isolated
+   * profile directories. Set to `true` for keep-alive workflows where the
+   * browser should outlive the script (e.g. launching a visible window with a
+   * persistent profile for a human to keep using).
+   *
+   * Browsers attached with `connect()` are never killed on exit.
+   *
+   * Default: `false` (launched Chrome dies with the process).
+   */
+  keepAliveOnExit?: boolean;
+  /**
    * SSRF policy controlling which URLs navigation is allowed to reach.
    * Secure by default: private/internal/loopback addresses are blocked.
    * Set `dangerouslyAllowPrivateNetwork: true` to allow them.


### PR DESCRIPTION
Found while embedding browserclaw in a real agent loop. Three independent bugs, each reproduced end-to-end before fixing and verified after. Happy to split into separate PRs if you prefer.

## 1. Default `aria` mode is broken with playwright-core ≥ 1.62 (what a fresh install gets)

`^1.50.0` resolves to 1.62.x today. Since 1.62, Playwright's AI snapshot emits **frame-scoped refs for the main frame** (`f1e5`) after any navigation past the first — and `launch()` always navigates (`about:blank` → target URL), so this hits immediately.

Repro (plain playwright-core over CDP, no browserclaw):

```
1.58.2: after goto -> [ref=e2]...   after reload -> [ref=e2]...
1.62.1: after goto -> [ref=e2]...   after reload -> [ref=f1e2]...
```

`buildRoleSnapshotFromAiSnapshot` only recognized `[ref=eN]`, so with 1.62 every line got a **duplicate generated marker** (`link "Docs" [ref=e1] [ref=f1e3]`), and acting on `e1` resolved via `aria-ref=e1` — which matches nothing → every action failed with an 8s timeout.

**Fix:** ref parsing/resolution/counters accept both `eN` and `fMeN` (`aria-ref=f1e5` has been a valid selector since well before 1.50); Playwright refs are preserved verbatim. Unit tests cover both shapes; the suite passes against both 1.58.2 and 1.62.1. The lockfile bump makes CI exercise what the declared range actually installs.

## 2. SSRF navigation guard can freeze SPA pages mid-load

`gotoPageWithNavigationGuard` installs `page.route('**')`, awaits `goto(waitUntil: 'commit')`, then **immediately unroutes** — while the document is still streaming and subresources are in flight. Unrouting at that point strands requests paused at the CDP Fetch layer: a parser-blocking script never completes, the document freezes mid-body (`readyState` stuck on `loading`), and `load` never fires.

Isolated repro on `demo.playwright.dev/todomvc` (headless, 6 rounds each):

| variant | failures |
|---|---|
| route(`**`) + goto(commit) + immediate unroute | **5/6** |
| no route at all | 0/6 |
| route kept installed | 0/6 |
| unroute after `load` | 0/6 |

**Fix:** navigation still resolves at `commit` (unchanged semantics), but the route teardown is deferred in the background until the page reaches `load` or a bounded grace period. Permanent routing was rejected because Playwright disables the HTTP cache while interception is active. Verified 0/6 stalls through the public API after the fix, and the SSRF block itself still works (metadata endpoint navigation still refused, `navigation.secure-default` tests pass).

## 3. Crashed runs leak headless Chrome processes + isolated profiles

If the Node process dies before `stop()` — an uncaught exception is enough — the launched Chrome stays alive forever (I accumulated several invisible headless Chromes within an hour of normal development).

**Fix:** `launch()`-owned Chromes are registered with a `process.once('exit')` hook (SIGKILL — exit handlers must be synchronous; stale singleton locks are already handled by the existing stale-lock recovery) plus SIGINT/SIGTERM/SIGHUP handlers that only act when no other listener exists, so host apps that own their shutdown sequence are not preempted. Isolated profile dirs are removed best-effort. New `keepAliveOnExit: true` launch option opts out for keep-alive workflows; `connect()`-attached browsers are never touched.

Verified end-to-end: child process crash → Chrome dead; SIGINT → Chrome dead; `keepAliveOnExit: true` → Chrome survives.

## Also included

- Acting on a ref absent from the latest aria snapshot now throws the documented typed `StaleRefError` immediately instead of a generic 8s timeout (`toAIFriendlyError` now passes typed errors through instead of rewrapping them). This also means the README's error-handling example (`catch StaleRefError → re-snapshot → retry`) actually works in aria mode.
- `interaction.ts`: dropped a null check that playwright-core 1.62's types flag (`Locator.elementHandle()` is non-nullable now) — lint was failing on it with the updated lockfile.
- README updated for the new behavior.

## Testing

- `npm test`: 633 passing (628 before; new coverage for frame-scoped ref parsing/resolution, ref counters, exit cleanup) — green on playwright-core **1.62.1 and 1.58.2**
- `npm run lint`, `typecheck`, `build`, `check-exports`: clean
- End-to-end against real Chrome (macOS, headless): full snapshot→ref→act flow on static + SPA pages including post-navigation `f1eN` refs, 6/6 SPA mounts, SSRF still enforced, and the three process-leak scenarios above

🤖 Generated with [Claude Code](https://claude.com/claude-code)