### PR TITLE
Updates from OpenClaw 2026.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserclaw",
-  "version": "0.19.8",
+  "version": "0.20.0",
   "description": "AI-friendly browser automation with snapshot + ref targeting. No CSS selectors, no XPath, no vision — just numbered refs.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/actions/download.test.ts
+++ b/src/actions/download.test.ts
@@ -216,3 +216,40 @@ describe('armNavigationDownloadCapture — secure-by-default URL validation', ()
     expect(capture.armed).toBe(false);
   });
 });
+
+describe('waitForDownloadViaPlaywright — no-path default location', () => {
+  function pageWithDownloadEmitter(): { page: Page; emit: (download: unknown) => void } {
+    let downloadHandler: ((download: unknown) => void) | undefined;
+    const page = {
+      on: (event: string, handler: (download: unknown) => void) => {
+        if (event === 'download') downloadHandler = handler;
+      },
+      off: () => undefined,
+    } as unknown as Page;
+    return { page, emit: (d: unknown) => downloadHandler?.(d) };
+  }
+
+  it('saves into the managed downloads dir (not CWD) with a UUID prefix when no path is given', async () => {
+    const { writeFileSync, existsSync, rmSync } = await import('node:fs');
+    const { DEFAULT_DOWNLOAD_DIR } = await import('../security.js');
+    const { page, emit } = pageWithDownloadEmitter();
+    mockGetPageForTargetId.mockResolvedValue(page);
+    mockEnsurePageState.mockReturnValue({ armIdDownload: 0, downloadWaiterDepth: 0 });
+    mockBumpDownloadArmId.mockReturnValue(1);
+    mockNormalizeTimeoutMs.mockReturnValue(1000);
+    const saveAs = vi.fn((tempPath: string) => {
+      writeFileSync(tempPath, 'payload');
+      return Promise.resolve();
+    });
+
+    const pending = waitForDownloadViaPlaywright({ cdpUrl: 'http://localhost:9222' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    emit({ url: () => 'https://example.com/report.pdf', suggestedFilename: () => 'report.pdf', saveAs });
+    const result = await pending;
+
+    expect(result.path.startsWith(DEFAULT_DOWNLOAD_DIR)).toBe(true);
+    expect(result.path).toMatch(/[0-9a-f-]{36}-report\.pdf$/);
+    expect(existsSync(result.path)).toBe(true);
+    rmSync(result.path, { force: true });
+  });
+});

--- a/src/actions/download.test.ts
+++ b/src/actions/download.test.ts
@@ -160,3 +160,59 @@ describe('download URL validation before saving bytes', () => {
     expect(existsSync(outPath)).toBe(true);
   });
 });
+
+const { armNavigationDownloadCapture } = await import('./download.js');
+
+describe('armNavigationDownloadCapture — secure-by-default URL validation', () => {
+  function pageWithDownloadEmitter(): { page: Page; emit: (download: unknown) => void } {
+    let downloadHandler: ((download: unknown) => void) | undefined;
+    const page = {
+      on: (event: string, handler: (download: unknown) => void) => {
+        if (event === 'download') downloadHandler = handler;
+      },
+      off: () => undefined,
+    } as unknown as Page;
+    return { page, emit: (d: unknown) => downloadHandler?.(d) };
+  }
+
+  function makeState() {
+    return {
+      armIdDownload: 0,
+      downloadWaiterDepth: 0,
+    } as unknown as import('../types.js').PageState;
+  }
+
+  it('blocks a data: download URL even when no ssrfPolicy is set', async () => {
+    const { page, emit } = pageWithDownloadEmitter();
+    const capture = armNavigationDownloadCapture(page, makeState(), 1000, 'https://example.com/page');
+    expect(capture.armed).toBe(true);
+    emit({ url: () => 'data:text/plain,exfil', suggestedFilename: () => 'x.bin', saveAs: vi.fn() });
+    await expect(capture.promise).rejects.toThrow(/data:|not allowed/i);
+  });
+
+  it('blocks a private-host download URL with no policy (secure-by-default)', async () => {
+    const { page, emit } = pageWithDownloadEmitter();
+    const saveAs = vi.fn(() => Promise.resolve());
+    const capture = armNavigationDownloadCapture(page, makeState(), 1000, 'https://example.com/page');
+    emit({ url: () => 'http://169.254.169.254/latest/meta-data', suggestedFilename: () => 'x.bin', saveAs });
+    await expect(capture.promise).rejects.toThrow();
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the navigation URL when the download URL is empty', async () => {
+    const { page, emit } = pageWithDownloadEmitter();
+    const saveAs = vi.fn(() => Promise.resolve());
+    const capture = armNavigationDownloadCapture(page, makeState(), 1000, 'http://169.254.169.254/');
+    emit({ url: () => '', suggestedFilename: () => 'x.bin', saveAs });
+    await expect(capture.promise).rejects.toThrow();
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it('is not armed when an explicit download waiter is already active', () => {
+    const { page } = pageWithDownloadEmitter();
+    const state = makeState();
+    (state as { downloadWaiterDepth: number }).downloadWaiterDepth = 1;
+    const capture = armNavigationDownloadCapture(page, state, 1000, 'https://example.com/');
+    expect(capture.armed).toBe(false);
+  });
+});

--- a/src/actions/download.test.ts
+++ b/src/actions/download.test.ts
@@ -65,3 +65,98 @@ describe('downloadViaPlaywright — waiter rejection safety', () => {
     expect(unhandled).toEqual([]);
   });
 });
+
+const { waitForDownloadViaPlaywright, isDownloadStartingNavigationError } = await import('./download.js');
+
+describe('isDownloadStartingNavigationError', () => {
+  it('matches the Playwright download-start message', () => {
+    expect(isDownloadStartingNavigationError(new Error('page.goto: Download is starting'))).toBe(true);
+  });
+
+  it('matches net::ERR_ABORTED only when the message includes the expected URL', () => {
+    const err = new Error('page.goto: net::ERR_ABORTED at https://example.com/file.zip');
+    expect(isDownloadStartingNavigationError(err, 'https://example.com/file.zip')).toBe(true);
+    expect(isDownloadStartingNavigationError(err, 'https://other.com/file.zip')).toBe(false);
+    expect(isDownloadStartingNavigationError(err)).toBe(false);
+  });
+
+  it('rejects unrelated errors', () => {
+    expect(isDownloadStartingNavigationError(new Error('boom'), 'https://example.com')).toBe(false);
+  });
+});
+
+describe('download URL validation before saving bytes', () => {
+  function pageWithDownloadEmitter(): { page: Page; emit: (download: unknown) => void } {
+    let downloadHandler: ((download: unknown) => void) | undefined;
+    const page = {
+      on: (event: string, handler: (download: unknown) => void) => {
+        if (event === 'download') downloadHandler = handler;
+      },
+      off: () => undefined,
+    } as unknown as Page;
+    return {
+      page,
+      emit: (download: unknown) => {
+        downloadHandler?.(download);
+      },
+    };
+  }
+
+  it('rejects a policy-blocked download URL without calling saveAs', async () => {
+    const { page, emit } = pageWithDownloadEmitter();
+    mockGetPageForTargetId.mockResolvedValue(page);
+    mockEnsurePageState.mockReturnValue({ armIdDownload: 0, downloadWaiterDepth: 0 });
+    mockBumpDownloadArmId.mockReturnValue(1);
+    mockNormalizeTimeoutMs.mockReturnValue(1000);
+    const saveAs = vi.fn(() => Promise.resolve());
+    const fakeDownload = {
+      url: () => 'data:text/plain,exfiltrated',
+      suggestedFilename: () => 'file.bin',
+      saveAs,
+    };
+
+    const pending = waitForDownloadViaPlaywright({
+      cdpUrl: 'http://localhost:9222',
+      path: '/tmp/browserclaw-download-validate.bin',
+      ssrfPolicy: {},
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    emit(fakeDownload);
+    await expect(pending).rejects.toThrow('Navigation result blocked');
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it('saves the same download when no policy is provided (control)', async () => {
+    const { mkdtempSync, writeFileSync, existsSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = mkdtempSync(join(tmpdir(), 'bc-dl-test-'));
+    const outPath = join(dir, 'file.bin');
+
+    const { page, emit } = pageWithDownloadEmitter();
+    mockGetPageForTargetId.mockResolvedValue(page);
+    mockEnsurePageState.mockReturnValue({ armIdDownload: 0, downloadWaiterDepth: 0 });
+    mockBumpDownloadArmId.mockReturnValue(1);
+    mockNormalizeTimeoutMs.mockReturnValue(1000);
+    const saveAs = vi.fn((tempPath: string) => {
+      writeFileSync(tempPath, 'payload');
+      return Promise.resolve();
+    });
+    const fakeDownload = {
+      url: () => 'data:text/plain,exfiltrated',
+      suggestedFilename: () => 'file.bin',
+      saveAs,
+    };
+
+    const pending = waitForDownloadViaPlaywright({
+      cdpUrl: 'http://localhost:9222',
+      path: outPath,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    emit(fakeDownload);
+    const result = await pending;
+    expect(saveAs).toHaveBeenCalledTimes(1);
+    expect(result.path).toBe(outPath);
+    expect(existsSync(outPath)).toBe(true);
+  });
+});

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -1,4 +1,6 @@
-import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 import type { Page, Download } from 'playwright-core';
 
@@ -10,15 +12,29 @@ import {
   normalizeTimeoutMs,
   bumpDownloadArmId,
 } from '../connection.js';
-import { assertSafeOutputPath, writeViaSiblingTempPath, sanitizeUntrustedFileName } from '../security.js';
-import type { DownloadResult, PageState } from '../types.js';
+import {
+  DEFAULT_DOWNLOAD_DIR,
+  assertBrowserNavigationResultAllowed,
+  assertSafeOutputPath,
+  withBrowserNavigationPolicy,
+  writeViaSiblingTempPath,
+  sanitizeUntrustedFileName,
+} from '../security.js';
+import type { DownloadResult, PageState, SsrfPolicy } from '../types.js';
 
-function createPageDownloadWaiter(page: Page, timeoutMs: number) {
+function createPageDownloadWaiter(page: Page, state: PageState, timeoutMs: number, timeoutMessage?: string) {
   let done = false;
+  let depthReleased = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let handler: ((download: Download) => void) | undefined;
 
+  state.downloadWaiterDepth += 1;
+
   const cleanup = () => {
+    if (!depthReleased) {
+      depthReleased = true;
+      state.downloadWaiterDepth = Math.max(0, state.downloadWaiterDepth - 1);
+    }
     if (timer) clearTimeout(timer);
     timer = undefined;
     if (handler) {
@@ -39,7 +55,7 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
       if (done) return;
       done = true;
       cleanup();
-      reject(new Error('Timeout waiting for download'));
+      reject(new Error(timeoutMessage ?? 'Timeout waiting for download'));
     }, timeoutMs);
   });
   // Keep a handler attached so a timeout rejection before the caller awaits
@@ -54,6 +70,11 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
       cleanup();
     },
   };
+}
+
+async function assertDownloadUrlAllowed(download: Download, ssrfPolicy?: SsrfPolicy): Promise<void> {
+  if (!ssrfPolicy) return;
+  await assertBrowserNavigationResultAllowed({ url: download.url(), ...withBrowserNavigationPolicy(ssrfPolicy) });
 }
 
 async function saveDownloadPayload(download: Download, outPath: string): Promise<DownloadResult> {
@@ -72,15 +93,69 @@ async function saveDownloadPayload(download: Download, outPath: string): Promise
   };
 }
 
+function buildManagedDownloadPath(fileName: string): string {
+  const safeName = sanitizeUntrustedFileName(fileName, 'download.bin');
+  return join(DEFAULT_DOWNLOAD_DIR, `${randomUUID()}-${safeName}`);
+}
+
+/** A passive download capture armed for the duration of a navigation. */
+export interface NavigationDownloadCapture {
+  /** False when another download waiter is already active on the page. */
+  armed: boolean;
+  promise: Promise<DownloadResult>;
+  cancel: () => void;
+}
+
+/** Passive per-navigation download capture: policy-validates the URL before saving bytes; not armed while an explicit waiter is active. */
+export function armNavigationDownloadCapture(
+  page: Page,
+  state: PageState,
+  timeoutMs: number,
+  ssrfPolicy?: SsrfPolicy,
+): NavigationDownloadCapture {
+  if (state.downloadWaiterDepth > 0) {
+    return {
+      armed: false,
+      promise: new Promise<DownloadResult>(() => {
+        /* never settles — unarmed captures are cancelled by the caller */
+      }),
+      cancel: () => {
+        /* noop */
+      },
+    };
+  }
+  const waiter = createPageDownloadWaiter(page, state, timeoutMs, 'Timeout waiting for navigation download');
+  const promise = waiter.promise.then(async (download) => {
+    await assertDownloadUrlAllowed(download, ssrfPolicy);
+    await mkdir(DEFAULT_DOWNLOAD_DIR, { recursive: true });
+    return await saveDownloadPayload(
+      download,
+      buildManagedDownloadPath(download.suggestedFilename() || 'download.bin'),
+    );
+  });
+  promise.catch(() => undefined);
+  return { armed: true, promise, cancel: waiter.cancel };
+}
+
+/** True when a navigation failed because it started a file download instead. */
+export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: string): boolean {
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  if (message.includes('download is starting')) return true;
+  const normalizedUrl = expectedUrl?.trim().toLowerCase();
+  return Boolean(normalizedUrl && message.includes('net::err_aborted') && message.includes(normalizedUrl));
+}
+
 async function awaitDownloadPayload(params: {
   waiter: ReturnType<typeof createPageDownloadWaiter>;
   state: PageState;
   armId: number;
   outPath: string;
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<DownloadResult> {
   try {
     const download = await params.waiter.promise;
     if (params.state.armIdDownload !== params.armId) throw new Error('Download was superseded by another waiter');
+    await assertDownloadUrlAllowed(download, params.ssrfPolicy);
     return await saveDownloadPayload(download, params.outPath);
   } catch (err) {
     params.waiter.cancel();
@@ -95,10 +170,11 @@ export async function downloadViaPlaywright(opts: {
   path: string;
   timeoutMs?: number;
   allowedOutputRoots?: string[];
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<DownloadResult> {
   await assertSafeOutputPath(opts.path, opts.allowedOutputRoots);
 
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: opts.ssrfPolicy });
   const state = ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
@@ -107,7 +183,7 @@ export async function downloadViaPlaywright(opts: {
 
   const armId = bumpDownloadArmId(state);
   state.armIdDownload = armId;
-  const waiter = createPageDownloadWaiter(page, timeout);
+  const waiter = createPageDownloadWaiter(page, state, timeout);
 
   try {
     const locator = refLocator(page, opts.ref);
@@ -116,7 +192,7 @@ export async function downloadViaPlaywright(opts: {
     } catch (err) {
       throw toAIFriendlyError(err, opts.ref);
     }
-    return await awaitDownloadPayload({ waiter, state, armId, outPath });
+    return await awaitDownloadPayload({ waiter, state, armId, outPath, ssrfPolicy: opts.ssrfPolicy });
   } catch (err) {
     waiter.cancel();
     throw err;
@@ -129,8 +205,9 @@ export async function waitForDownloadViaPlaywright(opts: {
   path?: string;
   timeoutMs?: number;
   allowedOutputRoots?: string[];
+  ssrfPolicy?: SsrfPolicy;
 }): Promise<DownloadResult> {
-  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId });
+  const page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: opts.ssrfPolicy });
   const state = ensurePageState(page);
 
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120000);
@@ -138,13 +215,14 @@ export async function waitForDownloadViaPlaywright(opts: {
   state.armIdDownload = bumpDownloadArmId(state);
   const armId = state.armIdDownload;
 
-  const waiter = createPageDownloadWaiter(page, timeout);
+  const waiter = createPageDownloadWaiter(page, state, timeout);
   try {
     const download = await waiter.promise;
     if (state.armIdDownload !== armId) throw new Error('Download was superseded by another waiter');
     const savePath =
       opts.path ?? sanitizeUntrustedFileName(download.suggestedFilename() || 'download.bin', 'download.bin');
     await assertSafeOutputPath(savePath, opts.allowedOutputRoots);
+    await assertDownloadUrlAllowed(download, opts.ssrfPolicy);
     return await saveDownloadPayload(download, savePath);
   } catch (err) {
     waiter.cancel();

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -77,6 +77,20 @@ async function assertDownloadUrlAllowed(download: Download, ssrfPolicy?: SsrfPol
   await assertBrowserNavigationResultAllowed({ url: download.url(), ...withBrowserNavigationPolicy(ssrfPolicy) });
 }
 
+// Unconditional (secure-by-default) — assertBrowserNavigationResultAllowed blocks
+// data:/blob: and, with no policy, private/loopback hosts, matching what the
+// navigation that triggered the download was already validated against.
+async function assertNavigationDownloadUrlAllowed(
+  download: Download,
+  navigationUrl: string,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<void> {
+  await assertBrowserNavigationResultAllowed({
+    url: download.url() || navigationUrl,
+    ...withBrowserNavigationPolicy(ssrfPolicy),
+  });
+}
+
 async function saveDownloadPayload(download: Download, outPath: string): Promise<DownloadResult> {
   await writeViaSiblingTempPath({
     rootDir: dirname(outPath),
@@ -111,6 +125,7 @@ export function armNavigationDownloadCapture(
   page: Page,
   state: PageState,
   timeoutMs: number,
+  navigationUrl: string,
   ssrfPolicy?: SsrfPolicy,
 ): NavigationDownloadCapture {
   if (state.downloadWaiterDepth > 0) {
@@ -126,7 +141,7 @@ export function armNavigationDownloadCapture(
   }
   const waiter = createPageDownloadWaiter(page, state, timeoutMs, 'Timeout waiting for navigation download');
   const promise = waiter.promise.then(async (download) => {
-    await assertDownloadUrlAllowed(download, ssrfPolicy);
+    await assertNavigationDownloadUrlAllowed(download, navigationUrl, ssrfPolicy);
     await mkdir(DEFAULT_DOWNLOAD_DIR, { recursive: true });
     return await saveDownloadPayload(
       download,

--- a/src/actions/download.ts
+++ b/src/actions/download.ts
@@ -234,8 +234,15 @@ export async function waitForDownloadViaPlaywright(opts: {
   try {
     const download = await waiter.promise;
     if (state.armIdDownload !== armId) throw new Error('Download was superseded by another waiter');
-    const savePath =
-      opts.path ?? sanitizeUntrustedFileName(download.suggestedFilename() || 'download.bin', 'download.bin');
+    // With no explicit path, save into the managed downloads dir under a UUID —
+    // never the process CWD with a page-controlled filename (overwrite risk).
+    let savePath: string;
+    if (opts.path === undefined) {
+      await mkdir(DEFAULT_DOWNLOAD_DIR, { recursive: true });
+      savePath = buildManagedDownloadPath(download.suggestedFilename() || 'download.bin');
+    } else {
+      savePath = opts.path;
+    }
     await assertSafeOutputPath(savePath, opts.allowedOutputRoots);
     await assertDownloadUrlAllowed(download, opts.ssrfPolicy);
     return await saveDownloadPayload(download, savePath);

--- a/src/actions/interaction.ts
+++ b/src/actions/interaction.ts
@@ -396,25 +396,25 @@ export async function typeViaPlaywright(opts: {
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
 
   try {
-    if (opts.slowly === true) {
-      await locator.click({ timeout });
-      await locator.pressSequentially(text, { timeout, delay: 75 });
-    } else {
-      await locator.fill(text, { timeout });
-    }
-    if (opts.submit === true) {
-      const previousUrl = page.url();
-      await assertInteractionNavigationCompletedSafely({
-        action: async () => {
-          await locator.press('Enter', { timeout });
-        },
-        cdpUrl: opts.cdpUrl,
-        page,
-        previousUrl,
-        ssrfPolicy: opts.ssrfPolicy,
-        targetId: opts.targetId,
-      });
-    }
+    // Guard the entire fill/type sequence, not just submit — an input/change
+    // handler can trigger a JS navigation on fill alone.
+    const previousUrl = page.url();
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        if (opts.slowly === true) {
+          await locator.click({ timeout });
+          await locator.pressSequentially(text, { timeout, delay: 75 });
+        } else {
+          await locator.fill(text, { timeout });
+        }
+        if (opts.submit === true) await locator.press('Enter', { timeout });
+      },
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -30,9 +30,15 @@ import {
   assertBrowserNavigationRedirectChainAllowed,
   withBrowserNavigationPolicy,
 } from '../security.js';
+import { isCdpUrlProxyRouted } from '../chrome-launcher.js';
 import type { BrowserTab, DownloadResult, SsrfPolicy } from '../types.js';
 
 import { armNavigationDownloadCapture, isDownloadStartingNavigationError } from './download.js';
+
+/** Navigation-policy proxy-mode addendum for a cdpUrl whose Chrome is proxy-routed. */
+function proxyModeOpts(cdpUrl: string): { browserProxyMode?: 'explicit-browser-proxy' } {
+  return isCdpUrlProxyRouted(cdpUrl) ? { browserProxyMode: 'explicit-browser-proxy' } : {};
+}
 
 const recordingContexts = new Map<string, BrowserContext>();
 
@@ -124,7 +130,7 @@ export async function assertPageNavigationCompletedSafely(opts: {
   ssrfPolicy?: SsrfPolicy;
   targetId?: string;
 }): Promise<void> {
-  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy, proxyModeOpts(opts.cdpUrl));
   try {
     await assertBrowserNavigationRedirectChainAllowed({ request: opts.response?.request(), ...navigationPolicy });
     await assertBrowserNavigationResultAllowed({ url: opts.page.url(), ...navigationPolicy });
@@ -169,10 +175,17 @@ function isMainFrameNavigation(page: Page, frame: Frame): boolean {
   return frame === page.mainFrame();
 }
 
-async function assertSubframeNavigationAllowed(frameUrl: string, ssrfPolicy?: SsrfPolicy): Promise<void> {
+async function assertSubframeNavigationAllowed(
+  cdpUrl: string,
+  frameUrl: string,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<void> {
   if (!ssrfPolicy) return;
   if (!frameUrl.startsWith('http://') && !frameUrl.startsWith('https://')) return;
-  await assertBrowserNavigationResultAllowed({ url: frameUrl, ...withBrowserNavigationPolicy(ssrfPolicy) });
+  await assertBrowserNavigationResultAllowed({
+    url: frameUrl,
+    ...withBrowserNavigationPolicy(ssrfPolicy, proxyModeOpts(cdpUrl)),
+  });
 }
 
 function snapshotNetworkFrameUrl(frame: Frame): string | null {
@@ -205,7 +218,8 @@ async function assertObservedDelayedNavigations(opts: {
 }): Promise<void> {
   let subframeError: Error | undefined;
   try {
-    for (const frameUrl of opts.observed.subframes) await assertSubframeNavigationAllowed(frameUrl, opts.ssrfPolicy);
+    for (const frameUrl of opts.observed.subframes)
+      await assertSubframeNavigationAllowed(opts.cdpUrl, frameUrl, opts.ssrfPolicy);
   } catch (err) {
     subframeError = err instanceof Error ? err : new Error(formatThrown(err));
   }
@@ -363,7 +377,7 @@ export async function assertInteractionNavigationCompletedSafely<T>(opts: {
   let subframeError: Error | undefined;
   try {
     for (const frameUrl of subframeNavigationsDuringAction) {
-      await assertSubframeNavigationAllowed(frameUrl, opts.ssrfPolicy ?? {});
+      await assertSubframeNavigationAllowed(opts.cdpUrl, frameUrl, opts.ssrfPolicy ?? {});
     }
   } catch (err) {
     subframeError = err instanceof Error ? err : new Error(formatThrown(err));
@@ -413,7 +427,7 @@ async function gotoPageWithNavigationGuard(opts: {
   ssrfPolicy?: SsrfPolicy;
   targetId?: string;
 }): Promise<Awaited<ReturnType<Page['goto']>>> {
-  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy, proxyModeOpts(opts.cdpUrl));
   const state: { blocked: Error | null } = { blocked: null };
   const safeContinue = async (route: Route): Promise<void> => {
     try {
@@ -492,7 +506,7 @@ export async function navigateViaPlaywright(opts: {
   const policy =
     opts.allowInternal === true ? { ...opts.ssrfPolicy, dangerouslyAllowPrivateNetwork: true } : opts.ssrfPolicy;
   /* eslint-enable @typescript-eslint/no-deprecated */
-  await assertBrowserNavigationAllowed({ url, ...withBrowserNavigationPolicy(policy) });
+  await assertBrowserNavigationAllowed({ url, ...withBrowserNavigationPolicy(policy, proxyModeOpts(opts.cdpUrl)) });
 
   const timeout = Math.max(1000, Math.min(120000, opts.timeoutMs ?? 20000));
   let page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: policy });
@@ -665,7 +679,10 @@ export async function createPageViaPlaywright(opts: {
   // Preflight URL policy *before* allocating a tab. Otherwise a denial would
   // leak the freshly-created blank tab into the browser session.
   if (targetUrl !== 'about:blank') {
-    await assertBrowserNavigationAllowed({ url: targetUrl, ...withBrowserNavigationPolicy(policy) });
+    await assertBrowserNavigationAllowed({
+      url: targetUrl,
+      ...withBrowserNavigationPolicy(policy, proxyModeOpts(opts.cdpUrl)),
+    });
   }
 
   const { browser } = await connectBrowser(opts.cdpUrl, undefined, policy, { stealth: opts.stealth });

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -512,7 +512,7 @@ export async function navigateViaPlaywright(opts: {
     response: Awaited<ReturnType<typeof navigate>>;
     download?: DownloadResult;
   }> => {
-    const capture = armNavigationDownloadCapture(page, pageState, timeout, policy);
+    const capture = armNavigationDownloadCapture(page, pageState, timeout, url, policy);
     try {
       const response = await navigate();
       capture.cancel();

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -30,7 +30,9 @@ import {
   assertBrowserNavigationRedirectChainAllowed,
   withBrowserNavigationPolicy,
 } from '../security.js';
-import type { BrowserTab, SsrfPolicy } from '../types.js';
+import type { BrowserTab, DownloadResult, SsrfPolicy } from '../types.js';
+
+import { armNavigationDownloadCapture, isDownloadStartingNavigationError } from './download.js';
 
 const recordingContexts = new Map<string, BrowserContext>();
 
@@ -483,7 +485,7 @@ export async function navigateViaPlaywright(opts: {
   ssrfPolicy?: SsrfPolicy;
   /** @deprecated Use ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } instead */
   allowInternal?: boolean;
-}): Promise<{ url: string }> {
+}): Promise<{ url: string; download?: DownloadResult }> {
   const url = opts.url.trim();
   if (!url) throw new Error('url is required');
   /* eslint-disable @typescript-eslint/no-deprecated */
@@ -494,7 +496,7 @@ export async function navigateViaPlaywright(opts: {
 
   const timeout = Math.max(1000, Math.min(120000, opts.timeoutMs ?? 20000));
   let page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: policy });
-  ensurePageState(page);
+  let pageState = ensurePageState(page);
 
   const navigate = async () =>
     await gotoPageWithNavigationGuard({
@@ -506,9 +508,35 @@ export async function navigateViaPlaywright(opts: {
       targetId: opts.targetId,
     });
 
-  let response;
+  const navigateWithDownloadCapture = async (): Promise<{
+    response: Awaited<ReturnType<typeof navigate>>;
+    download?: DownloadResult;
+  }> => {
+    const capture = armNavigationDownloadCapture(page, pageState, timeout, policy);
+    try {
+      const response = await navigate();
+      capture.cancel();
+      return { response };
+    } catch (err) {
+      if (!capture.armed || !isDownloadStartingNavigationError(err, url)) {
+        capture.cancel();
+        throw err;
+      }
+      try {
+        return { response: null, download: await capture.promise };
+      } catch (downloadErr) {
+        if (downloadErr instanceof Error && downloadErr.message === 'Timeout waiting for navigation download')
+          throw err;
+        if (isPolicyDenyNavigationError(downloadErr))
+          await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page, targetId: opts.targetId });
+        throw downloadErr;
+      }
+    }
+  };
+
+  let navigationResult;
   try {
-    response = await navigate();
+    navigationResult = await navigateWithDownloadCapture();
   } catch (err) {
     if (!isRetryableNavigateError(err)) throw err;
     // Clean recording context before force-disconnect to prevent stale references
@@ -522,24 +550,29 @@ export async function navigateViaPlaywright(opts: {
       /* intentional no-op */
     });
     page = await getPageForTargetId({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, ssrfPolicy: policy });
-    ensurePageState(page);
-    response = await navigate();
+    pageState = ensurePageState(page);
+    navigationResult = await navigateWithDownloadCapture();
   }
 
-  try {
-    await assertPageNavigationCompletedSafely({
-      cdpUrl: opts.cdpUrl,
-      page,
-      response,
-      ssrfPolicy: policy,
-      targetId: opts.targetId,
-    });
-  } catch (err) {
-    if (isPolicyDenyNavigationError(err))
-      await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page, targetId: opts.targetId });
-    throw err;
+  if (!navigationResult.download) {
+    try {
+      await assertPageNavigationCompletedSafely({
+        cdpUrl: opts.cdpUrl,
+        page,
+        response: navigationResult.response,
+        ssrfPolicy: policy,
+        targetId: opts.targetId,
+      });
+    } catch (err) {
+      if (isPolicyDenyNavigationError(err))
+        await closeBlockedNavigationTarget({ cdpUrl: opts.cdpUrl, page, targetId: opts.targetId });
+      throw err;
+    }
   }
-  return { url: page.url() };
+  return {
+    url: navigationResult.download?.url ?? page.url(),
+    ...(navigationResult.download ? { download: navigationResult.download } : {}),
+  };
 }
 
 async function listPagesViaPlaywrightOnce(cdpUrl: string): Promise<BrowserTab[]> {
@@ -562,14 +595,55 @@ async function listPagesViaPlaywrightOnce(cdpUrl: string): Promise<BrowserTab[]>
   return results;
 }
 
-export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<BrowserTab[]> {
-  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
+async function listPagesWithRecovery(cdpUrl: string, attempt?: { cancelled: boolean }): Promise<BrowserTab[]> {
+  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(cdpUrl);
   try {
-    return await listPagesViaPlaywrightOnce(opts.cdpUrl);
+    return await listPagesViaPlaywrightOnce(cdpUrl);
   } catch (err) {
-    if (!reusedCachedBrowser || !isRecoverablePlaywrightDisconnectError(err)) throw err;
-    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl, preserveSsrfState: true });
-    return await listPagesViaPlaywrightOnce(opts.cdpUrl);
+    if (!reusedCachedBrowser || !isRecoverablePlaywrightDisconnectError(err) || attempt?.cancelled) throw err;
+    await closePlaywrightBrowserConnection({ cdpUrl, preserveSsrfState: true });
+    if (attempt?.cancelled) throw err;
+    return await listPagesViaPlaywrightOnce(cdpUrl);
+  }
+}
+
+export async function listPagesViaPlaywright(opts: {
+  cdpUrl: string;
+  timeoutMs?: number;
+  ssrfPolicy?: SsrfPolicy;
+}): Promise<BrowserTab[]> {
+  const timeoutMs =
+    typeof opts.timeoutMs === 'number' && Number.isFinite(opts.timeoutMs)
+      ? Math.max(1, Math.floor(opts.timeoutMs))
+      : undefined;
+  if (timeoutMs === undefined) return await listPagesWithRecovery(opts.cdpUrl);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
+  const attempt = { cancelled: false };
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      attempt.cancelled = true;
+      timeoutError = new Error(`Playwright page enumeration timed out after ${String(timeoutMs)}ms`);
+      reject(timeoutError);
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([listPagesWithRecovery(opts.cdpUrl, attempt), timeout]);
+  } catch (err) {
+    // Retire the wedged connection so a late completion cannot restore it.
+    if (timeoutError !== undefined && err === timeoutError)
+      await forceDisconnectPlaywrightConnection({
+        cdpUrl: opts.cdpUrl,
+        reason: 'Playwright page enumeration',
+        ssrfPolicy: opts.ssrfPolicy,
+      }).catch(() => {
+        /* noop */
+      });
+    throw err;
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -844,7 +844,7 @@ export class CrawlPage {
    * @param opts - Timeout options
    * @returns The final URL after navigation (may differ due to redirects)
    */
-  async goto(url: string, opts?: { timeoutMs?: number }): Promise<{ url: string }> {
+  async goto(url: string, opts?: { timeoutMs?: number }): Promise<{ url: string; download?: DownloadResult }> {
     return navigateViaPlaywright({
       cdpUrl: this.cdpUrl,
       targetId: this._targetId,
@@ -1332,6 +1332,7 @@ export class CrawlPage {
       path,
       timeoutMs: opts?.timeoutMs,
       allowedOutputRoots: opts?.allowedOutputRoots,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 
@@ -1354,6 +1355,7 @@ export class CrawlPage {
       path: opts?.path,
       timeoutMs: opts?.timeoutMs,
       allowedOutputRoots: opts?.allowedOutputRoots,
+      ssrfPolicy: this.ssrfPolicy,
     });
   }
 

--- a/src/capture/response.ts
+++ b/src/capture/response.ts
@@ -1,5 +1,11 @@
-import { getPageForTargetId, ensurePageState, normalizeTimeoutMs } from '../connection.js';
+import { getPageForTargetId, ensurePageState, normalizeTimeoutMs, truncateUtf16Safe } from '../connection.js';
 import type { RequestResult, ResponseBodyResult } from '../types.js';
+
+function resolveMaxChars(maxChars: number | undefined): number {
+  return typeof maxChars === 'number' && Number.isFinite(maxChars)
+    ? Math.max(1, Math.min(5_000_000, Math.floor(maxChars)))
+    : 200000;
+}
 
 function matchUrlPattern(pattern: string, url: string): boolean {
   if (!pattern || !url) return false;
@@ -30,22 +36,23 @@ export async function responseBodyViaPlaywright(opts: {
   if (!pattern) throw new Error('url is required');
 
   const response = await page.waitForResponse((resp) => matchUrlPattern(pattern, resp.url()), { timeout });
+  const maxChars = resolveMaxChars(opts.maxChars);
+  // Decode at most maxBytes so an oversized body cannot force an unbounded string.
+  const maxBytes = maxChars * 4;
   let body: string;
+  let bodyByteLength = 0;
   try {
-    body = await response.text();
+    const buf = await response.body();
+    bodyByteLength = buf.byteLength;
+    body = new TextDecoder('utf-8').decode(buf.subarray(0, maxBytes));
   } catch (err) {
     throw new Error(
       `Failed to read response body for "${pattern}": ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-  let truncated = false;
-
-  const maxChars =
-    typeof opts.maxChars === 'number' && Number.isFinite(opts.maxChars)
-      ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars)))
-      : 200000;
+  let truncated = bodyByteLength > maxBytes;
   if (body.length > maxChars) {
-    body = body.slice(0, maxChars);
+    body = truncateUtf16Safe(body, maxChars);
     truncated = true;
   }
 
@@ -91,13 +98,13 @@ export async function waitForRequestViaPlaywright(opts: {
   let truncated = false;
 
   try {
-    responseBody = await response.text();
-    const maxChars =
-      typeof opts.maxChars === 'number' && Number.isFinite(opts.maxChars)
-        ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars)))
-        : 200000;
+    const maxChars = resolveMaxChars(opts.maxChars);
+    const maxBytes = maxChars * 4;
+    const buf = await response.body();
+    responseBody = new TextDecoder('utf-8').decode(buf.subarray(0, maxBytes));
+    if (buf.byteLength > maxBytes) truncated = true;
     if (responseBody.length > maxChars) {
-      responseBody = responseBody.slice(0, maxChars);
+      responseBody = truncateUtf16Safe(responseBody, maxChars);
       truncated = true;
     }
   } catch (err) {

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -45,6 +45,9 @@ const {
   activateMacOsWindowByPid,
   readJsonResponseBounded,
   getChromeWebSocketUrl,
+  markCdpUrlProxyRouted,
+  clearCdpUrlProxyRouted,
+  isCdpUrlProxyRouted,
 } = await import('./chrome-launcher.js');
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -835,5 +838,30 @@ describe('getChromeWebSocketUrl with URL credentials', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// proxy-routed CDP URL registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('proxy-routed CDP URL registry', () => {
+  it('marks, reports, and clears a proxy-routed cdpUrl (normalizing trailing slash/case)', () => {
+    const url = 'http://127.0.0.1:9222';
+    expect(isCdpUrlProxyRouted(url)).toBe(false);
+    markCdpUrlProxyRouted(url);
+    expect(isCdpUrlProxyRouted(url)).toBe(true);
+    // normalization: trailing slash + case are ignored
+    expect(isCdpUrlProxyRouted('http://127.0.0.1:9222/')).toBe(true);
+    expect(isCdpUrlProxyRouted('HTTP://127.0.0.1:9222')).toBe(true);
+    clearCdpUrlProxyRouted(url);
+    expect(isCdpUrlProxyRouted(url)).toBe(false);
+  });
+
+  it('keeps distinct ports separate', () => {
+    markCdpUrlProxyRouted('http://127.0.0.1:9333');
+    expect(isCdpUrlProxyRouted('http://127.0.0.1:9333')).toBe(true);
+    expect(isCdpUrlProxyRouted('http://127.0.0.1:9334')).toBe(false);
+    clearCdpUrlProxyRouted('http://127.0.0.1:9333');
   });
 });

--- a/src/chrome-launcher.test.ts
+++ b/src/chrome-launcher.test.ts
@@ -43,6 +43,8 @@ const {
   wipeChromeSessionState,
   reserveFreePortFromList,
   activateMacOsWindowByPid,
+  readJsonResponseBounded,
+  getChromeWebSocketUrl,
 } = await import('./chrome-launcher.js');
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -204,6 +206,11 @@ describe('normalizeCdpWsUrl', () => {
     const result = normalizeCdpWsUrl('ws://localhost:9222/devtools/browser/abc', 'http://127.0.0.1:9222');
     expect(result).toContain('127.0.0.1');
     expect(result).not.toContain('localhost');
+  });
+
+  it('inherits the cdp port when a loopback ws URL omits its port', () => {
+    const result = normalizeCdpWsUrl('ws://localhost/devtools/browser/abc', 'http://127.0.0.1:9222');
+    expect(result).toContain('127.0.0.1:9222');
   });
 
   it('normalizes loopback aliases in reverse (ws 127.0.0.1, cdp localhost → use cdp alias)', () => {
@@ -542,6 +549,14 @@ describe('buildChromeLaunchArgs', () => {
     expect(args).toContain('--disable-features=Translate,MediaRouter');
   });
 
+  it('adds --use-mock-keychain only on darwin with useMockKeychain', () => {
+    expect(buildChromeLaunchArgs({ ...baseOpts, useMockKeychain: true })).toContain('--use-mock-keychain');
+    expect(buildChromeLaunchArgs(baseOpts)).not.toContain('--use-mock-keychain');
+    expect(
+      buildChromeLaunchArgs({ ...baseOpts, platform: 'linux' as NodeJS.Platform, useMockKeychain: true }),
+    ).not.toContain('--use-mock-keychain');
+  });
+
   it('adds --password-store=basic on every platform (matches OpenClaw; avoids macOS Keychain hang)', () => {
     for (const platform of ['linux', 'darwin', 'win32'] as const) {
       expect(buildChromeLaunchArgs({ ...baseOpts, platform })).toContain('--password-store=basic');
@@ -736,5 +751,89 @@ describe('activateMacOsWindowByPid', () => {
       throw new Error('osascript not found');
     });
     await expect(activateMacOsWindowByPid(99)).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// readJsonResponseBounded
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('readJsonResponseBounded', () => {
+  it('parses a JSON body within the limit', async () => {
+    await expect(readJsonResponseBounded(new Response('{"a":1}'), 'test')).resolves.toEqual({ a: 1 });
+  });
+
+  it('rejects a body that exceeds the byte limit', async () => {
+    const res = new Response(`"${'x'.repeat(64)}"`);
+    await expect(readJsonResponseBounded(res, 'test', 16)).rejects.toThrow('test: JSON response exceeds 16 bytes');
+  });
+
+  it('rejects malformed JSON with a labeled error', async () => {
+    await expect(readJsonResponseBounded(new Response('{oops'), 'test')).rejects.toThrow(
+      'test: malformed JSON response',
+    );
+  });
+
+  it('reads via arrayBuffer when the response has no stream body', async () => {
+    const bytes = new TextEncoder().encode('[1,2,3]');
+    const res = { body: undefined, arrayBuffer: () => Promise.resolve(bytes.buffer) } as unknown as Response;
+    await expect(readJsonResponseBounded(res, 'test')).resolves.toEqual([1, 2, 3]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getChromeWebSocketUrl — credential-bearing endpoints
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getChromeWebSocketUrl with URL credentials', () => {
+  it('moves URL credentials into a Basic Authorization header and never fetches a credentialed URL', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/browser/abc' })),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const wsUrl = await getChromeWebSocketUrl('http://user:p%40ss@127.0.0.1:9222', 500);
+      expect(wsUrl).toContain('/devtools/browser/abc');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [fetchedUrl, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+      expect(fetchedUrl).toBe('http://127.0.0.1:9222/json/version');
+      expect(init.headers.Authorization).toBe(`Basic ${Buffer.from('user:p@ss').toString('base64')}`);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('retries /json/version/ when a credentialed endpoint exposes no WebSocket URL', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({})))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/browser/xyz' })),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const wsUrl = await getChromeWebSocketUrl('http://user:pass@127.0.0.1:9222', 500);
+      expect(wsUrl).toContain('/devtools/browser/xyz');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const secondUrl = (fetchMock.mock.calls[1] as [string])[0];
+      expect(secondUrl).toBe('http://127.0.0.1:9222/json/version/');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('does not retry the trailing-slash form for credential-free endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({})));
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      await getChromeWebSocketUrl('http://127.0.0.1:9222', 500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+      expect(init.headers.Authorization).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -1075,12 +1075,39 @@ const PROXY_CONTROL_CHROME_ARGS = new Set([
   '--proxy-auto-detect',
 ]);
 
+// Args that route Chrome's traffic through a proxy (excludes --no-proxy-server).
+const PROXY_ROUTING_CHROME_ARGS = new Set(['--proxy-server', '--proxy-pac-url', '--proxy-auto-detect']);
+
 function chromeArgName(arg: string): string {
   return arg.trim().split('=', 1)[0]?.toLowerCase() ?? '';
 }
 
 function hasChromeProxyControlArg(args: readonly string[]): boolean {
   return args.some((arg) => PROXY_CONTROL_CHROME_ARGS.has(chromeArgName(arg)));
+}
+
+function hasChromeProxyRoutingArg(args: readonly string[]): boolean {
+  return args.some((arg) => PROXY_ROUTING_CHROME_ARGS.has(chromeArgName(arg)));
+}
+
+// CDP URLs whose Chrome was launched proxy-routed — navigation under a strict SSRF
+// policy fails closed for these (the proxy egresses, defeating local address checks).
+const proxyRoutedCdpUrls = new Set<string>();
+
+function proxyRoutedKey(cdpUrl: string): string {
+  return cdpUrl.trim().replace(/\/+$/, '').toLowerCase();
+}
+
+export function markCdpUrlProxyRouted(cdpUrl: string): void {
+  proxyRoutedCdpUrls.add(proxyRoutedKey(cdpUrl));
+}
+
+export function clearCdpUrlProxyRouted(cdpUrl: string): void {
+  proxyRoutedCdpUrls.delete(proxyRoutedKey(cdpUrl));
+}
+
+export function isCdpUrlProxyRouted(cdpUrl: string): boolean {
+  return proxyRoutedCdpUrls.has(proxyRoutedKey(cdpUrl));
 }
 
 export interface BuildChromeLaunchArgsOptions {
@@ -1213,6 +1240,12 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
 
   const cdpUrl = `http://127.0.0.1:${String(cdpPort)}`;
 
+  const extraArgsForProxyCheck = Array.isArray(opts.chromeArgs)
+    ? opts.chromeArgs.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
+    : [];
+  if (hasChromeProxyRoutingArg(extraArgsForProxyCheck)) markCdpUrlProxyRouted(cdpUrl);
+  else clearCdpUrlProxyRouted(cdpUrl);
+
   const launchOnceAndWait = async (
     allowSingletonRecovery: boolean,
   ): Promise<{ proc: ReturnType<typeof spawnChrome> }> => {
@@ -1342,6 +1375,7 @@ async function waitForChromeCdpShutdown(cdpPort: number, timeoutMs: number): Pro
 
 export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Promise<void> {
   const proc = running.proc;
+  clearCdpUrlProxyRouted(`http://127.0.0.1:${String(running.cdpPort)}`);
   const cleanupIsolated = () => {
     if (running.isolated !== true) return;
     try {

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -7,7 +7,12 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-import { assertCdpEndpointAllowed } from './security.js';
+import {
+  assertCdpEndpointAllowed,
+  getHeadersWithAuth,
+  scopeCdpPolicyToConfiguredEndpoint,
+  stripUrlCredentials,
+} from './security.js';
 import type { ChromeExecutable, ChromeKind, LaunchOptions, RunningChrome, SsrfPolicy } from './types.js';
 
 // ── Singleton Lock Recovery ──
@@ -566,6 +571,7 @@ function safeWriteJson(filePath: string, data: Record<string, unknown>): void {
 }
 
 function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown): void {
+  if (keys.length === 0) return;
   let node: Record<string, unknown> = obj;
   for (const key of keys.slice(0, -1)) {
     if (key === '__proto__' || key === 'constructor' || key === 'prototype') return;
@@ -579,6 +585,24 @@ function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown): 
   node[lastKey] = value;
 }
 
+function readNestedRecord(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const next = (value as Record<string, unknown>)[key];
+  if (typeof next !== 'object' || next === null || Array.isArray(next)) return undefined;
+  return next as Record<string, unknown>;
+}
+
+function readDefaultProfileInfo(localState: Record<string, unknown> | null): Record<string, unknown> | undefined {
+  return readNestedRecord(readNestedRecord(localState?.profile, 'info_cache'), 'Default');
+}
+
+/** Mock-keychain marker must stay consistent across launches or Chrome cannot decrypt stored cookies. */
+function usesBrowserclawMockKeychain(userDataDir: string): boolean {
+  return (
+    readDefaultProfileInfo(safeReadJson(path.join(userDataDir, 'Local State')))?.browserclaw_mock_keychain === true
+  );
+}
+
 function parseHexRgbToSignedArgbInt(hex: string): number | null {
   const cleaned = hex.trim().replace(/^#/, '');
   if (!/^[0-9a-fA-F]{6}$/.test(cleaned)) return null;
@@ -586,12 +610,13 @@ function parseHexRgbToSignedArgbInt(hex: string): number | null {
   return argbUnsigned > 2147483647 ? argbUnsigned - 4294967296 : argbUnsigned;
 }
 
-function decorateProfile(userDataDir: string, name: string, color: string): void {
+function decorateProfile(userDataDir: string, name: string, color: string, opts?: { mockKeychain?: boolean }): void {
   const colorInt = parseHexRgbToSignedArgbInt(color);
   const localStatePath = path.join(userDataDir, 'Local State');
   const preferencesPath = path.join(userDataDir, 'Default', 'Preferences');
 
   const localState = safeReadJson(localStatePath) ?? {};
+  if (opts?.mockKeychain) setDeep(localState, ['profile', 'info_cache', 'Default', 'browserclaw_mock_keychain'], true);
   setDeep(localState, ['profile', 'info_cache', 'Default', 'name'], name);
   setDeep(localState, ['profile', 'info_cache', 'Default', 'shortcut_name'], name);
   setDeep(localState, ['profile', 'info_cache', 'Default', 'user_name'], name);
@@ -757,6 +782,7 @@ export function normalizeCdpWsUrl(wsUrl: string, cdpUrl: string): string {
     ws.protocol = cdp.protocol === 'https:' ? 'wss:' : 'ws:';
   } else if (isLoopbackHost(ws.hostname) && isLoopbackHost(cdp.hostname)) {
     ws.hostname = cdp.hostname;
+    if (!ws.port && cdp.port) ws.port = cdp.port;
   }
   if (cdp.protocol === 'https:' && ws.protocol === 'ws:') ws.protocol = 'wss:';
   if (!ws.username && !ws.password && (cdp.username || cdp.password)) {
@@ -830,11 +856,56 @@ async function canOpenWebSocket(url: string, timeoutMs: number): Promise<boolean
   });
 }
 
+/** Cap on CDP `/json/*` response sizes so a hostile endpoint cannot force an unbounded buffer. */
+export const CDP_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
+/** Read a fetch Response body as JSON, failing once it exceeds `maxBytes`. */
+export async function readJsonResponseBounded(
+  res: Response,
+  label: string,
+  maxBytes: number = CDP_JSON_RESPONSE_MAX_BYTES,
+): Promise<unknown> {
+  const reader = res.body?.getReader();
+  let bytes: Uint8Array;
+  if (reader === undefined) {
+    const buf = new Uint8Array(await res.arrayBuffer());
+    if (buf.byteLength > maxBytes) throw new Error(`${label}: JSON response exceeds ${String(maxBytes)} bytes`);
+    bytes = buf;
+  } else {
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {
+          /* noop */
+        });
+        throw new Error(`${label}: JSON response exceeds ${String(maxBytes)} bytes`);
+      }
+      chunks.push(value);
+    }
+    bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (cause) {
+    throw new Error(`${label}: malformed JSON response`, { cause });
+  }
+}
+
 async function fetchChromeVersion(
   cdpUrl: string,
   timeoutMs = 500,
   authToken?: string,
   ssrfPolicy?: SsrfPolicy,
+  versionPath = '/json/version',
 ): Promise<Record<string, unknown> | null> {
   try {
     await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
@@ -847,11 +918,13 @@ async function fetchChromeVersion(
   }, timeoutMs);
   try {
     const httpBase = isWebSocketUrl(cdpUrl) ? normalizeCdpHttpBaseForJsonEndpoints(cdpUrl) : cdpUrl;
-    const headers: Record<string, string> = {};
-    if (authToken !== undefined && authToken !== '') headers.Authorization = `Bearer ${authToken}`;
-    const res = await fetch(appendCdpPath(httpBase, '/json/version'), { signal: ctrl.signal, headers });
+    const versionUrl = appendCdpPath(httpBase, versionPath);
+    const headers: Record<string, string> = getHeadersWithAuth(versionUrl);
+    if (authToken !== undefined && authToken !== '' && !headers.Authorization)
+      headers.Authorization = `Bearer ${authToken}`;
+    const res = await fetch(stripUrlCredentials(versionUrl), { signal: ctrl.signal, headers });
     if (!res.ok) return null;
-    const data: unknown = await res.json();
+    const data: unknown = await readJsonResponseBounded(res, 'cdp-version');
     if (data === null || data === undefined || typeof data !== 'object') return null;
     return data as Record<string, unknown>;
   } catch {
@@ -859,6 +932,22 @@ async function fetchChromeVersion(
   } finally {
     clearTimeout(t);
   }
+}
+
+/** Retry `/json/version/` for credentialed endpoints whose proxy only serves the trailing-slash form. */
+async function fetchChromeVersionWithCredentialFallback(
+  cdpUrl: string,
+  timeoutMs = 500,
+  authToken?: string,
+  ssrfPolicy?: SsrfPolicy,
+): Promise<Record<string, unknown> | null> {
+  const primary = await fetchChromeVersion(cdpUrl, timeoutMs, authToken, ssrfPolicy);
+  const hasCredentials = stripUrlCredentials(cdpUrl) !== cdpUrl;
+  if (!hasCredentials) return primary;
+  const primaryWsUrl = typeof primary?.webSocketDebuggerUrl === 'string' ? primary.webSocketDebuggerUrl.trim() : '';
+  if (primaryWsUrl !== '') return primary;
+  const fallback = await fetchChromeVersion(cdpUrl, timeoutMs, authToken, ssrfPolicy, '/json/version/');
+  return fallback ?? primary;
 }
 
 export async function discoverChromeCdpUrl(timeoutMs = 500): Promise<string | null> {
@@ -883,8 +972,9 @@ export async function isChromeReachable(
     return false;
   }
   if (isDirectCdpWebSocketEndpoint(cdpUrl)) return await canOpenWebSocket(cdpUrl, timeoutMs);
+  const cdpControlPolicy = scopeCdpPolicyToConfiguredEndpoint(cdpUrl, ssrfPolicy);
   const discoveryUrl = isWebSocketUrl(cdpUrl) ? normalizeCdpHttpBaseForJsonEndpoints(cdpUrl) : cdpUrl;
-  const version = await fetchChromeVersion(discoveryUrl, timeoutMs, authToken, ssrfPolicy);
+  const version = await fetchChromeVersion(discoveryUrl, timeoutMs, authToken, cdpControlPolicy);
   if (version !== null) return true;
   if (isWebSocketUrl(cdpUrl)) return await canOpenWebSocket(cdpUrl, timeoutMs);
   return false;
@@ -898,8 +988,9 @@ export async function getChromeWebSocketUrl(
 ): Promise<string | null> {
   await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
   if (isDirectCdpWebSocketEndpoint(cdpUrl)) return cdpUrl;
+  const cdpControlPolicy = scopeCdpPolicyToConfiguredEndpoint(cdpUrl, ssrfPolicy);
   const discoveryUrl = isWebSocketUrl(cdpUrl) ? normalizeCdpHttpBaseForJsonEndpoints(cdpUrl) : cdpUrl;
-  const version = await fetchChromeVersion(discoveryUrl, timeoutMs, authToken, ssrfPolicy);
+  const version = await fetchChromeVersionWithCredentialFallback(discoveryUrl, timeoutMs, authToken, cdpControlPolicy);
   const rawWsUrl = version?.webSocketDebuggerUrl;
   const wsUrl = typeof rawWsUrl === 'string' ? rawWsUrl.trim() : '';
   if (wsUrl === '') {
@@ -907,7 +998,7 @@ export async function getChromeWebSocketUrl(
     return null;
   }
   const normalized = normalizeCdpWsUrl(wsUrl, discoveryUrl);
-  await assertCdpEndpointAllowed(normalized, ssrfPolicy);
+  await assertCdpEndpointAllowed(normalized, cdpControlPolicy, { source: 'discovered', configuredUrl: cdpUrl });
   return normalized;
 }
 
@@ -1001,6 +1092,7 @@ export interface BuildChromeLaunchArgsOptions {
   ciDefaults: boolean;
   chromeArgs?: string[];
   platform: NodeJS.Platform;
+  useMockKeychain?: boolean;
 }
 
 export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): string[] {
@@ -1032,6 +1124,7 @@ export function buildChromeLaunchArgs(opts: BuildChromeLaunchArgsOptions): strin
   if (opts.ignoreHTTPSErrors) {
     args.push('--ignore-certificate-errors');
   }
+  if (opts.platform === 'darwin' && opts.useMockKeychain === true) args.push('--use-mock-keychain');
   if (opts.platform === 'linux') args.push('--disable-dev-shm-usage');
   const extraArgs = Array.isArray(opts.chromeArgs)
     ? opts.chromeArgs.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
@@ -1061,6 +1154,13 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   const userDataDir = isolatedResolved?.userDataDir ?? opts.userDataDir ?? resolveUserDataDir(profileName);
   fs.mkdirSync(userDataDir, { recursive: true });
 
+  const localStatePath = path.join(userDataDir, 'Local State');
+  const preferencesPath = path.join(userDataDir, 'Default', 'Preferences');
+  const profileIsNew = !fileExists(localStatePath);
+  const useMockKeychain =
+    process.platform === 'darwin' &&
+    (usesBrowserclawMockKeychain(userDataDir) || (profileIsNew && opts.headless === true));
+
   const spawnChrome = (spawnOpts?: { detached?: boolean }, runOpts?: { forceHeadless?: boolean }) => {
     const args = buildChromeLaunchArgs({
       cdpPort,
@@ -1071,6 +1171,7 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
       ciDefaults: opts.ciDefaults === true,
       chromeArgs: opts.chromeArgs,
       platform: process.platform,
+      useMockKeychain,
     });
     return spawn(exe.path, args, {
       stdio: ['ignore', 'ignore', 'pipe'],
@@ -1080,8 +1181,6 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   };
 
   const startedAt = Date.now();
-  const localStatePath = path.join(userDataDir, 'Local State');
-  const preferencesPath = path.join(userDataDir, 'Default', 'Preferences');
 
   if (!fileExists(localStatePath) || !fileExists(preferencesPath)) {
     const useDetached = process.platform !== 'win32';
@@ -1103,7 +1202,9 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   }
 
   try {
-    decorateProfile(userDataDir, profileName, opts.profileColor ?? DEFAULT_PROFILE_COLOR);
+    decorateProfile(userDataDir, profileName, opts.profileColor ?? DEFAULT_PROFILE_COLOR, {
+      mockKeychain: useMockKeychain,
+    });
   } catch {}
 
   try {
@@ -1176,6 +1277,69 @@ export async function launchChrome(opts: LaunchOptions = {}): Promise<RunningChr
   };
 }
 
+const CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS = 500;
+
+/** CDP `Browser.close` flushes profile data (cookies) before any signal reaches the process group. */
+async function requestGracefulChromeClose(cdpPort: number, timeoutMs: number): Promise<boolean> {
+  const commandTimeoutMs = Math.max(1, Math.min(timeoutMs, CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS));
+  let commandSent = false;
+  try {
+    const wsUrl = await getChromeWebSocketUrl(`http://127.0.0.1:${String(cdpPort)}`, Math.min(commandTimeoutMs, 200));
+    if (wsUrl === null) return false;
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let ws: WebSocket | undefined;
+      const finish = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          ws?.close();
+        } catch {
+          /* noop */
+        }
+        if (err) reject(err);
+        else resolve();
+      };
+      const timer = setTimeout(() => {
+        finish(new Error('Chrome graceful close timed out'));
+      }, commandTimeoutMs);
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch (err) {
+        finish(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      ws.onopen = () => {
+        try {
+          ws?.send(JSON.stringify({ id: 1, method: 'Browser.close' }));
+          commandSent = true;
+          finish();
+        } catch (err) {
+          finish(err instanceof Error ? err : new Error(String(err)));
+        }
+      };
+      ws.onerror = () => {
+        finish(new Error('Chrome graceful close socket error'));
+      };
+    });
+    return true;
+  } catch {
+    return commandSent;
+  }
+}
+
+async function waitForChromeCdpShutdown(cdpPort: number, timeoutMs: number): Promise<boolean> {
+  const cdpUrl = `http://127.0.0.1:${String(cdpPort)}`;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!(await isChromeReachable(cdpUrl, 200))) return true;
+    const remainingMs = timeoutMs - (Date.now() - start);
+    await new Promise((r) => setTimeout(r, Math.max(1, Math.min(100, remainingMs))));
+  }
+  return !(await isChromeReachable(cdpUrl, 200));
+}
+
 export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Promise<void> {
   const proc = running.proc;
   const cleanupIsolated = () => {
@@ -1189,6 +1353,19 @@ export async function stopChrome(running: RunningChrome, timeoutMs = 2500): Prom
   if (proc.exitCode !== null) {
     cleanupIsolated();
     return;
+  }
+  if (
+    (await requestGracefulChromeClose(running.cdpPort, timeoutMs)) &&
+    (await waitForChromeCdpShutdown(running.cdpPort, timeoutMs))
+  ) {
+    const exitDeadline = Date.now() + 1000;
+    while (Date.now() < exitDeadline && proc.exitCode === null) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    if (proc.exitCode !== null) {
+      cleanupIsolated();
+      return;
+    }
   }
   killProcessTree(proc, 'SIGTERM');
   const start = Date.now();

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -832,13 +832,17 @@ describe('isRecoverablePlaywrightDisconnectError', () => {
 
 describe('tryTerminateExecutionViaCdp SSRF validation', () => {
   const craftedList = [{ id: 'T1', webSocketDebuggerUrl: 'ws://192.168.1.100:9222/devtools/page/T1' }];
+  const jsonResponse = (data: unknown) => {
+    const bytes = new TextEncoder().encode(JSON.stringify(data));
+    return { ok: true, body: undefined, arrayBuffer: () => Promise.resolve(bytes.buffer) };
+  };
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
   it('rejects a crafted /json/list webSocketDebuggerUrl pointing at a policy-blocked host', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(craftedList) });
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(craftedList));
     const webSocketMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     vi.stubGlobal('WebSocket', webSocketMock);
@@ -861,7 +865,7 @@ describe('tryTerminateExecutionViaCdp SSRF validation', () => {
   });
 
   it('dials the discovered webSocketDebuggerUrl when no policy is provided', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(craftedList) });
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(craftedList));
     const webSocketMock = vi.fn().mockImplementation(() => {
       throw new Error('socket unavailable in test');
     });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -11,11 +11,17 @@ import {
   normalizeCdpWsUrl,
   isLoopbackHost,
   hasProxyEnvConfigured,
+  readJsonResponseBounded,
 } from './chrome-launcher.js';
 import { BrowserTabNotFoundError } from './errors.js';
 import { ensurePageState, observeBrowser, setDialogHandlerOnPage, type ObserveOptions } from './page-utils.js';
 import { clearRoleRefsForCdpUrl, normalizeCdpUrl } from './ref-resolver.js';
-import { assertCdpEndpointAllowed } from './security.js';
+import {
+  assertCdpEndpointAllowed,
+  getHeadersWithAuth,
+  scopeCdpPolicyToConfiguredEndpoint,
+  stripUrlCredentials,
+} from './security.js';
 import type { DialogHandler, SsrfPolicy } from './types.js';
 
 // Re-export everything from sub-modules so existing `import … from './connection.js'`
@@ -31,6 +37,7 @@ export {
   bumpDownloadArmId,
   toAIFriendlyError,
   normalizeTimeoutMs,
+  truncateUtf16Safe,
 } from './page-utils.js';
 
 export {
@@ -89,7 +96,7 @@ async function fetchJsonForCdp(url: string, timeoutMs: number): Promise<unknown>
   try {
     const res = await fetch(fetchUrl, { signal: ctrl.signal, headers });
     if (!res.ok) return null;
-    return await res.json();
+    return await readJsonResponseBounded(res, 'cdp-json');
   } catch (err) {
     if (process.env.DEBUG !== undefined && process.env.DEBUG !== '')
       console.warn(
@@ -275,44 +282,7 @@ export function getDirectAgentForCdp(url: string): http.Agent | https.Agent | un
  * Resolve auth headers for a CDP endpoint URL.
  * Supports URL credentials (user:pass@host).
  */
-export function getHeadersWithAuth(endpoint: string, baseHeaders: Record<string, string> = {}): Record<string, string> {
-  const headers = { ...baseHeaders };
-  try {
-    const parsed = new URL(endpoint);
-    if (Object.keys(headers).some((k) => k.toLowerCase() === 'authorization')) return headers;
-    if (parsed.username || parsed.password) {
-      const decode = (value: string): string => {
-        try {
-          return decodeURIComponent(value);
-        } catch {
-          return value;
-        }
-      };
-      const credentials = Buffer.from(`${decode(parsed.username)}:${decode(parsed.password)}`).toString('base64');
-      headers.Authorization = `Basic ${credentials}`;
-    }
-  } catch {
-    // endpoint is not a valid URL (e.g. a raw WebSocket path) — skip auth header injection
-  }
-  return headers;
-}
-
-/**
- * Strip URL userinfo (user:pass@) so the URL can be safely logged or passed to
- * fetch without leaking credentials. Pair with `getHeadersWithAuth` to move
- * credentials into an Authorization header before issuing the request.
- */
-export function stripUrlCredentials(url: string): string {
-  try {
-    const parsed = new URL(url);
-    if (!parsed.username && !parsed.password) return url;
-    parsed.username = '';
-    parsed.password = '';
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
+export { getHeadersWithAuth, stripUrlCredentials } from './security.js';
 
 // ── Persistent Connection Cache ──
 
@@ -322,8 +292,17 @@ interface CachedConnection {
   onDisconnected?: () => void;
 }
 
+interface ConnectionAttempt {
+  cancelled: boolean;
+}
+
+interface PendingConnection {
+  attempt: ConnectionAttempt;
+  promise: Promise<CachedConnection>;
+}
+
 const cachedByCdpUrl = new Map<string, CachedConnection>();
-const connectingByCdpUrl = new Map<string, Promise<CachedConnection>>();
+const connectingByCdpUrl = new Map<string, PendingConnection>();
 const stealthByCdpUrl = new Map<string, boolean>();
 // Remembered per-URL so reconnects re-run assertCdpEndpointAllowed even when
 // the action function chain doesn't thread a policy through. Closes the
@@ -490,7 +469,7 @@ export async function connectBrowser(
   await assertCdpEndpointAllowed(normalized, effectivePolicy);
 
   const existing = connectingByCdpUrl.get(normalized);
-  if (existing) return await observeCached(await existing);
+  if (existing) return await observeCached(await existing.promise);
 
   // Slow path: acquire connection lock before creating a new connection
   return withConnectionLock(async () => {
@@ -498,21 +477,29 @@ export async function connectBrowser(
     const rechecked = cachedByCdpUrl.get(normalized);
     if (rechecked) return await observeCached(rechecked);
     const recheckPending = connectingByCdpUrl.get(normalized);
-    if (recheckPending) return await observeCached(await recheckPending);
+    if (recheckPending) return await observeCached(await recheckPending.promise);
 
+    const connectionAttempt: ConnectionAttempt = { cancelled: false };
     const connectWithRetry = async () => {
       let lastErr: unknown;
       for (let attempt = 0; attempt < 3; attempt++) {
+        if (connectionAttempt.cancelled) break;
         try {
           const timeout = 5000 + attempt * 2000;
-          const endpoint =
-            (await getChromeWebSocketUrl(normalized, timeout, authToken, effectivePolicy).catch(() => null)) ??
-            normalized;
+          const wsUrl = await getChromeWebSocketUrl(normalized, timeout, authToken, effectivePolicy).catch(() => null);
+          const hasUrlCredentials = stripUrlCredentials(normalized) !== normalized;
+          if (wsUrl === null && hasUrlCredentials && !isWebSocketUrl(normalized))
+            throw new Error('Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.');
+          const endpoint = wsUrl ?? normalized;
           const connectAt = async (target: string) => {
             const headers: Record<string, string> = getHeadersWithAuth(target);
             if (authToken !== undefined && authToken !== '' && !headers.Authorization)
               headers.Authorization = `Bearer ${authToken}`;
-            return await withNoProxyForCdpUrl(target, () => chromium.connectOverCDP(target, { timeout, headers }));
+            // Credentials travel in the Authorization header; never in the dialed URL.
+            const connectionUrl = stripUrlCredentials(target);
+            return await withNoProxyForCdpUrl(connectionUrl, () =>
+              chromium.connectOverCDP(connectionUrl, { timeout, headers }),
+            );
           };
           let browser: Browser;
           try {
@@ -520,6 +507,12 @@ export async function connectBrowser(
           } catch (connectErr) {
             if (!isWebSocketUrl(normalized) || endpoint === normalized) throw connectErr;
             browser = await connectAt(normalized);
+          }
+          if (connectionAttempt.cancelled) {
+            await browser.close().catch(() => {
+              /* noop */
+            });
+            throw new Error('Playwright connection attempt was superseded.');
           }
           const onDisconnected = () => {
             if (cachedByCdpUrl.get(normalized)?.browser === browser) {
@@ -534,6 +527,7 @@ export async function connectBrowser(
           return connected;
         } catch (err) {
           lastErr = err;
+          if (connectionAttempt.cancelled) break;
           if ((err instanceof Error ? err.message : String(err)).includes('rate limit')) {
             // Rate-limit: wait longer before retrying instead of breaking immediately
             await new Promise((r) => setTimeout(r, 1000 + attempt * 1000));
@@ -546,9 +540,9 @@ export async function connectBrowser(
     };
 
     const promise = connectWithRetry().finally(() => {
-      connectingByCdpUrl.delete(normalized);
+      if (connectingByCdpUrl.get(normalized)?.attempt === connectionAttempt) connectingByCdpUrl.delete(normalized);
     });
-    connectingByCdpUrl.set(normalized, promise);
+    connectingByCdpUrl.set(normalized, { attempt: connectionAttempt, promise });
     return await promise;
   });
 }
@@ -556,9 +550,10 @@ export async function connectBrowser(
 export async function disconnectBrowser(): Promise<void> {
   return withConnectionLock(async () => {
     if (connectingByCdpUrl.size) {
-      for (const p of connectingByCdpUrl.values()) {
+      for (const pending of connectingByCdpUrl.values()) pending.attempt.cancelled = true;
+      for (const pending of connectingByCdpUrl.values()) {
         try {
-          await p;
+          await pending.promise;
         } catch (err) {
           console.warn(
             `[browserclaw] disconnectBrowser: pending connect failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -602,6 +597,8 @@ export async function closePlaywrightBrowserConnection(opts?: {
       }
       const cur = cachedByCdpUrl.get(normalized);
       cachedByCdpUrl.delete(normalized);
+      const pending = connectingByCdpUrl.get(normalized);
+      if (pending) pending.attempt.cancelled = true;
       connectingByCdpUrl.delete(normalized);
       if (!cur) return;
       if (cur.onDisconnected && typeof cur.browser.off === 'function')
@@ -645,7 +642,7 @@ async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string, ssr
   try {
     const res = await fetch(fetchUrl, { signal: ctrl.signal, headers });
     if (!res.ok) return;
-    targets = await res.json();
+    targets = await readJsonResponseBounded(res, 'cdp-json');
   } catch {
     return;
   } finally {
@@ -661,8 +658,13 @@ async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string, ssr
   if (wsUrlRaw === '') return;
 
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, httpBase);
-  await assertCdpEndpointAllowed(wsUrl, ssrfPolicy);
-  const needsAttach = cdpSocketNeedsAttach(wsUrl);
+  await assertCdpEndpointAllowed(wsUrl, scopeCdpPolicyToConfiguredEndpoint(cdpUrl, ssrfPolicy), {
+    source: 'discovered',
+    configuredUrl: cdpUrl,
+  });
+  // Node's native WebSocket rejects credential-bearing URLs; never dial with userinfo.
+  const wsConnectionUrl = stripUrlCredentials(wsUrl);
+  const needsAttach = cdpSocketNeedsAttach(wsConnectionUrl);
 
   await new Promise<void>((resolve) => {
     let done = false;
@@ -679,7 +681,7 @@ async function tryTerminateExecutionViaCdp(cdpUrl: string, targetId: string, ssr
     let ws: WebSocket;
     let nextId = 1;
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(wsConnectionUrl);
     } catch {
       finish();
       return;
@@ -740,6 +742,8 @@ export async function forceDisconnectPlaywrightConnection(opts: {
   ssrfPolicy?: SsrfPolicy;
 }): Promise<void> {
   const normalized = normalizeCdpUrl(opts.cdpUrl);
+  const pending = connectingByCdpUrl.get(normalized);
+  if (pending) pending.attempt.cancelled = true;
   const cur = cachedByCdpUrl.get(normalized);
   if (!cur) return;
 

--- a/src/page-utils.test.ts
+++ b/src/page-utils.test.ts
@@ -11,6 +11,7 @@ import {
   ensurePageState,
   ensureContextState,
   observeContext,
+  truncateUtf16Safe,
 } from './page-utils.js';
 import type { PageState, NetworkRequest } from './types.js';
 
@@ -70,6 +71,31 @@ describe('normalizeTimeoutMs', () => {
   it('accepts exact boundary values', () => {
     expect(normalizeTimeoutMs(500, 5000)).toBe(500);
     expect(normalizeTimeoutMs(120000, 5000)).toBe(120000);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// truncateUtf16Safe
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('truncateUtf16Safe', () => {
+  it('returns short strings unchanged', () => {
+    expect(truncateUtf16Safe('abc', 5)).toBe('abc');
+    expect(truncateUtf16Safe('abc', 3)).toBe('abc');
+  });
+
+  it('truncates to the limit', () => {
+    expect(truncateUtf16Safe('abcdef', 4)).toBe('abcd');
+  });
+
+  it('backs off one unit rather than splitting a surrogate pair', () => {
+    // 'aaa😀' is 5 UTF-16 units; cutting at 4 would leave a lone high surrogate.
+    expect(truncateUtf16Safe('aaa\u{1F600}', 4)).toBe('aaa');
+    expect(truncateUtf16Safe('aaa\u{1F600}', 5)).toBe('aaa\u{1F600}');
+  });
+
+  it('handles a zero limit', () => {
+    expect(truncateUtf16Safe('abc', 0)).toBe('');
   });
 });
 
@@ -154,6 +180,7 @@ describe('arm ID bumping', () => {
       nextArmIdUpload: 0,
       nextArmIdDialog: 0,
       nextArmIdDownload: 0,
+      downloadWaiterDepth: 0,
     };
   }
 
@@ -207,6 +234,7 @@ describe('findNetworkRequestById', () => {
       nextArmIdUpload: 0,
       nextArmIdDialog: 0,
       nextArmIdDownload: 0,
+      downloadWaiterDepth: 0,
     };
   }
 

--- a/src/page-utils.ts
+++ b/src/page-utils.ts
@@ -76,6 +76,7 @@ export function ensurePageState(page: Page): PageState {
     nextArmIdUpload: 0,
     nextArmIdDialog: 0,
     nextArmIdDownload: 0,
+    downloadWaiterDepth: 0,
   };
   pageStates.set(page, state);
 
@@ -322,4 +323,13 @@ export function toAIFriendlyError(error: unknown, selector: string): Error {
 
 export function normalizeTimeoutMs(timeoutMs: number | undefined, fallback: number, maxMs = 120000): number {
   return Math.max(500, Math.min(maxMs, timeoutMs ?? fallback));
+}
+
+/** Truncate to `maxLength` UTF-16 code units without splitting a surrogate pair. */
+export function truncateUtf16Safe(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  let end = Math.max(0, Math.trunc(maxLength));
+  const lastCodeUnit = value.charCodeAt(end - 1);
+  if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) end -= 1;
+  return value.slice(0, end);
 }

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -11,6 +11,7 @@ import {
   resolvePinnedHostnameWithPolicy,
   assertBrowserNavigationAllowed,
   assertCdpEndpointAllowed,
+  scopeCdpPolicyToConfiguredEndpoint,
   BrowserCdpEndpointBlockedError,
   assertSafeOutputPath,
   assertSafeUploadPaths,
@@ -50,6 +51,16 @@ function mockPublicLookup(): LookupFn {
 /** Mock DNS lookup that resolves a hostname to a loopback IP */
 function mockLoopbackLookup(): LookupFn {
   return (() => Promise.resolve([{ address: '127.0.0.1', family: 4 }])) as unknown as LookupFn;
+}
+
+/** Mock DNS lookup that resolves a hostname to a private (non-loopback) IP */
+function mockPrivateLookup(): LookupFn {
+  return (() => Promise.resolve([{ address: '10.0.0.5', family: 4 }])) as unknown as LookupFn;
+}
+
+/** Mock DNS lookup that resolves a hostname to a caller-chosen address */
+function mockLookupOf(address: string, family = 4): LookupFn {
+  return (() => Promise.resolve([{ address, family }])) as unknown as LookupFn;
 }
 
 /** Mock DNS lookup that throws (simulating failed resolution) */
@@ -565,6 +576,21 @@ describe('security.ts', () => {
       );
     });
 
+    it('rejects URL-embedded credentials and points at the credentials API', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'https://user:pass@example.com/' })).rejects.toThrow(
+        'URL-embedded credentials are not supported',
+      );
+      await expect(assertBrowserNavigationAllowed({ url: 'https://user@example.com/' })).rejects.toThrow(
+        'URL-embedded credentials are not supported',
+      );
+    });
+
+    it('redacts credential-bearing text from invalid-URL errors', async () => {
+      await expect(assertBrowserNavigationAllowed({ url: 'http://user:pass@' })).rejects.toThrow(
+        '[redacted credential-bearing URL]',
+      );
+    });
+
     it('should reject file: protocol', async () => {
       await expect(assertBrowserNavigationAllowed({ url: 'file:///etc/passwd' })).rejects.toThrow(
         'unsupported protocol',
@@ -830,10 +856,52 @@ describe('security.ts', () => {
 
     it('should allow explicitly allowedHostnames even with private IPs', async () => {
       const result = await resolvePinnedHostnameWithPolicy('internal.myapp.com', {
-        lookupFn: mockLoopbackLookup(),
+        lookupFn: mockPrivateLookup(),
         policy: { ...STRICT_POLICY, allowedHostnames: ['internal.myapp.com'] },
       });
       expect(result.hostname).toBe('internal.myapp.com');
+    });
+
+    it('blocks an allow-listed hostname that resolves to a loopback address (DNS rebinding)', async () => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('rebind-loopback.myapp.com', {
+          lookupFn: mockLoopbackLookup(),
+          policy: { ...STRICT_POLICY, allowedHostnames: ['rebind-loopback.myapp.com'] },
+        }),
+      ).rejects.toThrow('resolves to a loopback address');
+    });
+
+    it('blocks an allow-listed hostname that resolves to an IPv6-embedded loopback address', async () => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('rebind-embedded.myapp.com', {
+          lookupFn: mockLookupOf('::ffff:127.0.0.1', 6),
+          policy: { ...STRICT_POLICY, allowedHostnames: ['rebind-embedded.myapp.com'] },
+        }),
+      ).rejects.toThrow('resolves to a loopback address');
+    });
+
+    it('blocks an allow-listed hostname that resolves to an unspecified address', async () => {
+      for (const [hostname, address] of [
+        ['rebind-unspec4.myapp.com', '0.0.0.0'],
+        ['rebind-unspec6.myapp.com', '::'],
+      ] as const) {
+        await expect(
+          resolvePinnedHostnameWithPolicy(hostname, {
+            lookupFn: mockLookupOf(address, address.includes(':') ? 6 : 4),
+            policy: { ...STRICT_POLICY, allowedHostnames: [hostname] },
+          }),
+        ).rejects.toThrow('resolves to an unspecified address');
+      }
+    });
+
+    it('allows an allow-listed explicit loopback hostname to resolve to loopback', async () => {
+      for (const hostname of ['localhost', '127.0.0.1', 'dev.localhost']) {
+        const result = await resolvePinnedHostnameWithPolicy(hostname, {
+          lookupFn: mockLoopbackLookup(),
+          policy: { ...STRICT_POLICY, allowedHostnames: [hostname] },
+        });
+        expect(result.hostname).toBe(hostname);
+      }
     });
 
     it('should normalize hostname (case, trailing dot) before checking', async () => {
@@ -1846,6 +1914,52 @@ describe('security.ts', () => {
     it('is a no-op when no policy is provided', async () => {
       await expect(assertCdpEndpointAllowed('http://localhost:9222')).resolves.toBeUndefined();
       await expect(assertCdpEndpointAllowed('http://169.254.169.254/')).resolves.toBeUndefined();
+    });
+
+    it('blocks a discovered endpoint whose authority differs from the configured endpoint', async () => {
+      await expect(
+        assertCdpEndpointAllowed('ws://192.168.1.100:9222/devtools/browser/abc', STRICT_POLICY, {
+          source: 'discovered',
+          configuredUrl: 'http://127.0.0.1:9222',
+        }),
+      ).rejects.toThrow('discovered CDP endpoint changed configured authority');
+    });
+
+    it('blocks a discovered endpoint that keeps the hostname but changes the port', async () => {
+      await expect(
+        assertCdpEndpointAllowed('ws://127.0.0.1:6379/devtools/browser/abc', STRICT_POLICY, {
+          source: 'discovered',
+          configuredUrl: 'http://127.0.0.1:9222',
+        }),
+      ).rejects.toThrow('discovered CDP endpoint changed configured authority');
+    });
+
+    it('allows a discovered endpoint with the same authority under a scoped policy', async () => {
+      const scoped = scopeCdpPolicyToConfiguredEndpoint('http://127.0.0.1:9222', STRICT_POLICY);
+      await expect(
+        assertCdpEndpointAllowed('ws://127.0.0.1:9222/devtools/browser/abc', scoped, {
+          source: 'discovered',
+          configuredUrl: 'http://127.0.0.1:9222',
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not enforce discovered-authority matching without a policy', async () => {
+      await expect(
+        assertCdpEndpointAllowed('ws://192.168.1.100:9222/devtools/browser/abc', undefined, {
+          source: 'discovered',
+          configuredUrl: 'http://127.0.0.1:9222',
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not enforce discovered-authority matching when private network is allowed', async () => {
+      await expect(
+        assertCdpEndpointAllowed('ws://192.168.1.100:9222/devtools/browser/abc', PERMISSIVE_POLICY, {
+          source: 'discovered',
+          configuredUrl: 'http://127.0.0.1:9222',
+        }),
+      ).resolves.toBeUndefined();
     });
 
     it('is a no-op when policy is undefined explicitly', async () => {

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -894,6 +894,32 @@ describe('security.ts', () => {
       }
     });
 
+    it('blocks an allow-listed hostname resolving to an embedded-IPv4 metadata/link-local address', async () => {
+      // IPv4-mapped, CGNAT-metadata-mapped, and 6to4-embedded forms all reach the
+      // metadata/link-local target once Node dials the v6 address.
+      const cases: [string, string][] = [
+        ['rebind-meta-mapped.myapp.com', '::ffff:169.254.169.254'],
+        ['rebind-cgnat-mapped.myapp.com', '::ffff:100.100.100.200'],
+        ['rebind-meta-6to4.myapp.com', '2002:a9fe:a9fe::1'],
+      ];
+      for (const [hostname, address] of cases) {
+        await expect(
+          resolvePinnedHostnameWithPolicy(hostname, {
+            lookupFn: mockLookupOf(address, 6),
+            policy: { ...STRICT_POLICY, allowedHostnames: [hostname] },
+          }),
+        ).rejects.toThrow('cloud-metadata/link-local');
+      }
+    });
+
+    it('still allows an allow-listed hostname resolving to an ordinary private IP (control)', async () => {
+      const result = await resolvePinnedHostnameWithPolicy('rebind-ok.myapp.com', {
+        lookupFn: mockLookupOf('10.1.2.3', 4),
+        policy: { ...STRICT_POLICY, allowedHostnames: ['rebind-ok.myapp.com'] },
+      });
+      expect(result.hostname).toBe('rebind-ok.myapp.com');
+    });
+
     it('allows an allow-listed explicit loopback hostname to resolve to loopback', async () => {
       for (const hostname of ['localhost', '127.0.0.1', 'dev.localhost']) {
         const result = await resolvePinnedHostnameWithPolicy(hostname, {

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -625,7 +625,7 @@ describe('security.ts', () => {
           assertBrowserNavigationAllowed({
             url: 'https://playwright.dev',
             lookupFn: mockPublicLookup(),
-            ssrfPolicy: STRICT_POLICY,
+            ssrfPolicy: { ...STRICT_POLICY, allowedHostnames: ['playwright.dev'] },
           }),
         ).resolves.toBeUndefined();
       });
@@ -649,6 +649,122 @@ describe('security.ts', () => {
           ssrfPolicy: STRICT_POLICY,
         }),
       ).rejects.toThrow(InvalidBrowserNavigationUrlError);
+    });
+
+    describe('explicit strict policy (dangerouslyAllowPrivateNetwork: false) — IP-literal gate', () => {
+      it('blocks a plain hostname that is neither IP-literal nor allow-listed', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'https://example.com',
+              lookupFn: mockPublicLookup(),
+              ssrfPolicy: STRICT_POLICY,
+            }),
+          ).rejects.toThrow('requires an IP-literal URL or an allow-listed hostname');
+        });
+      });
+
+      it('allows an IP-literal URL', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({ url: 'http://93.184.216.34/', ssrfPolicy: STRICT_POLICY }),
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      it('allows an IPv6-literal URL', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'http://[2606:2800:220:1:248:1893:25c8:1946]/',
+              ssrfPolicy: STRICT_POLICY,
+            }),
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      it('allows an explicitly allow-listed hostname', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'https://internal.corp',
+              lookupFn: mockPublicLookup(),
+              ssrfPolicy: { ...STRICT_POLICY, allowedHostnames: ['internal.corp'] },
+            }),
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      it('allows a hostname matching a hostnameAllowlist pattern', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'https://api.internal.corp',
+              lookupFn: mockPublicLookup(),
+              ssrfPolicy: { ...STRICT_POLICY, hostnameAllowlist: ['*.internal.corp'] },
+            }),
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      it('does not fire without a policy (default secure-by-default resolve still applies)', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({ url: 'https://example.com', lookupFn: mockPublicLookup() }),
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      it('does not fire when the policy is not explicit-strict', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'https://example.com',
+              lookupFn: mockPublicLookup(),
+              ssrfPolicy: { allowedHostnames: ['other.com'] },
+            }),
+          ).resolves.toBeUndefined();
+        });
+      });
+    });
+
+    describe('proxy-routed browser fail-close', () => {
+      it('blocks navigation when browserProxyMode is explicit-browser-proxy under a non-permissive policy', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'http://93.184.216.34/',
+              ssrfPolicy: STRICT_POLICY,
+              browserProxyMode: 'explicit-browser-proxy',
+            }),
+          ).rejects.toThrow('proxy-routed');
+        });
+      });
+
+      it('allows proxy-routed navigation when private network is permitted', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'https://example.com',
+              lookupFn: mockPublicLookup(),
+              ssrfPolicy: PERMISSIVE_POLICY,
+              browserProxyMode: 'explicit-browser-proxy',
+            }),
+          ).resolves.toBeUndefined();
+        });
+      });
+
+      it('does not block when browserProxyMode is direct', async () => {
+        await withoutProxyEnv(async () => {
+          await expect(
+            assertBrowserNavigationAllowed({
+              url: 'http://93.184.216.34/',
+              ssrfPolicy: STRICT_POLICY,
+              browserProxyMode: 'direct',
+            }),
+          ).resolves.toBeUndefined();
+        });
+      });
     });
 
     it('should block when DNS fails with strict policy', async () => {
@@ -1165,7 +1281,7 @@ describe('security.ts', () => {
           assertBrowserNavigationResultAllowed({
             url: 'https://playwright.dev',
             lookupFn: mockPublicLookup(),
-            ssrfPolicy: STRICT_POLICY,
+            ssrfPolicy: { ...STRICT_POLICY, allowedHostnames: ['playwright.dev'] },
           }),
         ).resolves.toBeUndefined();
       });
@@ -1212,7 +1328,7 @@ describe('security.ts', () => {
           assertBrowserNavigationRedirectChainAllowed({
             request: chain,
             lookupFn: mockPublicLookup(),
-            ssrfPolicy: STRICT_POLICY,
+            ssrfPolicy: { ...STRICT_POLICY, allowedHostnames: ['final.com', 'middle.com', 'start.com'] },
           }),
         ).resolves.toBeUndefined();
       });

--- a/src/security.ts
+++ b/src/security.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { lookup as dnsLookupCb } from 'node:dns';
 import { lookup as dnsLookup } from 'node:dns/promises';
 import { lstat, realpath, rename, rm } from 'node:fs/promises';
+import { isIP } from 'node:net';
 import { tmpdir } from 'node:os';
 import {
   resolve,
@@ -202,9 +203,17 @@ export async function assertCdpEndpointAllowed(
   }
 }
 
+/**
+ * How the target browser reaches the network.
+ * `explicit-browser-proxy`: Chrome was launched with a proxy-routing arg, so the
+ * proxy resolves DNS and egresses — local SSRF address validation is meaningless.
+ */
+export type BrowserProxyMode = 'direct' | 'explicit-browser-proxy';
+
 /** Options for browser navigation SSRF policy. */
 export interface BrowserNavigationPolicyOptions {
   ssrfPolicy?: SsrfPolicy;
+  browserProxyMode?: BrowserProxyMode;
 }
 
 /** Playwright-compatible request interface for redirect chain inspection. */
@@ -213,9 +222,17 @@ export interface BrowserNavigationRequestLike {
   redirectedFrom(): BrowserNavigationRequestLike | null;
 }
 
-/** Build a BrowserNavigationPolicyOptions from an SsrfPolicy. */
-export function withBrowserNavigationPolicy(ssrfPolicy?: SsrfPolicy): BrowserNavigationPolicyOptions {
-  return ssrfPolicy ? { ssrfPolicy } : {};
+/** Build a BrowserNavigationPolicyOptions from an SsrfPolicy (and optional proxy mode). */
+export function withBrowserNavigationPolicy(
+  ssrfPolicy?: SsrfPolicy,
+  opts?: { browserProxyMode?: BrowserProxyMode },
+): BrowserNavigationPolicyOptions {
+  return {
+    ...(ssrfPolicy ? { ssrfPolicy } : {}),
+    ...(opts?.browserProxyMode && opts.browserProxyMode !== 'direct'
+      ? { browserProxyMode: opts.browserProxyMode }
+      : {}),
+  };
 }
 
 // Only http: and https: are permitted for navigation; about:blank is the sole non-network exception.
@@ -560,6 +577,18 @@ function matchesHostnameAllowlist(hostname: string, allowlist: string[]): boolea
   return allowlist.some((pattern) => isHostnameAllowedByPattern(hostname, pattern));
 }
 
+function isIpLiteralHostname(hostname: string): boolean {
+  return isIP(normalizeHostname(hostname)) !== 0;
+}
+
+/** True when the hostname is exactly allow-listed or matches a hostnameAllowlist pattern. */
+function isExplicitlyAllowedBrowserHostname(hostname: string, policy?: SsrfPolicy): boolean {
+  const normalized = normalizeHostname(hostname);
+  if (normalizeHostnameSet(policy?.allowedHostnames).has(normalized)) return true;
+  const allowlist = normalizeHostnameAllowlist(policy?.hostnameAllowlist);
+  return allowlist.length > 0 ? matchesHostnameAllowlist(normalized, allowlist) : false;
+}
+
 // ── DNS pinning (prevents TOCTOU rebinding) ──
 
 function dedupeAndPreferIpv4(results: { address: string; family: number }[]): string[] {
@@ -823,6 +852,30 @@ export async function assertBrowserNavigationAllowed(
   if (hasProxyEnvConfigured() && !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy)) {
     throw new InvalidBrowserNavigationUrlError(
       'Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set',
+    );
+  }
+
+  // Fail closed when the browser itself is proxy-routed (launched with --proxy-server etc.):
+  // the proxy resolves DNS and egresses, so local address validation cannot enforce the policy.
+  if (opts.browserProxyMode === 'explicit-browser-proxy' && !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy)) {
+    throw new InvalidBrowserNavigationUrlError(
+      'Navigation blocked: strict browser SSRF policy cannot be enforced while this browser is proxy-routed',
+    );
+  }
+
+  // Under an explicit strict policy, hostnames cannot be safely navigated: the browser
+  // re-resolves DNS independently of this pinned check (a 0-TTL rebind reaches a private
+  // IP). Require an IP literal or an explicitly allow-listed hostname.
+  if (
+    requiresInspectableBrowserNavigationRedirects(opts.ssrfPolicy) &&
+    !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy) &&
+    !isIpLiteralHostname(parsed.hostname) &&
+    !isExplicitlyAllowedBrowserHostname(parsed.hostname, opts.ssrfPolicy)
+  ) {
+    throw new InvalidBrowserNavigationUrlError(
+      'Navigation blocked: strict SSRF policy (dangerouslyAllowPrivateNetwork: false) requires an IP-literal URL ' +
+        'or an allow-listed hostname, because the browser resolves DNS itself and hostname-based rebinding ' +
+        'protection cannot be guaranteed. Add the hostname to ssrfPolicy.allowedHostnames or navigate by IP.',
     );
   }
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -464,17 +464,23 @@ function isPrivateIpAddress(address: string, policy?: SsrfPolicy): boolean {
 const CLOUD_METADATA_IPV4 = ['169.254.169.254', '100.100.100.200'];
 const CLOUD_METADATA_IPV6 = ['fd00:ec2::254'];
 
+function isCloudMetadataOrLinkLocalIpv4(v4: ipaddr.IPv4): boolean {
+  if (v4.range() === 'linkLocal') return true;
+  return CLOUD_METADATA_IPV4.some((m) => v4.toNormalizedString() === ipaddr.IPv4.parse(m).toNormalizedString());
+}
+
 function isCloudMetadataOrLinkLocalAddress(address: string): boolean {
   const parsed = parseCanonicalIpAddress(address);
   if (!parsed) return false;
-  if (parsed.kind() === 'ipv4') {
-    const v4 = parsed as ipaddr.IPv4;
-    if (v4.range() === 'linkLocal') return true;
-    return CLOUD_METADATA_IPV4.some((m) => v4.toNormalizedString() === ipaddr.IPv4.parse(m).toNormalizedString());
-  }
+  if (parsed.kind() === 'ipv4') return isCloudMetadataOrLinkLocalIpv4(parsed as ipaddr.IPv4);
   const v6 = parsed as ipaddr.IPv6;
   if (v6.range() === 'linkLocal') return true;
-  return CLOUD_METADATA_IPV6.some((m) => v6.toNormalizedString() === ipaddr.IPv6.parse(m).toNormalizedString());
+  if (CLOUD_METADATA_IPV6.some((m) => v6.toNormalizedString() === ipaddr.IPv6.parse(m).toNormalizedString()))
+    return true;
+  // An IPv4-mapped/6to4/Teredo v6 whose embedded IPv4 is metadata/link-local reaches
+  // the same target once Node dials it — mirror the loopback/unspecified embedded checks.
+  const embedded = extractEmbeddedIpv4FromIpv6(v6);
+  return embedded ? isCloudMetadataOrLinkLocalIpv4(embedded) : false;
 }
 
 function isLoopbackIpAddressIncludingEmbeddedIpv4(address: string): boolean {

--- a/src/security.ts
+++ b/src/security.ts
@@ -62,13 +62,108 @@ export class BrowserCdpEndpointBlockedError extends Error {
 }
 
 /**
+ * Build request headers with Basic auth derived from URL userinfo, unless an
+ * Authorization header is already present. Percent-encoded credentials are
+ * decoded before base64-encoding (RFC 7617).
+ */
+export function getHeadersWithAuth(endpoint: string, baseHeaders: Record<string, string> = {}): Record<string, string> {
+  const headers = { ...baseHeaders };
+  try {
+    const parsed = new URL(endpoint);
+    if (Object.keys(headers).some((k) => k.toLowerCase() === 'authorization')) return headers;
+    if (parsed.username || parsed.password) {
+      const decode = (value: string): string => {
+        try {
+          return decodeURIComponent(value);
+        } catch {
+          return value;
+        }
+      };
+      const credentials = Buffer.from(`${decode(parsed.username)}:${decode(parsed.password)}`).toString('base64');
+      headers.Authorization = `Basic ${credentials}`;
+    }
+  } catch {
+    // endpoint is not a valid URL (e.g. a raw WebSocket path) — skip auth header injection
+  }
+  return headers;
+}
+
+/**
+ * Strip URL userinfo (user:pass@) so the URL can be safely logged or passed to
+ * fetch without leaking credentials. Pair with `getHeadersWithAuth` to move
+ * credentials into an Authorization header before issuing the request.
+ */
+export function stripUrlCredentials(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.username && !parsed.password) return url;
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/** Pin a policy to the configured CDP hostname so `/json/*` discovery cannot use a broader allowlist. */
+export function scopeCdpPolicyToConfiguredEndpoint(cdpUrl: string, ssrfPolicy?: SsrfPolicy): SsrfPolicy | undefined {
+  if (!ssrfPolicy) return undefined;
+  let hostname: string;
+  try {
+    hostname = new URL(cdpUrl).hostname;
+  } catch {
+    return ssrfPolicy;
+  }
+  return { ...ssrfPolicy, allowedHostnames: [hostname], hostnameAllowlist: [hostname] };
+}
+
+function cdpEndpointAuthority(url: string): string {
+  const parsed = new URL(url);
+  const usesTls = parsed.protocol === 'https:' || parsed.protocol === 'wss:';
+  const port = parsed.port || (usesTls ? '443' : '80');
+  return `${usesTls ? 'tls' : 'plain'}://${parsed.hostname}:${port}`;
+}
+
+function assertDiscoveredCdpEndpointMatchesConfigured(
+  discoveredUrl: string,
+  configuredUrl: string,
+  ssrfPolicy?: SsrfPolicy,
+): void {
+  if (!ssrfPolicy || isPrivateNetworkAllowedByPolicy(ssrfPolicy)) return;
+  let matches: boolean;
+  try {
+    matches = cdpEndpointAuthority(discoveredUrl) === cdpEndpointAuthority(configuredUrl);
+  } catch {
+    matches = false;
+  }
+  if (matches) return;
+  throw new BrowserCdpEndpointBlockedError(
+    'CDP endpoint blocked: discovered CDP endpoint changed configured authority',
+  );
+}
+
+/** A `discovered` URL (from `/json/*`) must not change the configured endpoint's authority. */
+export interface CdpEndpointSourceOptions {
+  source?: 'configured' | 'discovered';
+  configuredUrl?: string;
+}
+
+/**
  * Validate a CDP endpoint URL against an SSRF policy. No-op without a policy.
  * Loopback hostnames (`localhost`, `127.0.0.1`, `[::1]`) are allowed by default
  * when no explicit `allowedHostnames` or `hostnameAllowlist` is provided.
  * To reach a non-loopback private/internal endpoint, add its hostname to
  * `ssrfPolicy.allowedHostnames` or set `dangerouslyAllowPrivateNetwork: true`.
+ * Discovered endpoints (from `/json/*` responses) get no loopback auto-allow
+ * and must keep the configured endpoint's authority.
  */
-export async function assertCdpEndpointAllowed(cdpUrl: string, ssrfPolicy?: SsrfPolicy): Promise<void> {
+export async function assertCdpEndpointAllowed(
+  cdpUrl: string,
+  ssrfPolicy?: SsrfPolicy,
+  options?: CdpEndpointSourceOptions,
+): Promise<void> {
+  if (options?.source === 'discovered' && options.configuredUrl !== undefined)
+    assertDiscoveredCdpEndpointMatchesConfigured(cdpUrl, options.configuredUrl, ssrfPolicy);
   if (!ssrfPolicy) return;
   let parsed: URL;
   try {
@@ -88,7 +183,7 @@ export async function assertCdpEndpointAllowed(cdpUrl: string, ssrfPolicy?: Ssrf
     (Array.isArray(ssrfPolicy.allowedHostnames) && ssrfPolicy.allowedHostnames.length > 0) ||
     (Array.isArray(ssrfPolicy.hostnameAllowlist) && ssrfPolicy.hostnameAllowlist.length > 0);
   const effectivePolicy =
-    isLoopback && !hasExplicitAllowlist
+    isLoopback && !hasExplicitAllowlist && options?.source !== 'discovered'
       ? {
           ...ssrfPolicy,
           allowedHostnames: Array.from(new Set([...(ssrfPolicy.allowedHostnames ?? []), parsed.hostname])),
@@ -382,6 +477,32 @@ function isCloudMetadataOrLinkLocalAddress(address: string): boolean {
   return CLOUD_METADATA_IPV6.some((m) => v6.toNormalizedString() === ipaddr.IPv6.parse(m).toNormalizedString());
 }
 
+function isLoopbackIpAddressIncludingEmbeddedIpv4(address: string): boolean {
+  const parsed = parseCanonicalIpAddress(address);
+  if (!parsed) return false;
+  if (parsed.range() === 'loopback') return true;
+  if (parsed.kind() === 'ipv4') return false;
+  return extractEmbeddedIpv4FromIpv6(parsed as ipaddr.IPv6)?.range() === 'loopback';
+}
+
+function isExplicitLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === 'localhost.localdomain' ||
+    hostname.endsWith('.localhost') ||
+    isLoopbackIpAddressIncludingEmbeddedIpv4(hostname)
+  );
+}
+
+function isUnspecifiedIpAddressIncludingEmbeddedIpv4(address: string): boolean {
+  const parsed = parseCanonicalIpAddress(address);
+  if (!parsed) return false;
+  if (parsed.kind() === 'ipv4') return parsed.range() === 'unspecified';
+  if (parsed.range() === 'unspecified') return true;
+  if (parsed.range() === 'loopback') return false;
+  return extractEmbeddedIpv4FromIpv6(parsed as ipaddr.IPv6)?.range() === 'unspecified';
+}
+
 // ── URL-level checks ──
 
 /**
@@ -620,8 +741,19 @@ export async function resolvePinnedHostnameWithPolicy(
       }
     }
   } else if (isExplicitlyAllowed && !allowPrivateNetwork) {
-    // An allow-listed host may resolve to a private IP on purpose, but never to a metadata/link-local one.
+    // Private IPs may be allow-listed on purpose; unspecified/metadata/link-local/loopback never are (DNS rebinding).
+    const loopbackAllowed = isExplicitLoopbackHostname(normalized);
     for (const r of results) {
+      if (isUnspecifiedIpAddressIncludingEmbeddedIpv4(r.address)) {
+        throw new InvalidBrowserNavigationUrlError(
+          `Navigation blocked: allow-listed hostname "${hostname}" resolves to an unspecified address "${r.address}".`,
+        );
+      }
+      if (!loopbackAllowed && isLoopbackIpAddressIncludingEmbeddedIpv4(r.address)) {
+        throw new InvalidBrowserNavigationUrlError(
+          `Navigation blocked: allow-listed hostname "${hostname}" resolves to a loopback address "${r.address}".`,
+        );
+      }
       if (isCloudMetadataOrLinkLocalAddress(r.address)) {
         throw new InvalidBrowserNavigationUrlError(
           `Navigation blocked: allow-listed hostname "${hostname}" resolves to a cloud-metadata/link-local address "${r.address}".`,
@@ -663,7 +795,16 @@ export async function assertBrowserNavigationAllowed(
   try {
     parsed = new URL(rawUrl);
   } catch {
-    throw new InvalidBrowserNavigationUrlError(`Invalid URL: "${rawUrl}"`);
+    throw new InvalidBrowserNavigationUrlError(
+      `Invalid URL: "${rawUrl.includes('@') ? '[redacted credential-bearing URL]' : rawUrl}"`,
+    );
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new InvalidBrowserNavigationUrlError(
+      'Navigation blocked: URL-embedded credentials are not supported for page navigation. ' +
+        'Set HTTP Basic auth with `page.setHttpCredentials()` instead.',
+    );
   }
 
   // Block non-network protocols (file:, data:, javascript:, etc.) — only http/https allowed.

--- a/src/snapshot/ai-snapshot.ts
+++ b/src/snapshot/ai-snapshot.ts
@@ -5,6 +5,7 @@ import {
   storeRoleRefsForTarget,
   normalizeTimeoutMs,
   takeAiSnapshotText,
+  truncateUtf16Safe,
 } from '../connection.js';
 import { NavigationRaceError, SnapshotHydrationError } from '../errors.js';
 import type { SnapshotResult, SnapshotOptions, SsrfPolicy } from '../types.js';
@@ -74,7 +75,7 @@ export async function snapshotAi(opts: {
     if (limit !== undefined && snapshot.length > limit) {
       const lastNewline = snapshot.lastIndexOf('\n', limit);
       const cutoff = lastNewline > 0 ? lastNewline : limit;
-      snapshot = `${snapshot.slice(0, cutoff)}\n\n[...TRUNCATED - page too large]`;
+      snapshot = `${truncateUtf16Safe(snapshot, cutoff)}\n\n[...TRUNCATED - page too large]`;
       truncated = true;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -644,6 +644,7 @@ export interface PageState {
   nextArmIdUpload: number;
   nextArmIdDialog: number;
   nextArmIdDownload: number;
+  downloadWaiterDepth: number;
   dialogHandler?: DialogHandler;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,12 @@ export interface SsrfPolicy {
   /**
    * Allow navigation to private/internal network addresses.
    * Default: `false` — private/internal/loopback addresses are blocked. Set to `true` to allow them.
+   *
+   * Setting this **explicitly to `false`** (strict mode) additionally requires page
+   * navigation to use an IP-literal URL or an allow-listed hostname: the browser
+   * re-resolves DNS independently of browserclaw's pinned lookup, so a hostname
+   * cannot be protected against 0-TTL rebinding. Add hostnames to `allowedHostnames`
+   * (or `hostnameAllowlist`) or navigate by IP under strict mode.
    */
   dangerouslyAllowPrivateNetwork?: boolean;
   /**


### PR DESCRIPTION
Syncs browserclaw with OpenClaw 2026.7.1 (mainline tip 2026.7.1-2) plus the 2026.6.33/2026.6.34 extended-stable backports (each verified present in 2026.8.1-beta, i.e. mainline-future). Baseline was 2026.6.11. Bumps version 0.19.8 → 0.20.0.

## Security
- **DNS-rebinding hardening**: an allow-listed hostname may still resolve to a private IP on purpose, but no longer to a loopback (unless the hostname itself is an explicit loopback name), unspecified (`0.0.0.0`/`::`), or IPv6-embedded form of either.
- **Discovered-CDP-endpoint authority pinning**: WebSocket URLs discovered via `/json/version`/`/json/list` must keep the configured endpoint's authority (scheme class + host + port) under a strict policy, get no loopback auto-allow, and discovery fetches run under a policy pinned to the configured hostname.
- **CDP credential hygiene** (#103139 backport): credentials are stripped from every dialed URL (`connectOverCDP`, raw WebSocket, `/json/*` fetches) and travel as Basic `Authorization` headers. This also fixes a real bug: Node `fetch` rejects credential-bearing URLs, so authenticated CDP discovery silently failed before. Adds a `/json/version/` trailing-slash fallback and a fail-fast for authed HTTP endpoints that expose no usable WebSocket URL.
- **URL-embedded-credential navigation block** (backport): `goto('https://user:pass@…')` now throws with a pointer to `page.setHttpCredentials()`; invalid-URL errors redact credential-bearing text.
- **Bounded CDP JSON reads**: `/json/version` and `/json/list` responses are capped at 16 MB (`readJsonResponseBounded`) so a hostile endpoint can't force unbounded buffering.
- **Download URL validation**: downloads are validated against the SSRF policy *before* any bytes are saved (explicit `download()`/`waitForDownload()` gain an optional `ssrfPolicy`; navigation captures always validate when a policy is set).

## Behavior / reliability
- **Navigation downloads**: `goto()` on a direct file link now saves the file to the managed downloads dir and returns `{ url, download: { url, suggestedFilename, path } }` instead of failing with `net::ERR_ABORTED`. Additive optional field. (Act/click download draining was intentionally not ported.)
- **Connection-attempt cancellation**: force-disconnect/close now cancel in-flight connect attempts; a late-completing connect can no longer resurrect a retired connection. `listPagesViaPlaywright` gains an optional `timeoutMs` that force-disconnects a wedged connection on timeout.
- **macOS cookie persistence**: new headless profiles on darwin get Chrome's mock keychain (marker kept consistent across launches) so logins survive restarts.
- **Graceful Chrome close**: `stopChrome` asks Chrome to close via CDP `Browser.close` (flushing cookies/Local State) before falling back to the existing process-group SIGTERM/SIGKILL path.
- **Bounded response capture**: `responseBody()`/`waitForRequest()` decode at most `maxChars * 4` bytes and truncate UTF-16-safely; snapshot truncation fallback is also surrogate-pair-safe.
- Smaller fixes: `setDeep` empty-keys guard, `normalizeCdpWsUrl` inherits the CDP port when a loopback ws URL omits one.

## Tests
824 passing (+29 new): DNS-rebinding/unspecified blocking with explicit-loopback and private-IP controls, authority pinning with no-policy/private-allowed controls, download-URL validation with a saves-without-policy control, authed CDP discovery headers, bounded JSON reader, credential-nav block, UTF-16 truncation, ws-port inherit, mock-keychain arg.